### PR TITLE
CI Schedule

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: '10 5 * * *'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.vscode/agb.code-workspace
+++ b/.vscode/agb.code-workspace
@@ -25,6 +25,9 @@
 			"path": "../examples/hyperspace-roll"
 		},
 		{
+			"path": "../.github"
+		},
+		{
 			"path": "../template"
 		}
 	]


### PR DESCRIPTION
Run CI daily with the latest nightly. This has two benefits:

* See regressions in Rust early and see changes to clippy.
* Warm up the caches for the day.

- [x] Changelog updated / no changelog update needed
