### PR TITLE
Custom hashmap

### DIFF
--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -25,7 +25,6 @@ agb_sound_converter = { version = "0.1.0", path = "../agb-sound-converter" }
 agb_macros = { version = "0.1.0", path = "../agb-macros" }
 agb_fixnum = { version = "0.1.0", path = "../agb-fixnum" }
 bare-metal = "1"
-hashbrown = "0.12"
 modular-bitfield = "0.11"
 rustc-hash =  { version = "1", default-features = false }
 

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -171,6 +171,12 @@ impl<K, V> HashMap<K, V> {
     }
 }
 
+impl<K, V> Default for HashMap<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 const fn fast_mod(len: usize, hash: HashType) -> usize {
     debug_assert!(len.is_power_of_two(), "Length must be a power of 2");
     (hash as usize) & (len - 1)
@@ -233,6 +239,13 @@ where
 
         self.get_location(key, hash)
             .map(|location| &self.nodes.0[location].as_ref().unwrap().value)
+    }
+
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        let hash = self.hash(key);
+
+        self.get_location(key, hash)
+            .map(|location| &mut self.nodes.0[location].as_mut().unwrap().value)
     }
 
     pub fn remove(&mut self, key: &K) -> Option<V> {

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -1,0 +1,166 @@
+use alloc::{vec, vec::Vec};
+use core::{
+    hash::{BuildHasher, BuildHasherDefault, Hash, Hasher},
+    mem,
+};
+
+use rustc_hash::FxHasher;
+
+type HashType = u32;
+
+struct Node<K: Sized, V: Sized> {
+    hash: HashType,
+    distance_to_initial_bucket: u32,
+    key: K,
+    value: V,
+}
+
+impl<K, V> Node<K, V>
+where
+    K: Sized,
+    V: Sized,
+{
+    fn with_new_key_value(&self, new_key: K, new_value: V) -> Self {
+        Self {
+            hash: self.hash,
+            distance_to_initial_bucket: self.distance_to_initial_bucket,
+            key: new_key,
+            value: new_value,
+        }
+    }
+}
+
+struct HashMap<K, V> {
+    number_of_elements: usize,
+    max_distance_to_initial_bucket: u32,
+    nodes: Vec<Option<Node<K, V>>>,
+
+    hasher: BuildHasherDefault<FxHasher>,
+}
+
+impl<K, V> HashMap<K, V> {
+    pub fn new() -> Self {
+        Self {
+            number_of_elements: 0,
+            max_distance_to_initial_bucket: 0,
+            nodes: vec![
+                None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+                None, None,
+            ],
+            hasher: Default::default(),
+        }
+    }
+}
+
+fn fast_mod(len: usize, hash: HashType) -> usize {
+    debug_assert!(len.is_power_of_two(), "Length must be a power of 2");
+    (hash as usize) & (len - 1)
+}
+
+impl<K, V> HashMap<K, V>
+where
+    K: Eq,
+{
+    fn get_location(&self, key: &K, hash: HashType) -> Option<usize> {
+        for distance_to_initial_bucket in 0..=self.max_distance_to_initial_bucket + 1 {
+            let location = fast_mod(self.nodes.len(), hash + distance_to_initial_bucket);
+
+            let node = &self.nodes[location];
+            if let Some(node) = node {
+                if &node.key == key {
+                    return Some(location);
+                }
+            } else {
+                return None;
+            }
+        }
+
+        None
+    }
+}
+
+impl<K, V> HashMap<K, V>
+where
+    K: Eq + Hash,
+{
+    pub fn put(&mut self, key: K, value: V) {
+        let mut hasher = self.hasher.build_hasher();
+        key.hash(&mut hasher);
+        let hash = hasher.finish() as HashType;
+
+        if let Some(location) = self.get_location(&key, hash) {
+            let old_node = self.nodes[location].as_ref().unwrap();
+            self.nodes[location] = Some(old_node.with_new_key_value(key, value));
+
+            return;
+        }
+
+        self.insert_new(key, value, hash);
+    }
+
+    pub fn get(&self, key: &K) -> Option<&V> {
+        let mut hasher = self.hasher.build_hasher();
+        key.hash(&mut hasher);
+        let hash = hasher.finish() as HashType;
+
+        self.get_location(&key, hash)
+            .map(|location| &self.nodes[location].as_ref().unwrap().value)
+    }
+}
+
+impl<K, V> HashMap<K, V> {
+    fn insert_new(&mut self, key: K, value: V, hash: HashType) {
+        // if we need to resize
+        if self.nodes.len() * 85 / 100 < self.number_of_elements {
+            todo!("resize not implemented yet");
+        }
+
+        let mut new_node = Node {
+            hash,
+            distance_to_initial_bucket: 0,
+            key,
+            value,
+        };
+
+        loop {
+            let location = fast_mod(self.nodes.len(), hash + new_node.distance_to_initial_bucket);
+            let current_node = self.nodes[location].as_mut();
+
+            if let Some(current_node) = current_node {
+                if current_node.distance_to_initial_bucket <= new_node.distance_to_initial_bucket {
+                    self.max_distance_to_initial_bucket = new_node
+                        .distance_to_initial_bucket
+                        .max(self.max_distance_to_initial_bucket);
+
+                    mem::swap(&mut new_node, current_node);
+                }
+            } else {
+                self.nodes[location] = Some(new_node);
+                break;
+            }
+
+            new_node.distance_to_initial_bucket += 1;
+        }
+
+        self.number_of_elements += 1;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::Gba;
+
+    #[test_case]
+    fn can_store_up_to_initial_capacity_elements(_gba: &mut Gba) {
+        let mut map = HashMap::new();
+
+        for i in 0..8 {
+            map.put(i, i % 4);
+        }
+
+        for i in 0..8 {
+            assert_eq!(map.get(&i), Some(&(i % 4)));
+        }
+    }
+}

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -147,6 +147,10 @@ impl<K, V> HashMap<K, V> {
         self.number_of_elements
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.number_of_elements == 0
+    }
+
     pub fn resize(&mut self, new_size: usize) {
         assert!(
             new_size >= self.nodes.len(),

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -202,7 +202,7 @@ impl<K, V> HashMap<K, V>
 where
     K: Eq + Hash,
 {
-    pub fn put(&mut self, key: K, value: V) -> Option<V> {
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         let hash = self.hash(&key);
 
         if let Some(location) = self.get_location(&key, hash) {
@@ -303,7 +303,7 @@ mod test {
         let mut map = HashMap::new();
 
         for i in 0..8 {
-            map.put(i, i % 4);
+            map.insert(i, i % 4);
         }
 
         for i in 0..8 {
@@ -316,7 +316,7 @@ mod test {
         let mut map = HashMap::new();
 
         for i in 0..8 {
-            map.put(i / 2, true);
+            map.insert(i / 2, true);
         }
 
         assert_eq!(map.len(), 4);
@@ -327,7 +327,7 @@ mod test {
         let mut map = HashMap::new();
 
         for i in 0..8 {
-            map.put(i, i % 3);
+            map.insert(i, i % 3);
         }
 
         assert_eq!(map.get(&12), None);
@@ -338,7 +338,7 @@ mod test {
         let mut map = HashMap::new();
 
         for i in 0..8 {
-            map.put(i, i % 3);
+            map.insert(i, i % 3);
         }
 
         for i in 0..4 {
@@ -355,7 +355,7 @@ mod test {
         let mut map = HashMap::new();
 
         for i in 0..8 {
-            map.put(i, i);
+            map.insert(i, i);
         }
 
         let mut max_found = -1;
@@ -375,7 +375,7 @@ mod test {
         let mut map = HashMap::new();
 
         for i in 0..65 {
-            map.put(i, i % 4);
+            map.insert(i, i % 4);
         }
 
         for i in 0..65 {

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -59,7 +59,7 @@ impl<K, V> HashMap<K, V> {
     }
 }
 
-fn fast_mod(len: usize, hash: HashType) -> usize {
+const fn fast_mod(len: usize, hash: HashType) -> usize {
     debug_assert!(len.is_power_of_two(), "Length must be a power of 2");
     (hash as usize) & (len - 1)
 }

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -314,8 +314,7 @@ where
 
         self.nodes
             .get_location(key, hash)
-            .map(|location| self.nodes.nodes[location].get_value_ref())
-            .flatten()
+            .and_then(|location| self.nodes.nodes[location].get_value_ref())
     }
 
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -51,7 +51,7 @@ impl<K, V> Node<K, V> {
         }
     }
 
-    fn get_value_ref(&self) -> Option<&V> {
+    fn value_ref(&self) -> Option<&V> {
         if self.has_value() {
             Some(unsafe { self.value.assume_init_ref() })
         } else {
@@ -59,7 +59,7 @@ impl<K, V> Node<K, V> {
         }
     }
 
-    fn get_value_mut(&mut self) -> Option<&mut V> {
+    fn value_mut(&mut self) -> Option<&mut V> {
         if self.has_value() {
             Some(unsafe { self.value.assume_init_mut() })
         } else {
@@ -310,14 +310,14 @@ where
 
         self.nodes
             .get_location(key, hash)
-            .and_then(|location| self.nodes.nodes[location].get_value_ref())
+            .and_then(|location| self.nodes.nodes[location].value_ref())
     }
 
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         let hash = self.hash(key);
 
         if let Some(location) = self.nodes.get_location(key, hash) {
-            self.nodes.nodes[location].get_value_mut()
+            self.nodes.nodes[location].value_mut()
         } else {
             None
         }
@@ -361,7 +361,7 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
             self.at += 1;
 
             if node.has_value() {
-                return Some((node.key_ref().unwrap(), node.get_value_ref().unwrap()));
+                return Some((node.key_ref().unwrap(), node.value_ref().unwrap()));
             }
         }
     }
@@ -416,7 +416,7 @@ where
     {
         match self {
             Entry::Occupied(e) => {
-                f(e.entry.get_value_mut().unwrap());
+                f(e.entry.value_mut().unwrap());
                 Entry::Occupied(e)
             }
             Entry::Vacant(e) => Entry::Vacant(e),

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -33,7 +33,7 @@ where
     }
 }
 
-struct HashMap<K, V> {
+pub struct HashMap<K, V> {
     number_of_elements: usize,
     max_distance_to_initial_bucket: u32,
     nodes: Vec<Option<Node<K, V>>>,

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -164,16 +164,14 @@ impl<K, V> HashMap<K, V> {
         let mut new_max_distance_to_initial_bucket = 0;
         let number_of_elements = self.number_of_elements;
 
-        for node in self.nodes.0.drain(..) {
-            if let Some(node) = node {
-                new_max_distance_to_initial_bucket = new_node_storage.insert_new(
-                    node.key,
-                    node.value,
-                    node.hash,
-                    number_of_elements,
-                    new_max_distance_to_initial_bucket,
-                );
-            }
+        for node in self.nodes.0.drain(..).flatten() {
+            new_max_distance_to_initial_bucket = new_node_storage.insert_new(
+                node.key,
+                node.value,
+                node.hash,
+                number_of_elements,
+                new_max_distance_to_initial_bucket,
+            );
         }
 
         self.nodes = new_node_storage;

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -568,7 +568,7 @@ mod test {
 
         for _ in 0..5_000 {
             let command = rng.next().rem_euclid(2);
-            let key = rng.next().rem_euclid(128);
+            let key = rng.next().rem_euclid(answers.len() as i32);
             let value = rng.next();
 
             match command {

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -198,6 +198,14 @@ pub struct VacantEntry<'a, K: 'a, V: 'a> {
 }
 
 impl<'a, K: 'a, V: 'a> VacantEntry<'a, K, V> {
+    pub fn key(&self) -> &K {
+        &self.key
+    }
+
+    pub fn into_key(self) -> K {
+        self.key
+    }
+
     pub fn insert(self, value: V) -> &'a mut V
     where
         K: Hash + Eq,

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -98,10 +98,18 @@ impl<K, V> NodeStorage<K, V> {
         let result = loop {
             let next_location = fast_mod(self.len(), (current_location + 1) as HashType);
 
-            // if the next node is empty, then we can clear the current node
-            if self.0[next_location].is_none() {
+            // if the next node is empty, or the next location has 0 distance to initial bucket then
+            // we can clear the current node
+            if self.0[next_location].is_none()
+                || self.0[next_location]
+                    .as_ref()
+                    .unwrap()
+                    .distance_to_initial_bucket
+                    == 0
+            {
                 break self.0[current_location].take().unwrap();
             }
+            if self.0[next_location].is_none() {}
 
             self.0.swap(current_location, next_location);
             self.0[current_location]

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -1,7 +1,7 @@
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use core::{
     hash::{BuildHasher, BuildHasherDefault, Hash, Hasher},
-    mem,
+    iter, mem,
 };
 
 use rustc_hash::FxHasher;
@@ -46,10 +46,7 @@ impl<K, V> HashMap<K, V> {
         Self {
             number_of_elements: 0,
             max_distance_to_initial_bucket: 0,
-            nodes: vec![
-                None, None, None, None, None, None, None, None, None, None, None, None, None, None,
-                None, None,
-            ],
+            nodes: iter::repeat_with(|| None).take(16).collect(),
             hasher: Default::default(),
         }
     }

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -209,21 +209,12 @@ const fn fast_mod(len: usize, hash: HashType) -> usize {
 
 impl<K, V> HashMap<K, V>
 where
-    K: Eq,
-{
-    fn get_location(&self, key: &K, hash: HashType) -> Option<usize> {
-        self.nodes.get_location(key, hash)
-    }
-}
-
-impl<K, V> HashMap<K, V>
-where
     K: Eq + Hash,
 {
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         let hash = self.hash(&key);
 
-        if let Some(location) = self.get_location(&key, hash) {
+        if let Some(location) = self.nodes.get_location(&key, hash) {
             let old_node = self.nodes.nodes[location].take().unwrap();
             let (new_node, old_value) = old_node.with_new_key_value(key, value);
             self.nodes.nodes[location] = Some(new_node);
@@ -242,14 +233,15 @@ where
     pub fn get(&self, key: &K) -> Option<&V> {
         let hash = self.hash(key);
 
-        self.get_location(key, hash)
+        self.nodes
+            .get_location(key, hash)
             .map(|location| &self.nodes.nodes[location].as_ref().unwrap().value)
     }
 
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         let hash = self.hash(key);
 
-        if let Some(location) = self.get_location(key, hash) {
+        if let Some(location) = self.nodes.get_location(key, hash) {
             Some(&mut self.nodes.nodes[location].as_mut().unwrap().value)
         } else {
             None
@@ -259,7 +251,8 @@ where
     pub fn remove(&mut self, key: &K) -> Option<V> {
         let hash = self.hash(key);
 
-        self.get_location(key, hash)
+        self.nodes
+            .get_location(key, hash)
             .map(|location| self.nodes.remove_from_location(location))
     }
 }
@@ -362,7 +355,7 @@ where
 {
     pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
         let hash = self.hash(&key);
-        let location = self.get_location(&key, hash);
+        let location = self.nodes.get_location(&key, hash);
 
         if let Some(location) = location {
             Entry::Occupied(OccupiedEntry {

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -43,10 +43,16 @@ pub struct HashMap<K, V> {
 
 impl<K, V> HashMap<K, V> {
     pub fn new() -> Self {
+        Self::with_capacity(16)
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        let next_power_of_2 = find_next_power_of_2(capacity);
+
         Self {
             number_of_elements: 0,
             max_distance_to_initial_bucket: 0,
-            nodes: iter::repeat_with(|| None).take(16).collect(),
+            nodes: iter::repeat_with(|| None).take(next_power_of_2).collect(),
             hasher: Default::default(),
         }
     }
@@ -59,6 +65,15 @@ impl<K, V> HashMap<K, V> {
 const fn fast_mod(len: usize, hash: HashType) -> usize {
     debug_assert!(len.is_power_of_two(), "Length must be a power of 2");
     (hash as usize) & (len - 1)
+}
+
+const fn find_next_power_of_2(n: usize) -> usize {
+    let mut next_power_of_2 = 1;
+    while next_power_of_2 <= n {
+        next_power_of_2 *= 2;
+    }
+
+    next_power_of_2
 }
 
 impl<K, V> HashMap<K, V>

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -163,7 +163,7 @@ pub struct VacantEntry<'a, K: 'a, V: 'a> {
 }
 
 impl<'a, K: 'a, V: 'a> VacantEntry<'a, K, V> {
-    pub fn insert(self, value: V)
+    fn insert(self, value: V)
     where
         K: Hash + Eq,
     {
@@ -195,7 +195,7 @@ where
             Entry::Occupied(_) => {}
             Entry::Vacant(e) => {
                 let value = f(&e.key);
-                e.map.insert(e.key, value);
+                e.insert(value);
             }
         }
     }

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -10,7 +10,7 @@ type HashType = u32;
 
 struct Node<K, V> {
     hash: HashType,
-    distance_to_initial_bucket: u32,
+    distance_to_initial_bucket: i32,
     key: K,
     value: V,
 }
@@ -48,8 +48,8 @@ impl<K, V> NodeStorage<K, V> {
         value: V,
         hash: HashType,
         number_of_elements: usize,
-        max_distance_to_initial_bucket: u32,
-    ) -> u32 {
+        max_distance_to_initial_bucket: i32,
+    ) -> i32 {
         debug_assert!(
             self.len() * 85 / 100 > number_of_elements,
             "Do not have space to insert into len {} with {number_of_elements}",
@@ -68,7 +68,7 @@ impl<K, V> NodeStorage<K, V> {
         loop {
             let location = fast_mod(
                 self.len(),
-                new_node.hash + new_node.distance_to_initial_bucket,
+                new_node.hash + new_node.distance_to_initial_bucket as HashType,
             );
             let current_node = self.0[location].as_mut();
 
@@ -123,7 +123,7 @@ impl<K, V> NodeStorage<K, V> {
 
 pub struct HashMap<K, V> {
     number_of_elements: usize,
-    max_distance_to_initial_bucket: u32,
+    max_distance_to_initial_bucket: i32,
     nodes: NodeStorage<K, V>,
 
     hasher: BuildHasherDefault<FxHasher>,
@@ -196,7 +196,10 @@ where
 {
     fn get_location(&self, key: &K, hash: HashType) -> Option<usize> {
         for distance_to_initial_bucket in 0..=self.max_distance_to_initial_bucket {
-            let location = fast_mod(self.nodes.len(), hash + distance_to_initial_bucket);
+            let location = fast_mod(
+                self.nodes.len(),
+                hash + distance_to_initial_bucket as HashType,
+            );
 
             let node = &self.nodes.0[location];
             if let Some(node) = node {

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -187,6 +187,19 @@ where
         }
     }
 
+    pub fn or_insert_with_key<F>(self, f: F)
+    where
+        F: FnOnce(&K) -> V,
+    {
+        match self {
+            Entry::Occupied(_) => {}
+            Entry::Vacant(e) => {
+                let value = f(&e.key);
+                e.map.insert(e.key, value);
+            }
+        }
+    }
+
     pub fn and_modify<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut V),

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -215,6 +215,18 @@ impl<K, V> NodeStorage<K, V> {
 
         None
     }
+
+    fn resized_to(&mut self, new_size: usize) -> Self {
+        let mut new_node_storage = Self::with_size(new_size);
+
+        for mut node in self.nodes.drain(..) {
+            if let Some((key, value, hash)) = node.take_key_value() {
+                new_node_storage.insert_new(key, value, hash);
+            }
+        }
+
+        new_node_storage
+    }
 }
 
 pub struct HashMap<K, V, H = BuildHasherDefault<FxHasher>>
@@ -255,15 +267,7 @@ impl<K, V> HashMap<K, V> {
             return;
         }
 
-        let mut new_node_storage = NodeStorage::with_size(new_size);
-
-        for mut node in self.nodes.nodes.drain(..) {
-            if let Some((key, value, hash)) = node.take_key_value() {
-                new_node_storage.insert_new(key, value, hash);
-            }
-        }
-
-        self.nodes = new_node_storage;
+        self.nodes = self.nodes.resized_to(new_size);
     }
 }
 

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -192,6 +192,39 @@ impl<K, V> HashMap<K, V> {
     }
 }
 
+pub struct Iter<'a, K: 'a, V: 'a> {
+    map: &'a HashMap<K, V>,
+    at: usize,
+}
+
+impl<'a, K, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.at >= self.map.nodes.len() {
+                return None;
+            }
+
+            if let Some(node) = &self.map.nodes[self.at] {
+                self.at += 1;
+                return Some((&node.key, &node.value));
+            }
+
+            self.at += 1;
+        }
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a HashMap<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Iter { map: self, at: 0 }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -247,5 +280,25 @@ mod test {
         assert_eq!(map.len(), 4);
         assert_eq!(map.get(&3), None);
         assert_eq!(map.get(&7), Some(&1));
+    }
+
+    #[test_case]
+    fn can_iterate_through_all_entries(_gba: &mut Gba) {
+        let mut map = HashMap::new();
+
+        for i in 0..8 {
+            map.put(i, i);
+        }
+
+        let mut max_found = -1;
+        let mut num_found = 0;
+
+        for (_, value) in map.into_iter() {
+            max_found = max_found.max(*value);
+            num_found += 1;
+        }
+
+        assert_eq!(num_found, 8);
+        assert_eq!(max_found, 7);
     }
 }

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -439,7 +439,7 @@ impl<K, V> Node<K, V> {
 
 impl<K, V> Drop for Node<K, V> {
     fn drop(&mut self) {
-        if self.distance_to_initial_bucket >= 0 {
+        if self.has_value() {
             unsafe { ptr::drop_in_place(self.key.as_mut_ptr()) };
             unsafe { ptr::drop_in_place(self.value.as_mut_ptr()) };
         }

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -228,10 +228,13 @@ impl<K, V> NodeStorage<K, V> {
     }
 }
 
-pub struct HashMap<K, V> {
+pub struct HashMap<K, V, H = BuildHasherDefault<FxHasher>>
+where
+    H: BuildHasher,
+{
     nodes: NodeStorage<K, V>,
 
-    hasher: BuildHasherDefault<FxHasher>,
+    hasher: H,
 }
 
 impl<K, V> HashMap<K, V> {

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -21,7 +21,7 @@ struct Node<K, V> {
 }
 
 impl<K, V> Node<K, V> {
-    fn with_new_key_value(self, new_key: K, new_value: V) -> (Self, Option<V>) {
+    fn with_new_key_value(mut self, new_key: K, new_value: V) -> (Self, Option<V>) {
         (
             Self {
                 hash: self.hash,
@@ -29,7 +29,7 @@ impl<K, V> Node<K, V> {
                 key: MaybeUninit::new(new_key),
                 value: MaybeUninit::new(new_value),
             },
-            self.get_owned_value(),
+            self.take_key_value().map(|(_, v, _)| v),
         )
     }
 
@@ -62,17 +62,6 @@ impl<K, V> Node<K, V> {
     fn get_value_mut(&mut self) -> Option<&mut V> {
         if self.has_value() {
             Some(unsafe { self.value.assume_init_mut() })
-        } else {
-            None
-        }
-    }
-
-    fn get_owned_value(mut self) -> Option<V> {
-        if self.has_value() {
-            let value = mem::replace(&mut self.value, MaybeUninit::uninit());
-            self.distance_to_initial_bucket = -1;
-
-            Some(unsafe { value.assume_init() })
         } else {
             None
         }

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -8,18 +8,14 @@ use rustc_hash::FxHasher;
 
 type HashType = u32;
 
-struct Node<K: Sized, V: Sized> {
+struct Node<K, V> {
     hash: HashType,
     distance_to_initial_bucket: u32,
     key: K,
     value: V,
 }
 
-impl<K, V> Node<K, V>
-where
-    K: Sized,
-    V: Sized,
-{
+impl<K, V> Node<K, V> {
     fn with_new_key_value(self, new_key: K, new_value: V) -> (Self, V) {
         (
             Self {

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -75,10 +75,6 @@ impl<K, V> NodeStorage<K, V> {
 
             if let Some(current_node) = current_node {
                 if current_node.distance_to_initial_bucket <= new_node.distance_to_initial_bucket {
-                    max_distance_to_initial_bucket = new_node
-                        .distance_to_initial_bucket
-                        .max(max_distance_to_initial_bucket);
-
                     mem::swap(&mut new_node, current_node);
                 }
             } else {
@@ -87,6 +83,9 @@ impl<K, V> NodeStorage<K, V> {
             }
 
             new_node.distance_to_initial_bucket += 1;
+            max_distance_to_initial_bucket = new_node
+                .distance_to_initial_bucket
+                .max(max_distance_to_initial_bucket);
         }
 
         max_distance_to_initial_bucket

--- a/agb/src/hash_map.rs
+++ b/agb/src/hash_map.rs
@@ -44,15 +44,15 @@ impl<K, V> NodeStorage<K, V> {
         }
     }
 
-    fn len(&self) -> usize {
+    fn capacity(&self) -> usize {
         self.nodes.len()
     }
 
     fn insert_new(&mut self, key: K, value: V, hash: HashType, number_of_elements: usize) {
         debug_assert!(
-            self.len() * 85 / 100 > number_of_elements,
+            self.capacity() * 85 / 100 > number_of_elements,
             "Do not have space to insert into len {} with {number_of_elements}",
-            self.len()
+            self.capacity()
         );
 
         let mut new_node = Node {
@@ -64,7 +64,7 @@ impl<K, V> NodeStorage<K, V> {
 
         loop {
             let location = fast_mod(
-                self.len(),
+                self.capacity(),
                 new_node.hash + new_node.distance_to_initial_bucket as HashType,
             );
             let current_node = self.nodes[location].as_mut();
@@ -89,7 +89,7 @@ impl<K, V> NodeStorage<K, V> {
         let mut current_location = location;
 
         let result = loop {
-            let next_location = fast_mod(self.len(), (current_location + 1) as HashType);
+            let next_location = fast_mod(self.capacity(), (current_location + 1) as HashType);
 
             // if the next node is empty, or the next location has 0 distance to initial bucket then
             // we can clear the current node
@@ -169,15 +169,15 @@ impl<K, V> HashMap<K, V> {
 
     pub fn resize(&mut self, new_size: usize) {
         assert!(
-            new_size >= self.nodes.len(),
+            new_size >= self.nodes.capacity(),
             "Can only increase the size of a hash map"
         );
-        if new_size == self.nodes.len() {
+        if new_size == self.nodes.capacity() {
             return;
         }
 
         let mut new_node_storage = NodeStorage::with_size(new_size);
-        let mut new_max_distance_to_initial_bucket = 0;
+
         let number_of_elements = self.number_of_elements;
 
         for node in self.nodes.nodes.drain(..).flatten() {
@@ -223,8 +223,8 @@ where
             return Some(old_value);
         }
 
-        if self.nodes.len() * 85 / 100 <= self.number_of_elements {
-            self.resize(self.nodes.len() * 2);
+        if self.nodes.capacity() * 85 / 100 <= self.number_of_elements {
+            self.resize(self.nodes.capacity() * 2);
         }
 
         self.nodes
@@ -283,7 +283,7 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if self.at >= self.map.nodes.len() {
+            if self.at >= self.map.nodes.capacity() {
                 return None;
             }
 

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -152,6 +152,8 @@ mod memory_mapped;
 pub mod mgba;
 /// Implementation of fixnums for working with non-integer values.
 pub use agb_fixnum as fixnum;
+/// Contains an implementation of a hashmap which suits the gameboy advance's hardware
+pub mod hash_map;
 mod single;
 /// Implements sound output.
 pub mod sound;
@@ -159,8 +161,6 @@ pub mod sound;
 pub mod syscall;
 /// Interactions with the internal timers
 pub mod timer;
-
-mod hash_map;
 
 #[cfg(not(test))]
 #[panic_handler]

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -160,6 +160,8 @@ pub mod syscall;
 /// Interactions with the internal timers
 pub mod timer;
 
+mod hash_map;
+
 #[cfg(not(test))]
 #[panic_handler]
 #[allow(unused_must_use)]

--- a/book/games/pong/Cargo.lock
+++ b/book/games/pong/Cargo.lock
@@ -24,7 +24,6 @@ dependencies = [
  "agb_sound_converter",
  "bare-metal",
  "bitflags",
- "hashbrown",
  "modular-bitfield",
  "rustc-hash",
 ]
@@ -66,17 +65,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
 ]
 
 [[package]]
@@ -164,26 +152,6 @@ dependencies = [
  "crc32fast",
  "libc",
  "miniz_oxide 0.4.4",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -310,12 +278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
-
-[[package]]
 name = "png"
 version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,15 +371,3 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"

--- a/examples/the-hat-chooses-the-wizard/Cargo.lock
+++ b/examples/the-hat-chooses-the-wizard/Cargo.lock
@@ -24,7 +24,6 @@ dependencies = [
  "agb_sound_converter",
  "bare-metal",
  "bitflags",
- "hashbrown",
  "modular-bitfield",
  "rustc-hash",
 ]
@@ -66,17 +65,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
 ]
 
 [[package]]
@@ -164,26 +152,6 @@ dependencies = [
  "crc32fast",
  "libc",
  "miniz_oxide 0.4.4",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -316,12 +284,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
-
-[[package]]
 name = "png"
 version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,15 +396,3 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"

--- a/examples/the-purple-night/Cargo.lock
+++ b/examples/the-purple-night/Cargo.lock
@@ -24,7 +24,6 @@ dependencies = [
  "agb_sound_converter",
  "bare-metal",
  "bitflags",
- "hashbrown",
  "modular-bitfield",
  "rustc-hash",
 ]
@@ -66,17 +65,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
 ]
 
 [[package]]
@@ -188,26 +176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
 dependencies = [
  "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -346,12 +314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
-
-[[package]]
 name = "png"
 version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,18 +433,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "xml-rs"


### PR DESCRIPTION
hashbrown appears on the top of the profile quite frequently, and it seems the design, although really good on modern hardware, doesn't work well for something like the GBA.

This is a much simpler hash map implementation (based on the same ideas as hashbrown, a robin hood hash), but better optimised for the GBA hardware.

There is still some work to do on it, but this is probably a good first step :).