### PR TITLE
Remove unused field

### DIFF
--- a/agb/src/display/background.rs
+++ b/agb/src/display/background.rs
@@ -129,7 +129,6 @@ impl<'a> Map<'a> {
 pub struct BackgroundRegister {
     background: u8,
     block: u8,
-    background_size: BackgroundSize,
     shadowed_register: u16,
 }
 
@@ -138,7 +137,6 @@ impl<'a> BackgroundRegister {
         let mut b = Self {
             background,
             block,
-            background_size,
             shadowed_register: 0,
         };
         b.set_block(block);


### PR DESCRIPTION
There was a warning and I found that annoying. The field isn't read, but the value passed to the constructor is actually used