### PR TITLE
Make it possible to run tests in target crates (and add a basic tests in hat-wizard)

### DIFF
--- a/agb-macros/src/lib.rs
+++ b/agb-macros/src/lib.rs
@@ -92,7 +92,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
             let mut #argument_name = unsafe { #argument_type ::new_in_entry() };
 
             if cfg!(test) {
-                agb::test_runner::agb_start_tests(#argument_name, test_main);
+                ::agb::test_runner::agb_start_tests(#argument_name, test_main);
             } else {
                 #(#stmts)*
             }

--- a/agb-macros/src/lib.rs
+++ b/agb-macros/src/lib.rs
@@ -76,12 +76,26 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
     );
 
     quote!(
+        #[cfg(not(test))]
         #[export_name = "main"]
         #(#attrs)*
         pub fn #fn_name() -> ! {
             let #mutable #argument_name = unsafe { #argument_type ::new_in_entry() };
 
             #(#stmts)*
+        }
+
+        #[cfg(test)]
+        #[export_name = "main"]
+        #(#attrs)*
+        pub fn #fn_name() -> ! {
+            let mut #argument_name = unsafe { #argument_type ::new_in_entry() };
+
+            if cfg!(test) {
+                agb::test_runner::agb_start_tests(#argument_name, test_main);
+            } else {
+                #(#stmts)*
+            }
         }
     )
     .into()

