### PR TITLE
a test for agbabi memset

### DIFF
--- a/agb/src/agbabi/memset.s
+++ b/agb/src/agbabi/memset.s
@@ -19,13 +19,13 @@
     .balign 4
 
     .section .iwram.__aeabi_memset, "ax", %progbits
-    .global __agbabi_memset
-__agbabi_memset:
     .global __aeabi_memclr
 __aeabi_memclr:
     mov     r2, #0
     b       .LskipShifts
 
+    .global __agbabi_memset
+__agbabi_memset:
     .global __aeabi_memset
 __aeabi_memset:
     mov     r2, r2, lsl #24

--- a/agb/src/agbabi/mod.rs
+++ b/agb/src/agbabi/mod.rs
@@ -1,5 +1,42 @@
 #[cfg(test)]
 mod test {
+    mod memset {
+        use crate::Gba;
+        use alloc::vec;
+
+        extern "C" {
+            fn __aeabi_memset(dest: *mut u8, n: usize, v: u8);
+            fn __aeabi_memset4(dest: *mut u8, n: usize, v: u8);
+        }
+
+        #[test_case]
+        fn test_memset_with_different_sizes(_gba: &mut Gba) {
+            let mut values = vec![0u8; 100];
+
+            let v = 0x12;
+
+            for n in 0..80 {
+                values.fill(0xFF);
+
+                unsafe {
+                    __aeabi_memset4(values.as_mut_ptr().wrapping_offset(10), n, v);
+                }
+
+                for (i, &v) in values.iter().enumerate().take(10) {
+                    assert_eq!(v, 0xFF, "underrun at {}", i);
+                }
+
+                for i in 0..n {
+                    assert_eq!(values[10 + i], v, "incorrect value at {}", i + 10);
+                }
+
+                for (i, &v) in values.iter().enumerate().skip(10 + n) {
+                    assert_eq!(v, 0xFF, "overrun at {}", i);
+                }
+            }
+        }
+    }
+
     mod memcpy {
         use alloc::vec;
 


### PR DESCRIPTION
Appears to not properly handle 8 byte aligned destinations? Writes some earlier bytes to align to word boundary?