### PR TITLE
Make testing a default feature

### DIFF
--- a/.vscode/agb.code-workspace
+++ b/.vscode/agb.code-workspace
@@ -23,6 +23,9 @@
 		},
 		{
 			"path": "../examples/hyperspace-roll"
+		},
+		{
+			"path": "../template"
 		}
 	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the fast magnitude function in agb_fixnum. This is also used in fast_normalise. Previously only worked for positive (x, y).
 - Fixed formatting of fixed point numbers in the range (-1, 0), which previously appeared positive.
 
+## Changed
+- `testing` is now a default feature, so you no longer need to add a separate `dev-dependencies` line for `agb` in order to enable unit tests for your project.
+
 ## [0.11.1] - 2022/08/02
 
 Version 0.11.1 brings documentation for fixed point numbers. We recommend all users upgrade to this version since it also includes fixes to a few functions in fixnum. See changed section for breaking changes.

--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -16,7 +16,7 @@ lto = true
 debug = true
 
 [features]
-default = []
+default = ["testing"]
 freq18157 = ["agb_sound_converter/freq18157"]
 freq32768 = ["agb_sound_converter/freq32768"]
 testing = []

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -253,12 +253,6 @@ impl Gba {
 /// #![cfg_attr(test, test_runner(agb::test_runner::test_runner))]
 /// ```
 ///
-/// And ensure you add agb with the `testing` feature to your `dev-dependencies`
-/// ```toml
-/// [dev-dependencies]
-/// agb = { version = "<same as in dependencies>", features = ["testing"] }
-/// ```
-///
 /// With this support, you will be able to write tests which you can run using `mgba-test-runner`.
 /// Tests are written using `#[test_case]` rather than `#[test]`.
 ///

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -247,7 +247,7 @@ impl Gba {
 /// In order to use this, you need to enable the unstable `custom_test_framework` feature and copy-paste
 /// the following into the top of your application:
 ///
-/// ```
+/// ```rust,ignore
 /// #![cfg_attr(test, feature(custom_test_frameworks))]
 /// #![cfg_attr(test, reexport_test_harness_main = "test_main")]
 /// #![cfg_attr(test, test_runner(agb::test_runner::test_runner))]
@@ -256,7 +256,7 @@ impl Gba {
 /// With this support, you will be able to write tests which you can run using `mgba-test-runner`.
 /// Tests are written using `#[test_case]` rather than `#[test]`.
 ///
-/// ```
+/// ```rust,ignore
 /// #[test_case]
 /// fn test_ping_pong(_gba: &mut Gba) {
 ///     assert_eq!(1, 1);

--- a/examples/the-hat-chooses-the-wizard/Cargo.toml
+++ b/examples/the-hat-chooses-the-wizard/Cargo.toml
@@ -9,9 +9,6 @@ edition = "2018"
 [dependencies]
 agb = { version = "0.11.1", path = "../../agb" }
 
-[dev-dependencies]
-agb = { version = "0.11.1", path = "../../agb", features = ["testing"] }
-
 [build-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -9,9 +9,6 @@ edition = "2018"
 [dependencies]
 agb = "0.11.1"
 
-[dev-dependencies]
-agb = { version = "0.11.1", features = ["testing"] }
-
 [profile.dev]
 opt-level = 2
 debug = true


### PR DESCRIPTION
Enough people are using the `testing` feature that we should probably just make it a default. This will also be helpful for making it easy to add integration tests.

- [x] Changelog updated / no changelog update needed
