### PR TITLE
Print warnings for assembler

### DIFF
--- a/agb/build.rs
+++ b/agb/build.rs
@@ -25,5 +25,11 @@ fn main() {
         String::from_utf8_lossy(&out.stderr)
     );
 
+    for warning_line in String::from_utf8_lossy(&out.stderr).split('\n') {
+        if !warning_line.is_empty() {
+            println!("cargo:warning={}", warning_line);
+        }
+    }
+
     println!("cargo:rustc-link-search={}", out_dir);
 }

--- a/agb/interrupt_handler.s
+++ b/agb/interrupt_handler.s
@@ -26,10 +26,10 @@ InterruptHandler:
 
     @ call the rust interrupt handler with r0 set to the triggered interrupts
     ldr r1, =__RUST_INTERRUPT_HANDLER
-    push {lr, r2}
+    push {r2, lr}
     mov lr, pc
     bx r1
-    pop {lr, r2}
+    pop {r2, lr}
 
     @ change back to interrupt mode
     mrs r1, cpsr


### PR DESCRIPTION
It was annoying me how hard it was to see the assembly warnings. So now print them as part of the build (currently doesn't fail the build, but I'm tempted)