### PR TITLE
Update agb when releasing

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -79,7 +79,7 @@ if [ "$PROJECT" = "agb" ]; then
     sed -i -e "s/^agb = \".*\"/agb = \"$VERSION\"/" template/Cargo.toml
     git add template/Cargo.toml
 else
-    local PROJECT_NAME_WITH_UNDERSCORES=$(echo -n "$PROJECT" | tr - _)
+    PROJECT_NAME_WITH_UNDERSCORES=$(echo -n "$PROJECT" | tr - _)
     sed -i -E -e "s/($PROJECT_NAME_WITH_UNDERSCORES = .*version = \")[^\"]+(\".*)/\1$VERSION\2/" agb/Cargo.toml
     
     (cd agb && cargo update)

--- a/release.sh
+++ b/release.sh
@@ -70,6 +70,12 @@ if [ "$PROJECT" = "agb" ]; then
     # also update the agb version in the template
     sed -i -e "s/^agb = \".*\"/agb = \"$VERSION\"/" template/Cargo.toml
     git add template/Cargo.toml
+else
+    local PROJECT_NAME_WITH_UNDERSCORES=$(echo -n "$PROJECT" | tr - _)
+    sed -i -E -e "s/($PROJECT_NAME_WITH_UNDERSCORES = .*version = \")[^\"]+(\".*)/\1$VERSION\2/" agb/Cargo.toml
+    
+    (cd agb && cargo update)
+    git add agb/Cargo.toml agb/Cargo.lock
 fi
 
 # Commit the Cargo.toml changes

--- a/release.sh
+++ b/release.sh
@@ -62,11 +62,6 @@ if [ ! "$NO_COMMIT" = "--no-commit" ] && [ "$(git symbolic-ref --short HEAD)" !=
     exit 1
 fi
 
-# Sanity check to make sure the build works
-(cd agb && cargo test)
-(cd agb-image-converter && cargo test)
-(cd agb-macros && cargo test)
-
 # Update the version in Cargo.toml
 sed -i -e "s/^version = \".*\"/version = \"$VERSION\"/" "$DIRECTORY/Cargo.toml"
 
@@ -85,6 +80,11 @@ else
     (cd agb && cargo update)
     git add agb/Cargo.toml agb/Cargo.lock
 fi
+
+# Sanity check to make sure the build works
+(cd agb && cargo test)
+(cd agb-image-converter && cargo test)
+(cd agb-macros && cargo test)
 
 if [ ! "$NO_COMMIT" = "--no-commit" ]; then
     # Commit the Cargo.toml changes

--- a/release.sh
+++ b/release.sh
@@ -65,6 +65,7 @@ fi
 # Sanity check to make sure the build works
 (cd agb && cargo test)
 (cd agb-image-converter && cargo test)
+(cd agb-macros && cargo test)
 
 # Update the version in Cargo.toml
 sed -i -e "s/^version = \".*\"/version = \"$VERSION\"/" "$DIRECTORY/Cargo.toml"

--- a/release.sh
+++ b/release.sh
@@ -20,7 +20,7 @@ if [ ! "$(echo "$VERSION" | grep -E "^[0-9]+\.[0-9]+\.[0-9]+$")" ]; then
 fi
 
 # Check if no commit option is valid
-if [ ! "$NO_COMMIT" = "" ] || [ ! "$NO_COMMIT" = "--no-commit" ]; then
+if [ ! "$NO_COMMIT" = "" ] && [ ! "$NO_COMMIT" = "--no-commit" ]; then
     echo "Must pass either no last argument or --no-commit"
     exit 1
 fi


### PR DESCRIPTION
I noticed when I last did a release that the agb dependency wasn't updated which caused the build to fail.

Now if you release a new version of say agb-macros, the `agb_macros` line in agb's Cargo.toml file will be updated to state the new version, so you can ensure the build always works :tada: