### PR TITLE
Fix incorrect package name in Linux setup guide

### DIFF
--- a/book/src/setup/linux.md
+++ b/book/src/setup/linux.md
@@ -13,7 +13,7 @@ You can update rustup with `rustup update` if you have already installed it.
 
 We need this installed in order to be able to assemble the small amount of assembly in agb, and to do the final linking.
 
-* On Debian and derivatives (like Ubuntu): `sudo apt install binutils-arm-non-eabi`
+* On Debian and derivatives (like Ubuntu): `sudo apt install binutils-arm-none-eabi`
 * On Arch Linux and derivatives: `pacman -S arm-none-eabi-binutils`
 
 # 3. git


### PR DESCRIPTION
This PR fixes the linux setup guide using the wrong package name

- [x] no changelog update needed
