### PR TITLE
You don't need `extern crate agb;` any more

### DIFF
--- a/agb/examples/allocation.rs
+++ b/agb/examples/allocation.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
 extern crate alloc;
 
 use alloc::boxed::Box;

--- a/agb/examples/beep.rs
+++ b/agb/examples/beep.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
-
 use agb::sound;
 
 #[agb::entry]

--- a/agb/examples/bitmap3.rs
+++ b/agb/examples/bitmap3.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
-
 use agb::display;
 
 struct Vector2D {

--- a/agb/examples/bitmap4.rs
+++ b/agb/examples/bitmap4.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
-
 use agb::display;
 
 #[agb::entry]

--- a/agb/examples/chicken.rs
+++ b/agb/examples/chicken.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
 use agb::{
     display::{background::Map, object::ObjectStandard, HEIGHT, WIDTH},
     input::Button,

--- a/agb/examples/mixer_basic.rs
+++ b/agb/examples/mixer_basic.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
-
 use agb::input::{Button, ButtonController, Tri};
 use agb::number::Num;
 use agb::sound::mixer::SoundChannel;

--- a/agb/examples/multiple_video.rs
+++ b/agb/examples/multiple_video.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
-
 use agb::display;
 
 struct Vector2D {

--- a/agb/examples/output.rs
+++ b/agb/examples/output.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
-
 #[agb::entry]
 fn main() -> ! {
     let count = agb::interrupt::Mutex::new(0);

--- a/agb/examples/panic.rs
+++ b/agb/examples/panic.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
-
 use agb::display;
 
 #[agb::entry]

--- a/agb/examples/stereo_sound.rs
+++ b/agb/examples/stereo_sound.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
-
 use agb::sound::mixer::SoundChannel;
 use agb::{include_wav, Gba};
 

--- a/agb/examples/syscall.rs
+++ b/agb/examples/syscall.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
 use agb::{display, syscall};
 
 #[agb::entry]

--- a/agb/examples/test_logo.rs
+++ b/agb/examples/test_logo.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
-
 use agb::display::example_logo;
 
 #[agb::entry]

--- a/agb/examples/wave.rs
+++ b/agb/examples/wave.rs
@@ -1,8 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
-
 use agb::{
     display::example_logo,
     interrupt::{Interrupt, Mutex},

--- a/agb/src/display/object.rs
+++ b/agb/src/display/object.rs
@@ -27,8 +27,6 @@ const TILE_SPRITE: MemoryMapped1DArray<u32, { 1024 * 8 }> =
 /// # #![no_std]
 /// # #![no_main]
 /// #
-/// # extern crate agb;
-/// #
 /// # use agb::Gba;
 /// #
 /// # #[agb::entry]
@@ -62,8 +60,6 @@ struct ObjectLoan<'a> {
 /// ```
 /// # #![no_std]
 /// # #![no_main]
-/// #
-/// # extern crate agb;
 /// #
 /// # use agb::Gba;
 /// use agb::display::object::Size;

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -122,9 +122,6 @@ pub use agb_image_converter::include_gfx;
 /// #![no_std]
 /// #![no_main]
 ///
-/// // Required to set panic handlers
-/// extern crate agb;
-///
 /// use agb::Gba;
 ///
 /// #[agb::entry]
@@ -197,8 +194,6 @@ static mut GBASINGLE: single::Singleton<Gba> = single::Singleton::new(unsafe { G
 /// ```
 /// #![no_std]
 /// #![no_main]
-///
-/// extern crate agb;
 ///
 /// use agb::Gba;
 ///

--- a/book/games/pong/src/main.rs
+++ b/book/games/pong/src/main.rs
@@ -10,10 +10,6 @@
 // which won't be a particularly clear error message.
 #![no_main]
 
-// This is required in order to ensure that the panic handler defined in `agb` is set
-// up correctly.
-extern crate agb;
-
 use agb::display::object::Size;
 use agb::Gba;
 

--- a/book/src/pong/02_the_gba_struct.md
+++ b/book/src/pong/02_the_gba_struct.md
@@ -19,7 +19,6 @@ Replace the content of the `main` function with the following:
 ```rust,ignore
 # #![no_std]
 # #![no_main]
-# extern crate agb;
 # #[agb::entry]
 # fn main() -> ! {
 let mut gba = agb::Gba::new();

--- a/examples/the-purple-night/src/main.rs
+++ b/examples/the-purple-night/src/main.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-extern crate agb;
 extern crate alloc;
 
 mod rng;

--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -10,10 +10,6 @@
 // which won't be a particularly clear error message.
 #![no_main]
 
-// This is required in order to ensure that the panic handler defined in `agb` is set
-// up correctly.
-extern crate agb;
-
 use agb::{display, syscall};
 
 // The main function must take 0 arguments and never return. The agb::entry decorator


### PR DESCRIPTION
Seems either we're misremembering that this was required for panic handler reasons or it was fixed at some point in nightly