### PR TITLE
Allow the sound mixer to do work during vdraw

### DIFF
--- a/agb/examples/mixer_basic.rs
+++ b/agb/examples/mixer_basic.rs
@@ -51,7 +51,8 @@ fn main() -> ! {
             }
         }
 
+        mixer.frame();
         vblank_provider.wait_for_vblank();
-        mixer.vblank();
+        mixer.after_vblank();
     }
 }

--- a/agb/examples/stereo_sound.rs
+++ b/agb/examples/stereo_sound.rs
@@ -29,7 +29,8 @@ fn main() -> ! {
     loop {
         vblank_provider.wait_for_vblank();
         let before_mixing_cycles = timer.get_value();
-        mixer.vblank();
+        mixer.after_vblank();
+        mixer.frame();
         let after_mixing_cycles = timer.get_value();
 
         frame_counter = frame_counter.wrapping_add(1);

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -45,12 +45,14 @@ impl<'a> Mixer<'a> {
         hw::set_sound_control_register_for_mixer();
     }
 
-    pub fn vblank(&mut self) {
-        self.buffer.swap();
+    pub fn frame(&mut self) {
         self.buffer.clear();
-
         self.buffer
             .write_channels(self.channels.iter_mut().flatten());
+    }
+
+    pub fn after_vblank(&mut self) {
+        self.buffer.swap();
     }
 
     pub fn play_sound(&mut self, new_channel: SoundChannel) -> Option<ChannelId> {

--- a/examples/the-hat-chooses-the-wizard/src/main.rs
+++ b/examples/the-hat-chooses-the-wizard/src/main.rs
@@ -808,9 +808,10 @@ pub fn main() -> ! {
                 break;
             }
 
+            music_box.before_frame(&mut mixer);
+            mixer.frame();
             vblank.wait_for_vblank();
-            music_box.after_blank(&mut mixer);
-            mixer.vblank();
+            mixer.after_vblank();
 
             level_display::write_level(
                 &mut world_display,
@@ -820,9 +821,10 @@ pub fn main() -> ! {
 
             world_display.show();
 
+            music_box.before_frame(&mut mixer);
+            mixer.frame();
             vblank.wait_for_vblank();
-            music_box.after_blank(&mut mixer);
-            mixer.vblank();
+            mixer.after_vblank();
 
             let mut level = PlayingLevel::open_level(
                 &map_tiles::LEVELS[current_level as usize],
@@ -833,17 +835,21 @@ pub fn main() -> ! {
             );
             let mut level_load = level.load_1().step_by(24);
             for _ in 0..30 {
+                music_box.before_frame(&mut mixer);
+                mixer.frame();
                 vblank.wait_for_vblank();
-                music_box.after_blank(&mut mixer);
-                mixer.vblank();
+                mixer.after_vblank();
+
                 level_load.next();
             }
             level_load.count();
             let mut level_load = level.load_2().step_by(24);
             for _ in 0..30 {
+                music_box.before_frame(&mut mixer);
+                mixer.frame();
                 vblank.wait_for_vblank();
-                music_box.after_blank(&mut mixer);
-                mixer.vblank();
+                mixer.after_vblank();
+
                 level_load.next();
             }
             level_load.count();
@@ -857,9 +863,10 @@ pub fn main() -> ! {
                     UpdateState::Dead => {
                         level.dead_start();
                         while level.dead_update() {
+                            music_box.before_frame(&mut mixer);
+                            mixer.frame();
                             vblank.wait_for_vblank();
-                            music_box.after_blank(&mut mixer);
-                            mixer.vblank();
+                            mixer.after_vblank();
                         }
                         break;
                     }
@@ -868,9 +875,11 @@ pub fn main() -> ! {
                         break;
                     }
                 }
+
+                music_box.before_frame(&mut mixer);
+                mixer.frame();
                 vblank.wait_for_vblank();
-                music_box.after_blank(&mut mixer);
-                mixer.vblank();
+                mixer.after_vblank();
             }
         }
 

--- a/examples/the-hat-chooses-the-wizard/src/sfx.rs
+++ b/examples/the-hat-chooses-the-wizard/src/sfx.rs
@@ -46,7 +46,7 @@ impl MusicBox {
         MusicBox { frame: 0 }
     }
 
-    pub fn after_blank(&mut self, mixer: &mut Mixer) {
+    pub fn before_frame(&mut self, mixer: &mut Mixer) {
         if self.frame == 0 {
             // play the introduction
             mixer.play_sound(SoundChannel::new_high_priority(music_data::INTRO_MUSIC));

--- a/examples/the-hat-chooses-the-wizard/src/splash_screen.rs
+++ b/examples/the-hat-chooses-the-wizard/src/splash_screen.rs
@@ -52,12 +52,16 @@ pub fn show_splash_screen(
         ) {
             break;
         }
-        vblank.wait_for_vblank();
         if let Some(ref mut mixer) = mixer {
             if let Some(ref mut music_box) = music_box {
-                music_box.after_blank(mixer);
+                music_box.before_frame(mixer);
             }
-            mixer.vblank();
+            mixer.frame();
+        }
+        vblank.wait_for_vblank();
+
+        if let Some(ref mut mixer) = mixer {
+            mixer.after_vblank();
         }
     }
     splash_screen_display.hide();

--- a/examples/the-purple-night/src/main.rs
+++ b/examples/the-purple-night/src/main.rs
@@ -2185,8 +2185,9 @@ fn game_with_level(gba: &mut agb::Gba) {
         );
 
         start_at_boss = loop {
+            sfx.frame();
             vblank.wait_for_vblank();
-            sfx.vblank();
+            sfx.after_vblank();
             match game.advance_frame(&object, &mut sfx) {
                 GameStatus::Continue => {}
                 GameStatus::Lost => {

--- a/examples/the-purple-night/src/sfx.rs
+++ b/examples/the-purple-night/src/sfx.rs
@@ -35,8 +35,12 @@ impl<'a> Sfx<'a> {
         Self { mixer, bgm: None }
     }
 
-    pub fn vblank(&mut self) {
-        self.mixer.vblank();
+    pub fn frame(&mut self) {
+        self.mixer.frame();
+    }
+
+    pub fn after_vblank(&mut self) {
+        self.mixer.after_vblank();
     }
 
     pub fn stop_music(&mut self) {


### PR DESCRIPTION
vblank time is in short supply and so we should minimise the work that actually needs to be done in it.

This splits the mixer so that now the recommended method of using it is:

```rust
mixer.frame(); // super expensive operation requiring about 10% of frame time in worst case
vblank.wait_for_vblank();
mixer.after_vblank(); // super cheap operation requiring about 20 instructions
```

rather than before where it was

```rust
vblank.wait_for_vblank();
mixer.vblank(); // do both steps here which takes pretty much all of vblank in the best case
```