### PR TITLE
Fix agbabi memcpy issue

### DIFF
--- a/agb/src/agbabi/memcpy.s
+++ b/agb/src/agbabi/memcpy.s
@@ -29,6 +29,10 @@ __aeabi_memcpy:
     bmi     .Lcopy1
     bcs     .Lcopy2
 
+    // If the number of bytes to copy is less than 4, we should just copy one byte at a time
+    cmp     r2, #4
+    bmi     .Lcopy1
+
 .Lcopy4:
     // Copy half and byte head
     rsb     r3, r0, #4

--- a/agb/src/agbabi/mod.rs
+++ b/agb/src/agbabi/mod.rs
@@ -43,7 +43,7 @@ mod test {
 
             for size in 0..68 {
                 for (i, value) in input.iter_mut().enumerate() {
-                    *value = i as u8 * 6;
+                    *value = i as u8 * 3;
                 }
 
                 output.fill(0);
@@ -57,6 +57,94 @@ mod test {
                 }
 
                 for (i, value) in output.iter().enumerate().skip(size) {
+                    assert_eq!(*value, 0, "overrun with size = {size} at i = {i}");
+                }
+            }
+        }
+
+        #[test_case]
+        fn test_memcpy_bytes_output_offsetted_with_different_sizes(_gba: &mut Gba) {
+            let mut input = vec![0u8; 70];
+            let mut output = vec![0u8; 70];
+
+            for size in 0..60 {
+                for (i, value) in input.iter_mut().enumerate() {
+                    *value = i as u8 * 3;
+                }
+
+                output.fill(0);
+
+                unsafe {
+                    __agbabi_memcpy(output.as_mut_ptr().add(1), input.as_ptr(), size);
+                }
+
+                for i in 0..size {
+                    assert_eq!(
+                        input[i],
+                        output[i + 1],
+                        "Failed with size = {size} at i = {i}"
+                    );
+                }
+
+                for (i, value) in output.iter().enumerate().skip(size + 1) {
+                    assert_eq!(*value, 0, "overrun with size = {size} at i = {i}");
+                }
+            }
+        }
+
+        #[test_case]
+        fn test_memcpy_bytes_input_offsetted_with_different_sizes(_gba: &mut Gba) {
+            let mut input = vec![0u8; 70];
+            let mut output = vec![0u8; 70];
+
+            for size in 0..60 {
+                for (i, value) in input.iter_mut().enumerate() {
+                    *value = i as u8 * 3;
+                }
+
+                output.fill(0);
+
+                unsafe {
+                    __agbabi_memcpy(output.as_mut_ptr(), input.as_ptr().add(1), size);
+                }
+
+                for i in 0..size {
+                    assert_eq!(
+                        input[i + 1],
+                        output[i],
+                        "Failed with size = {size} at i = {i}"
+                    );
+                }
+
+                for (i, value) in output.iter().enumerate().skip(size) {
+                    assert_eq!(*value, 0, "overrun with size = {size} at i = {i}");
+                }
+            }
+        }
+
+        #[test_case]
+        fn test_memcpy_bytes_input_output_offsetted_with_different_sizes(_gba: &mut Gba) {
+            let mut input = vec![0u8; 70];
+            let mut output = vec![0u8; 70];
+
+            for size in 0..60 {
+                for (i, value) in input.iter_mut().enumerate() {
+                    *value = i as u8 * 3;
+                }
+
+                output.fill(0);
+
+                unsafe {
+                    __agbabi_memcpy(output.as_mut_ptr().add(1), input.as_ptr().add(1), size);
+                }
+
+                assert_eq!(output[0], 0);
+
+                for i in 1..size + 1 {
+                    assert_eq!(input[i], output[i], "Failed with size = {size} at i = {i}");
+                }
+
+                for (i, value) in output.iter().enumerate().skip(size + 1) {
                     assert_eq!(*value, 0, "overrun with size = {size} at i = {i}");
                 }
             }

--- a/agb/src/agbabi/mod.rs
+++ b/agb/src/agbabi/mod.rs
@@ -1,0 +1,65 @@
+#[cfg(test)]
+mod test {
+    mod memcpy {
+        use alloc::vec;
+
+        use crate::Gba;
+
+        extern "C" {
+            fn __agbabi_memcpy(dest: *mut u8, src: *const u8, n: usize);
+            fn __aeabi_memcpy4(dest: *mut u32, src: *const u32, n: usize);
+        }
+
+        #[test_case]
+        fn test_memcpy4_with_different_sizes(_gba: &mut Gba) {
+            let mut input = vec![0u32; 70];
+            let mut output = vec![0u32; 70];
+
+            for size in 0..68 {
+                for (i, value) in input.iter_mut().enumerate() {
+                    *value = i as u32 * 6;
+                }
+
+                output.fill(0);
+
+                unsafe {
+                    __aeabi_memcpy4(output.as_mut_ptr(), input.as_ptr(), size * 4);
+                }
+
+                for i in 0..size {
+                    assert_eq!(input[i], output[i], "Failed with size = {size} at i = {i}");
+                }
+
+                for (i, value) in output.iter().enumerate().skip(size) {
+                    assert_eq!(*value, 0, "overrun with size = {size} at i = {i}");
+                }
+            }
+        }
+
+        #[test_case]
+        fn test_memcpy_bytes_with_different_sizes(_gba: &mut Gba) {
+            let mut input = vec![0u8; 70];
+            let mut output = vec![0u8; 70];
+
+            for size in 0..68 {
+                for (i, value) in input.iter_mut().enumerate() {
+                    *value = i as u8 * 6;
+                }
+
+                output.fill(0);
+
+                unsafe {
+                    __agbabi_memcpy(output.as_mut_ptr(), input.as_ptr(), size);
+                }
+
+                for i in 0..size {
+                    assert_eq!(input[i], output[i], "Failed with size = {size} at i = {i}");
+                }
+
+                for (i, value) in output.iter().enumerate().skip(size) {
+                    assert_eq!(*value, 0, "overrun with size = {size} at i = {i}");
+                }
+            }
+        }
+    }
+}

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -157,6 +157,7 @@ pub use agb_sound_converter::include_wav;
 extern crate alloc;
 mod agb_alloc;
 
+mod agbabi;
 mod bitarray;
 /// Implements everything relating to things that are displayed on screen.
 pub mod display;


### PR DESCRIPTION
When using the new memcpy implementation, the hat chooses the wizard would crash if you died on a stage containing an enemy. After proving that the issue lies within the new memcpy implementation, I wrote a bunch of tests to see what would cause the issue.

The system would hang with misaligned copies less than 4 bytes in size, so I added a simple bypass in that case.

The tests are probably also worth keeping.