### PR TITLE
Make vscode not give me an error with hyperspace-roll and the-purple-night

### DIFF
--- a/examples/hyperspace-roll/src/main.rs
+++ b/examples/hyperspace-roll/src/main.rs
@@ -9,6 +9,9 @@
 // using the #[agb::entry] proc macro. Failing to do so will cause failure in linking
 // which won't be a particularly clear error message.
 #![no_main]
+#![cfg_attr(test, feature(custom_test_frameworks))]
+#![cfg_attr(test, reexport_test_harness_main = "test_main")]
+#![cfg_attr(test, test_runner(agb::test_runner::test_runner))]
 
 use agb::display::object::ObjectController;
 use agb::display::tiled::{TiledMap, VRamManager};

--- a/examples/the-purple-night/src/main.rs
+++ b/examples/the-purple-night/src/main.rs
@@ -1,5 +1,8 @@
 #![no_std]
 #![no_main]
+#![cfg_attr(test, feature(custom_test_frameworks))]
+#![cfg_attr(test, reexport_test_harness_main = "test_main")]
+#![cfg_attr(test, test_runner(agb::test_runner::test_runner))]
 
 extern crate alloc;
 


### PR DESCRIPTION
- [x] Changelog updated / no changelog update needed