--- a/agb-macros/src/lib.rs
+++ b/agb-macros/src/lib.rs
@@ -92,7 +92,7 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
             let mut #argument_name = unsafe { #argument_type ::new_in_entry() };
 
             if cfg!(test) {
-                ::agb::test_runner::agb_start_tests(#argument_name, test_main);
+                agb::test_runner::agb_start_tests(#argument_name, test_main);
             } else {
                 #(#stmts)*
             }

--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -19,6 +19,7 @@ debug = true
 default = []
 freq18157 = ["agb_sound_converter/freq18157"]
 freq32768 = ["agb_sound_converter/freq32768"]
+testing = []
 
 [dependencies]
 bitflags = "1"

--- a/agb/src/agb_alloc/block_allocator.rs
+++ b/agb/src/agb_alloc/block_allocator.rs
@@ -58,7 +58,8 @@ impl BlockAllocator {
         }
     }
 
-    #[cfg(test)]
+    #[doc(hidden)]
+    #[cfg(any(test, feature = "testing"))]
     pub unsafe fn number_of_blocks(&self) -> u32 {
         free(|key| {
             let mut state = self.state.borrow(key).borrow_mut();

--- a/agb/src/agb_alloc/mod.rs
+++ b/agb/src/agb_alloc/mod.rs
@@ -42,7 +42,7 @@ static GLOBAL_ALLOC: BlockAllocator = unsafe {
     })
 };
 
-#[cfg(test)]
+#[cfg(any(test, feature = "testing"))]
 pub unsafe fn number_of_blocks() -> u32 {
     GLOBAL_ALLOC.number_of_blocks()
 }

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -256,7 +256,45 @@ impl Gba {
 }
 
 #[cfg(any(test, feature = "testing"))]
-#[doc(hidden)]
+/// *Unstable* support for running tests using `agb`
+///
+/// In order to use this, you need to enable the unstable `custom_test_framework` feature and copy-paste
+/// the following into the top of your application:
+///
+/// ```
+/// #![cfg_attr(test, feature(custom_test_frameworks))]
+/// #![cfg_attr(test, reexport_test_harness_main = "test_main")]
+/// #![cfg_attr(test, test_runner(agb::test_runner::test_runner))]
+///
+/// #[cfg(test)]
+/// #[agb::entry]
+/// fn main(mut gba: agb::Gba) -> ! {
+///     agb::test_runner::agb_start_tests(gba, test_main);
+/// }
+/// ```
+///
+/// And ensure that your main does not build if testing, so do something similar to:
+///
+/// ```
+/// #[cfg(not(test))]
+/// #[agb::entry]
+/// fn main(mut gba: agb::Gba) -> ! {
+///     // ...
+/// }
+/// ```
+///
+/// With this support, you will be able to write tests which you can run using `mgba-test-runner`.
+/// Tests are written using `#[test_case]` rather than `#[test]`.
+///
+/// ```
+/// #[test_case]
+/// fn test_ping_pong(_gba: &mut Gba) {
+///     assert_eq!(1, 1);
+/// }
+/// ```
+///
+/// You can run the tests using `cargo test`, but it will work better through `mgba-test-runner` by
+/// running something along the lines of `CARGO_TARGET_THUMBV4T_NONE_EABI_RUNNER=mgba-test-runner cargo test`.
 pub mod test_runner {
     use super::*;
 

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -265,22 +265,12 @@ impl Gba {
 /// #![cfg_attr(test, feature(custom_test_frameworks))]
 /// #![cfg_attr(test, reexport_test_harness_main = "test_main")]
 /// #![cfg_attr(test, test_runner(agb::test_runner::test_runner))]
-///
-/// #[cfg(test)]
-/// #[agb::entry]
-/// fn main(mut gba: agb::Gba) -> ! {
-///     agb::test_runner::agb_start_tests(gba, test_main);
-/// }
 /// ```
 ///
-/// And ensure that your main does not build if testing, so do something similar to:
-///
-/// ```
-/// #[cfg(not(test))]
-/// #[agb::entry]
-/// fn main(mut gba: agb::Gba) -> ! {
-///     // ...
-/// }
+/// And ensure you add agb with the `testing` feature to your `dev-dependencies`
+/// ```toml
+/// [dev-dependencies]
+/// agb = { version = "<same as in dependencies>", features = ["testing"] }
 /// ```
 ///
 /// With this support, you will be able to write tests which you can run using `mgba-test-runner`.
@@ -363,6 +353,13 @@ pub mod test_runner {
             mgba::DebugLevel::Info,
         )
         .unwrap();
+    }
+
+    // needed to fudge the #[entry] below
+    mod agb {
+        pub mod test_runner {
+            pub use super::super::agb_start_tests;
+        }
     }
 
     #[cfg(test)]

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -369,6 +369,7 @@ pub mod test_runner {
         loop {} // full implementation provided by the #[entry]
     }
 
+    #[doc(hidden)]
     pub fn agb_start_tests(gba: Gba, test_main: impl Fn()) -> ! {
         unsafe { TEST_GBA = Some(gba) };
         test_main();

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -365,7 +365,8 @@ pub mod test_runner {
     #[cfg(test)]
     #[entry]
     fn agb_test_main(gba: Gba) -> ! {
-        agb_start_tests(gba, test_main);
+        #[allow(clippy::empty_loop)]
+        loop {} // full implementation provided by the #[entry]
     }
 
     pub fn agb_start_tests(gba: Gba, test_main: impl Fn()) -> ! {

--- a/examples/the-hat-chooses-the-wizard/Cargo.toml
+++ b/examples/the-hat-chooses-the-wizard/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2018"
 [dependencies]
 agb = { version = "0.9.2", path = "../../agb" }
 
+[dev-dependencies]
+agb = { version = "0.9.2", path = "../../agb", features = ["testing"] }
+
 [build-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/examples/the-hat-chooses-the-wizard/src/main.rs
+++ b/examples/the-hat-chooses-the-wizard/src/main.rs
@@ -1,5 +1,14 @@
 #![no_std]
 #![no_main]
+#![cfg_attr(test, feature(custom_test_frameworks))]
+#![cfg_attr(test, reexport_test_harness_main = "test_main")]
+#![cfg_attr(test, test_runner(agb::test_runner::test_runner))]
+
+#[cfg(test)]
+#[agb::entry]
+fn main(mut gba: agb::Gba) -> ! {
+    agb::test_runner::agb_start_tests(gba, test_main);
+}
 
 extern crate alloc;
 
@@ -775,8 +784,13 @@ impl<'a, 'b> PlayingLevel<'a, 'b> {
     }
 }
 
+#[cfg(not(test))]
 #[agb::entry]
-fn main(mut agb: agb::Gba) -> ! {
+fn agb_main(mut gba: agb::Gba) -> ! {
+    main(gba);
+}
+
+pub fn main(mut agb: agb::Gba) -> ! {
     let (tiled, mut vram) = agb.display.video.tiled0();
     vram.set_background_palettes(tile_sheet::background.palettes);
     let mut splash_screen = tiled.background(Priority::P0, RegularBackgroundSize::Background32x32);
@@ -956,5 +970,34 @@ fn main(mut agb: agb::Gba) -> ! {
             &mut splash_screen,
             &mut vram,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agb::Gba;
+
+    #[test_case]
+    fn test_ping_pong(_gba: &mut Gba) {
+        let test_cases = [
+            [0, 2, 0],
+            [0, 7, 0],
+            [1, 2, 1],
+            [2, 2, 0],
+            [3, 2, 1],
+            [4, 2, 0],
+        ];
+
+        for test_case in test_cases {
+            assert_eq!(
+                ping_pong(test_case[0], test_case[1]),
+                test_case[2],
+                "Expected ping_pong({}, {}) to equal {}",
+                test_case[0],
+                test_case[1],
+                test_case[2],
+            );
+        }
     }
 }

--- a/examples/the-hat-chooses-the-wizard/src/main.rs
+++ b/examples/the-hat-chooses-the-wizard/src/main.rs
@@ -778,7 +778,6 @@ impl<'a, 'b> PlayingLevel<'a, 'b> {
     }
 }
 
-#[cfg(not(test))]
 #[agb::entry]
 fn agb_main(mut gba: agb::Gba) -> ! {
     main(gba);

--- a/examples/the-hat-chooses-the-wizard/src/main.rs
+++ b/examples/the-hat-chooses-the-wizard/src/main.rs
@@ -4,12 +4,6 @@
 #![cfg_attr(test, reexport_test_harness_main = "test_main")]
 #![cfg_attr(test, test_runner(agb::test_runner::test_runner))]
 
-#[cfg(test)]
-#[agb::entry]
-fn main(mut gba: agb::Gba) -> ! {
-    agb::test_runner::agb_start_tests(gba, test_main);
-}
-
 extern crate alloc;
 
 use agb::{

--- a/mgba-test-runner/build-mgba.sh
+++ b/mgba-test-runner/build-mgba.sh
@@ -1,22 +1,22 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 MGBA_VERSION=$1
 OUT_DIRECTORY=$2
 CURRENT_DIRECTORY=$(pwd)
 
-cd ${OUT_DIRECTORY}
+cd "${OUT_DIRECTORY}" || exit
 
 if [[ -f libmgba-cycle.a ]]; then
 	exit 0
 fi
 
-curl -L https://github.com/mgba-emu/mgba/archive/refs/tags/${MGBA_VERSION}.tar.gz -o mgba-${MGBA_VERSION}.tar.gz
-tar -xvf mgba-${MGBA_VERSION}.tar.gz
-cd mgba-${MGBA_VERSION}
+curl -L "https://github.com/mgba-emu/mgba/archive/refs/tags/${MGBA_VERSION}.tar.gz" -o "mgba-${MGBA_VERSION}.tar.gz"
+tar -xvf "mgba-${MGBA_VERSION}.tar.gz"
+cd "mgba-${MGBA_VERSION}" || exit
 rm -rf build
-patch --strip=1 < ${CURRENT_DIRECTORY}/add_cycles_register.patch
+patch --strip=1 < "${CURRENT_DIRECTORY}/add_cycles_register.patch"
 mkdir -p build
-cd build
+cd build || exit
 cmake .. \
     -DBUILD_STATIC=ON \
     -DBUILD_SHARED=OFF \

--- a/mgba-test-runner/build-mgba.sh
+++ b/mgba-test-runner/build-mgba.sh
@@ -6,6 +6,10 @@ CURRENT_DIRECTORY=$(pwd)
 
 cd "${OUT_DIRECTORY}" || exit
 
+if [[ ! -f "mgba-${MGBA_VERSION}.tar.gz" ]]; then
+	curl -L "https://github.com/mgba-emu/mgba/archive/refs/tags/${MGBA_VERSION}.tar.gz" -o "mgba-${MGBA_VERSION}.tar.gz"
+fi
+
 if [[ -f libmgba-cycle.a ]]; then
 	exit 0
 fi

--- a/release.sh
+++ b/release.sh
@@ -46,7 +46,7 @@ fi
 
 TAGNAME="v$VERSION"
 
-for PROJECT_TOML_FILE in agb/Cargo.toml agb-*/Cargo.toml; do
+for PROJECT_TOML_FILE in agb/Cargo.toml agb-*/Cargo.toml template/Cargo.toml; do
     DIRECTORY=$(dirname "$PROJECT_TOML_FILE")
 
     # Update the version in Cargo.toml

--- a/release.sh
+++ b/release.sh
@@ -46,7 +46,7 @@ fi
 
 TAGNAME="v$VERSION"
 
-for PROJECT_TOML_FILE in agb/Cargo.toml agb-*/Cargo.toml template/Cargo.toml; do
+for PROJECT_TOML_FILE in agb/Cargo.toml agb-*/Cargo.toml; do
     DIRECTORY=$(dirname "$PROJECT_TOML_FILE")
 
     # Update the version in Cargo.toml
@@ -59,7 +59,7 @@ for PROJECT_TOML_FILE in agb/Cargo.toml agb-*/Cargo.toml template/Cargo.toml; do
         # also update the agb version in the template and the examples
         sed -i -e "s/^agb = \".*\"/agb = \"$VERSION\"/" template/Cargo.toml
 
-        for EXAMPLE_TOML_FILE in examples/*/Cargo.toml book/games/*/Cargo.toml; do
+        for EXAMPLE_TOML_FILE in examples/*/Cargo.toml book/games/*/Cargo.toml template/Cargo.toml; do
             EXAMPLE_DIR=$(dirname "$EXAMPLE_TOML_FILE")
             sed -E -i -e "/agb =/ s/version = \"[^\"]+\"/version = \"$VERSION\"/" "$EXAMPLE_DIR/Cargo.toml"
             (cd "$EXAMPLE_DIR" && cargo update)

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -9,6 +9,9 @@ edition = "2018"
 [dependencies]
 agb = "0.9.2"
 
+[dev-dependencies]
+agb = { version = "0.9.2", features = ["testing"] }
+
 [profile.release]
 panic = "abort"
 lto = true

--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -9,6 +9,10 @@
 // using the #[agb::entry] proc macro. Failing to do so will cause failure in linking
 // which won't be a particularly clear error message.
 #![no_main]
+// This is required to allow writing tests
+#![cfg_attr(test, feature(custom_test_frameworks))]
+#![cfg_attr(test, reexport_test_harness_main = "test_main")]
+#![cfg_attr(test, test_runner(agb::test_runner::test_runner))]
 
 use agb::{display, syscall};
 


### PR DESCRIPTION
The ability to add tests in a sub-crate was requested by Jinxit in the gbadev discord. Seemed like a useful feature so here is a draft implementation for getting some feedback.

I'll add some documentation (since it isn't obvious how to enable it) once we've decided it could be a good idea :).

See the changes in main.rs in `the-hat-chooses-the-wizard` for what you have to do to enable it (also need to enable the 'testing' feature in the `dev-dependencies`)