### PR TITLE
More memcpy tests

### DIFF
--- a/agb/src/agbabi/memcpy.s
+++ b/agb/src/agbabi/memcpy.s
@@ -22,6 +22,10 @@
 __agbabi_memcpy:
     .global __aeabi_memcpy
 __aeabi_memcpy:
+    // Handle <= 2 byte copies byte-by-byte
+    cmp     r2, #2
+    ble     .Lcopy1
+
     // Check pointer alignment
     eor     r3, r1, r0
     // JoaoBapt carry & sign bit test
@@ -30,9 +34,6 @@ __aeabi_memcpy:
     bcs     .Lcopy2
 
 .Lcopy4:
-    // Handle <= 2 byte copies byte-by-byte
-    cmp     r2, #2
-    ble     .Lcopy1
 
     // Copy half and byte head
     rsb     r3, r0, #4

--- a/agb/src/agbabi/mod.rs
+++ b/agb/src/agbabi/mod.rs
@@ -188,8 +188,8 @@ mod test {
             let mut output = vec![0u32; 100];
 
             for size in 0..80 {
-                for offset_input in 0..10 {
-                    for offset_output in 0..10 {
+                for offset_input in 0..8 {
+                    for offset_output in 0..8 {
                         // initialise the buffers
                         for (i, value) in input.iter_mut().enumerate() {
                             *value = i as u32;
@@ -224,8 +224,8 @@ mod test {
             let mut output = vec![0u32; 100];
 
             for size in 0..40 {
-                for offset_input in 0..10 {
-                    for offset_output in 0..10 {
+                for offset_input in 0..8 {
+                    for offset_output in 0..8 {
                         // initialise the buffers
                         for (i, value) in input.iter_mut().enumerate() {
                             *value = i as u32;


### PR DESCRIPTION
Tests a lot more permutations of input and output offsets for memcpy and memcpy4 to try and find the source of the corruption bug.

This spotted another infinite loop in agbabi's memcpy, but no memory corruption...