### PR TITLE
Fix crash when stereo sound loops

### DIFF
--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -147,7 +147,7 @@ impl MixerBuffer {
             if (channel.pos + playback_speed * SOUND_BUFFER_SIZE).floor() >= channel.data.len() {
                 // TODO: This should probably play what's left rather than skip the last bit
                 if channel.should_loop {
-                    channel.pos -= channel.data.len();
+                    channel.pos = 0.into();
                 } else {
                     channel.is_done = true;
                     continue;


### PR DESCRIPTION
`channel.data.len() = 2 * channel.pos` when stereo.

May as well set it to 0 here though.