### PR TITLE
Speed up sound attempt 209

### DIFF
--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -150,13 +150,13 @@ agb_arm_func agb_rs__init_buffer
     push {r4-r5}
 
     @ zero registers r3-r5
-    mov r2, #constant_zero
+    ldr r2, =constant_zero
     ldm r2, {r3-r5,r12}
 
 1:
     @ zero 4 words worth of the buffer
-    stmia r0, {r3-r5,r12}
-    subs r1, r1, #16
+    stmia r0!, {r3-r5,r12}
+    subs r1, r1, #(4 * 4)
     @ loop if we haven't zeroed everything
     bne 1b
 

--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -169,13 +169,7 @@ agb_arm_func agb_rs__mixer_collapse
     @ r0 = target buffer (i8)
     @ r1 = input buffer (i16) of fixnums with 4 bits of precision (read in sets of i16 in an i32)
 
-    @ firstly clear the buffer
-    push {r0, r1, r4-r11, lr}
-    ldr r1, agb_rs__buffer_size
-
-    bl agb_rs__init_buffer
-
-    pop {r0, r1}
+    push {r4-r11}
 
 CONST_0   .req r7
 CONST_FF  .req r8
@@ -252,6 +246,6 @@ SWAP_SIGN .req r11
     subs r2, r2, #16      @ r2 -= 16
     bne 1b               @ loop if not 0
 
-    pop {r4-r11, lr}
+    pop {r4-r11}
     bx lr
 agb_arm_end agb_rs__mixer_collapse

--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -136,11 +136,33 @@ agb_arm_func agb_rs__mixer_add_stereo
 
 agb_arm_end agb_rs__mixer_add_stereo
 
+.section .iwram
+    .balign 4
+constant_zero:
+.rept 4
+    .word 0
+.endr
+
 agb_arm_func agb_rs__mixer_collapse
     @ Arguments:
     @ r0 = target buffer (i8)
     @ r1 = input buffer (i16) of fixnums with 4 bits of precision (read in sets of i16 in an i32)
     push {r4-r11}
+
+    @ zero registers r4-r7 (4 of them)
+    mov r8, #constant_zero
+    ldm r8, {r4-r7}
+
+    @ get the size of the buffer
+    ldr r9, agb_rs__buffer_size
+    @ make a copy of the output buffer pointer
+    mov r10, r0
+1:
+    @ zero 4 words worth of the output buffer
+    stmia r10, {r4-r7}
+    subs r9, r9, #16
+    @ loop if we haven't zeroed everything
+    bne 1b
 
 CONST_0   .req r7
 CONST_FF  .req r8

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -1,4 +1,6 @@
 use core::cell::RefCell;
+use core::mem;
+use core::mem::MaybeUninit;
 
 use bare_metal::{CriticalSection, Mutex};
 
@@ -27,6 +29,8 @@ extern "C" {
     fn agb_rs__mixer_add_stereo(sound_data: *const u8, sound_buffer: *mut Num<i16, 4>);
 
     fn agb_rs__mixer_collapse(sound_buffer: *mut i8, input_buffer: *const Num<i16, 4>);
+
+    fn agb_rs__init_buffer(buffer: *mut MaybeUninit<Num<i16, 4>>, size_in_bytes: usize);
 }
 
 pub struct Mixer {
@@ -231,8 +235,28 @@ impl MixerBuffer {
     }
 
     fn write_channels<'a>(&mut self, channels: impl Iterator<Item = &'a mut SoundChannel>) {
-        let mut buffer: [Num<i16, 4>; constants::SOUND_BUFFER_SIZE * 2] =
-            [Num::new(0); constants::SOUND_BUFFER_SIZE * 2];
+        // This code is equivalent to:
+        // let mut buffer: [Num<i16, 4>; constants::SOUND_BUFFER_SIZE * 2] =
+        //     [Num::new(0); constants::SOUND_BUFFER_SIZE * 2];
+        // but the above uses approximately 7% of the CPU time if running at 32kHz
+        let mut buffer: [Num<i16, 4>; constants::SOUND_BUFFER_SIZE * 2] = {
+            // Create an uninitialized array of `MaybeUninit`. The `assume_init` is
+            // safe because the type we are claiming to have initialized here is a
+            // bunch of `MaybeUninit`s, which do not require initialization.
+            let mut data: [MaybeUninit<Num<i16, 4>>; constants::SOUND_BUFFER_SIZE * 2] =
+                unsafe { MaybeUninit::uninit().assume_init() };
+
+            // Actually init the array (by filling it with zeros) and then transmute it (which is safe because
+            // we have now zeroed everything)
+            unsafe {
+                agb_rs__init_buffer(
+                    data.as_mut_ptr(),
+                    mem::size_of::<Num<i16, 4>>() * data.len(),
+                );
+
+                mem::transmute(data)
+            }
+        };
 
         for channel in channels {
             if channel.is_done {

--- a/agb/src/syscall.rs
+++ b/agb/src/syscall.rs
@@ -120,29 +120,6 @@ pub fn arc_tan2(x: i16, y: i32) -> i16 {
     result
 }
 
-pub(crate) fn cpu_fast_fill_i8(input: &mut [i8], new_content: i32) {
-    assert_eq!(
-        input.len() % (4 * 8),
-        0,
-        "Input length must be divisible by 32"
-    );
-
-    let input_ptr = [new_content].as_ptr();
-    let output_ptr = input.as_mut_ptr();
-    let length_mode = (1 << 24) | // copy
-        (input.len() / 4);
-
-    unsafe {
-        asm!(
-            "swi 0x0c",
-            in("r0") input_ptr,
-            in("r1") output_ptr,
-            in("r2") length_mode,
-            lateout("r3") _,
-        );
-    }
-}
-
 // pub fn affine_matrix(
 //     x_scale: Num<i16, 8>,
 //     y_scale: Num<i16, 8>,


### PR DESCRIPTION
turns out rust's zeroing of buffers is really really slow on the GBA. Maybe we can do something better with that by replacing the intrinsic, but for now, a special case for the sound engine.

Brings the 32kHz basic example from 13% CPU to 6% CPU making it almost as fast as the 10512Hz was at the beginning of last week.