### PR TITLE
Strategic inlines

### DIFF
--- a/agb-fixnum/src/lib.rs
+++ b/agb-fixnum/src/lib.rs
@@ -68,15 +68,19 @@ pub trait FixedWidthSignedInteger: FixedWidthUnsignedInteger + Neg<Output = Self
 macro_rules! fixed_width_unsigned_integer_impl {
     ($T: ty) => {
         impl FixedWidthUnsignedInteger for $T {
+            #[inline(always)]
             fn zero() -> Self {
                 0
             }
+            #[inline(always)]
             fn one() -> Self {
                 1
             }
+            #[inline(always)]
             fn ten() -> Self {
                 10
             }
+            #[inline(always)]
             fn from_as_i32(v: i32) -> Self {
                 v as $T
             }
@@ -87,6 +91,7 @@ macro_rules! fixed_width_unsigned_integer_impl {
 macro_rules! fixed_width_signed_integer_impl {
     ($T: ty) => {
         impl FixedWidthSignedInteger for $T {
+            #[inline(always)]
             fn fixed_abs(self) -> Self {
                 self.abs()
             }

--- a/agb/src/sound/mixer/mod.rs
+++ b/agb/src/sound/mixer/mod.rs
@@ -43,6 +43,7 @@ pub struct SoundChannel {
 }
 
 impl SoundChannel {
+    #[inline(always)]
     pub fn new(data: &'static [u8]) -> Self {
         SoundChannel {
             data,
@@ -57,6 +58,7 @@ impl SoundChannel {
         }
     }
 
+    #[inline(always)]
     pub fn new_high_priority(data: &'static [u8]) -> Self {
         SoundChannel {
             data,
@@ -71,16 +73,19 @@ impl SoundChannel {
         }
     }
 
+    #[inline(always)]
     pub fn should_loop(&mut self) -> &mut Self {
         self.should_loop = true;
         self
     }
 
+    #[inline(always)]
     pub fn playback(&mut self, playback_speed: Num<usize, 8>) -> &mut Self {
         self.playback_speed = playback_speed;
         self
     }
 
+    #[inline(always)]
     pub fn panning(&mut self, panning: Num<i16, 4>) -> &mut Self {
         debug_assert!(panning >= Num::new(-1), "panning value must be >= -1");
         debug_assert!(panning <= Num::new(1), "panning value must be <= 1");
@@ -89,6 +94,7 @@ impl SoundChannel {
         self
     }
 
+    #[inline(always)]
     pub fn volume(&mut self, volume: Num<i16, 4>) -> &mut Self {
         assert!(volume <= Num::new(1), "volume must be <= 1");
         assert!(volume >= Num::new(0), "volume must be >= 0");
@@ -97,12 +103,14 @@ impl SoundChannel {
         self
     }
 
+    #[inline(always)]
     pub fn stereo(&mut self) -> &mut Self {
         self.is_stereo = true;
 
         self
     }
 
+    #[inline(always)]
     pub fn stop(&mut self) {
         self.is_done = true
     }


### PR DESCRIPTION
I checked the output of both hat chooses wizard and purple night for obvious places where the compiler decided not to inline. These turn out to be particularly bad places.