### PR TITLE
Special case simple mixer

### DIFF
--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -136,7 +136,8 @@ impl MixerBuffer {
             let right_amount = ((channel.panning + 1) / 2) * channel.volume;
             let left_amount = ((-channel.panning + 1) / 2) * channel.volume;
 
-            if (channel.pos + channel.playback_speed * SOUND_BUFFER_SIZE).floor() >= channel.data.len()
+            if (channel.pos + channel.playback_speed * SOUND_BUFFER_SIZE).floor()
+                >= channel.data.len()
             {
                 // TODO: This should probably play what's left rather than skip the last bit
                 if channel.should_loop {


### PR DESCRIPTION
If you're making the same modification to both the left and the right channel, and it is a perfect power of 2, then don't multiply and instead do a shift. Should actually be noticeably faster