### PR TITLE
Better defaults for dev mode and release mode in the template

### DIFF
--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -12,6 +12,11 @@ agb = "0.9.2"
 [dev-dependencies]
 agb = { version = "0.9.2", features = ["testing"] }
 
+[profile.dev]
+opt-level = 2
+debug = true
+
 [profile.release]
 panic = "abort"
 lto = true
+debug = true


### PR DESCRIPTION
Not enabling optimisations in the template can be painful, so these should be enabled. Also enable debug symbols to be in the binary for when we want to objdump it.