### PR TITLE
Support armv4t-none-eabi target as well.

### DIFF
--- a/agb/.cargo/config.toml
+++ b/agb/.cargo/config.toml
@@ -8,3 +8,7 @@ target = "thumbv4t-none-eabi"
 [target.thumbv4t-none-eabi]
 rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
 runner = "mgba-test-runner"
+
+[target.armv4t-none-eabi]
+rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
+runner = "mgba-test-runner"

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -12,6 +12,7 @@
 )]
 #![feature(alloc_error_handler)]
 #![feature(allocator_api)]
+#![feature(asm_const)]
 #![warn(clippy::all)]
 #![deny(clippy::must_use_candidate)]
 #![deny(clippy::trivially_copy_pass_by_ref)]

--- a/agb/src/syscall.rs
+++ b/agb/src/syscall.rs
@@ -4,10 +4,19 @@ use core::arch::asm;
 
 #[allow(non_snake_case)]
 
+const fn swi_map(thumb_id: u32) -> u32 {
+    if cfg!(target_feature="thumb-mode") {
+        thumb_id
+    } else {
+        thumb_id << 16
+    }
+}
+
 pub fn halt() {
     unsafe {
         asm!(
-            "swi 0x02",
+            "swi {SWI}",
+            SWI = const { swi_map(0x02) },
             lateout("r0") _,
             lateout("r1") _,
             lateout("r2") _,
@@ -19,7 +28,8 @@ pub fn halt() {
 pub fn stop() {
     unsafe {
         asm!(
-            "swi 0x03",
+            "swi {SWI}",
+            SWI = const { swi_map(0x03) },
             lateout("r0") _,
             lateout("r1") _,
             lateout("r2") _,
@@ -31,7 +41,8 @@ pub fn stop() {
 pub fn wait_for_interrupt() {
     unsafe {
         asm!(
-            "swi 0x04",
+            "swi {SWI}",
+            SWI = const { swi_map(0x04) },
             lateout("r0") _,
             lateout("r1") _,
             lateout("r2") _,
@@ -45,7 +56,8 @@ pub fn wait_for_interrupt() {
 pub fn wait_for_vblank() {
     unsafe {
         asm!(
-            "swi 0x05",
+            "swi {SWI}",
+            SWI = const { swi_map(0x05) },
             lateout("r0") _,
             lateout("r1") _,
             lateout("r2") _,
@@ -61,7 +73,8 @@ pub fn div(numerator: i32, denominator: i32) -> (i32, i32, i32) {
     let abs_divide: i32;
     unsafe {
         asm!(
-            "swi 0x06",
+            "swi {SWI}",
+            SWI = const { swi_map(0x06) },
             in("r0") numerator,
             in("r1") denominator,
             lateout("r0") divide,
@@ -77,7 +90,8 @@ pub fn sqrt(n: i32) -> i32 {
     let result: i32;
     unsafe {
         asm!(
-            "swi 0x08",
+            "swi {SWI}",
+            SWI = const { swi_map(0x08) },
             in("r0") n,
             lateout("r0") result,
             lateout("r1") _,
@@ -93,7 +107,8 @@ pub fn arc_tan(n: i16) -> i16 {
     let result: i16;
     unsafe {
         asm!(
-            "swi 0x09",
+            "swi {SWI}",
+            SWI = const { swi_map(0x09) },
             in("r0") n,
             lateout("r0") result,
             lateout("r1") _,
@@ -109,7 +124,8 @@ pub fn arc_tan2(x: i16, y: i32) -> i16 {
     let result: i16;
     unsafe {
         asm!(
-            "swi 0x09",
+            "swi {SWI}",
+            SWI = const { swi_map(0x09) },
             in("r0") x,
             in("r1") y,
             lateout("r0") result,

--- a/armv4t-none-eabi.json
+++ b/armv4t-none-eabi.json
@@ -1,0 +1,23 @@
+{
+    "arch": "arm",
+    "asm-args": [
+        "-mthumb-interwork",
+        "-march=armv4t",
+        "-mcpu=arm7tdmi",
+        "-mlittle-endian"
+    ],
+    "atomic-cas": false,
+    "data-layout": "e-m:e-p:32:32-Fi8-i64:64-v128:64:128-a:0:32-n32-S64",
+    "emit-debug-gdb-scripts": false,
+    "executables": true,
+    "features": "+soft-float,+strict-align",
+    "has-thumb-interworking": true,
+    "linker": "arm-none-eabi-ld",
+    "linker-flavor": "ld",
+    "linker-is-gnu": true,
+    "llvm-target": "armv4t-none-eabi",
+    "main-needs-argc-argv": false,
+    "panic-strategy": "abort",
+    "relocation-model": "static",
+    "target-pointer-width": "32"
+}

--- a/book/games/pong/.cargo/config.toml
+++ b/book/games/pong/.cargo/config.toml
@@ -6,5 +6,9 @@ build-std-features = ["compiler-builtins-mem"]
 target = "thumbv4t-none-eabi"
 
 [target.thumbv4t-none-eabi]
-rustflags = ["-Clink-arg=-Tgba.ld"]
+rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
+runner = "mgba-qt"
+
+[target.armv4t-none-eabi]
+rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
 runner = "mgba-qt"

--- a/examples/hyperspace-roll/.cargo/config.toml
+++ b/examples/hyperspace-roll/.cargo/config.toml
@@ -7,5 +7,9 @@ sparse-registry = true
 target = "thumbv4t-none-eabi"
 
 [target.thumbv4t-none-eabi]
-rustflags = ["-Clink-arg=-Tgba.ld"]
+rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
+runner = "mgba-qt"
+
+[target.armv4t-none-eabi]
+rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
 runner = "mgba-qt"

--- a/examples/the-hat-chooses-the-wizard/.cargo/config.toml
+++ b/examples/the-hat-chooses-the-wizard/.cargo/config.toml
@@ -6,5 +6,9 @@ build-std-features = ["compiler-builtins-mem"]
 target = "thumbv4t-none-eabi"
 
 [target.thumbv4t-none-eabi]
-rustflags = ["-Clink-arg=-Tgba.ld"]
+rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
+runner = "mgba-qt"
+
+[target.armv4t-none-eabi]
+rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
 runner = "mgba-qt"

--- a/examples/the-purple-night/.cargo/config.toml
+++ b/examples/the-purple-night/.cargo/config.toml
@@ -6,5 +6,9 @@ build-std-features = ["compiler-builtins-mem"]
 target = "thumbv4t-none-eabi"
 
 [target.thumbv4t-none-eabi]
-rustflags = ["-Clink-arg=-Tgba.ld"]
+rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
+runner = "mgba-qt"
+
+[target.armv4t-none-eabi]
+rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
 runner = "mgba-qt"

--- a/justfile
+++ b/justfile
@@ -13,9 +13,11 @@ clippy:
 test:
     just _test-debug agb
     just _test-debug agb-fixnum
+    just _test-debug-arm agb
 
 test-release:
     just _test-release agb
+    just _test-release-arm agb
 
 doctest-agb:
     (cd agb && cargo test --doc -Z doctest-xcompile)
@@ -92,9 +94,13 @@ _build-release crate:
 _test-release crate:
     just _build-release {{crate}}
     (cd "{{crate}}" && cargo test --release)
+_test-release-arm crate:
+    (cd "{{crate}}" && cargo test --release --target={{justfile_directory()+"/armv4t-none-eabi.json"}})
 _test-debug crate:
     just _build-debug {{crate}}
     (cd "{{crate}}" && cargo test)
+_test-debug-arm crate:
+    (cd "{{crate}}" && cargo test --release --target={{justfile_directory()+"/armv4t-none-eabi.json"}})
 _clippy crate:
     (cd "{{crate}}" && cargo clippy --examples --tests -- {{CLIPPY_ARGUMENTS}})
 _clean crate:

--- a/justfile
+++ b/justfile
@@ -95,12 +95,12 @@ _test-release crate:
     just _build-release {{crate}}
     (cd "{{crate}}" && cargo test --release)
 _test-release-arm crate:
-    (cd "{{crate}}" && cargo test --release --target={{justfile_directory()+"/armv4t-none-eabi.json"}})
+    (cd "{{crate}}" && cargo test --release --target="{{justfile_directory()+"/armv4t-none-eabi.json"}}")
 _test-debug crate:
     just _build-debug {{crate}}
     (cd "{{crate}}" && cargo test)
 _test-debug-arm crate:
-    (cd "{{crate}}" && cargo test --release --target={{justfile_directory()+"/armv4t-none-eabi.json"}})
+    (cd "{{crate}}" && cargo test --release --target="{{justfile_directory()+"/armv4t-none-eabi.json"}}")
 _clippy crate:
     (cd "{{crate}}" && cargo clippy --examples --tests -- {{CLIPPY_ARGUMENTS}})
 _clean crate:

--- a/template/.cargo/config.toml
+++ b/template/.cargo/config.toml
@@ -6,5 +6,9 @@ build-std-features = ["compiler-builtins-mem"]
 target = "thumbv4t-none-eabi"
 
 [target.thumbv4t-none-eabi]
-rustflags = ["-Clink-arg=-Tgba.ld"]
+rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
+runner = "mgba-qt"
+
+[target.armv4t-none-eabi]
+rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
 runner = "mgba-qt"


### PR DESCRIPTION
I've found that sometimes Rust generates better-enough code for some usecases in arm mode vs. thumb mode that it becomes worth it to build my whole project with [`--target armv4t-none-eabi.json`](https://github.com/lifning/gba-flac-demo/blob/remaster/armv4t-none-eabi.json) - so here's a hopefully simple-enough way to support the BIOS calls when targeting either mode :)