### PR TITLE
Mark where the readme.md file is so it appears on crates.io

### DIFF
--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Corwin Kuiper <corwin@kuiper.dev>", "Gwilym Kuiper <gw@ilym.me>"]
 edition = "2018"
 description = "Library for Game Boy Advance Development"
 license = "MPL-2.0"
+readme = "../README.md"
 
 [profile.dev]
 opt-level = 3


### PR DESCRIPTION
The crates.io page for agb says there is no readme.md... but there is. So mark it so it gets included on crates.io.

I assume the image link won't work, so maybe we need to do a bit more for that? Hard to test though :/