### PR TITLE
Add changelog entry for 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.2] - 2022/10/22
 
+This is a minor release to fix an alignment issue with background tiles.
+
+### Fixed
+- Corrected alignment of background tiles which was causing issues with rendering tiles in some cases.
+
 ## [0.12.1] - 2022/10/12
 
 This is a minor release to fix the build of the docs on [docs.rs/agb](https://docs.rs/agb).


### PR DESCRIPTION
Due to the release rush, we didn't add a changelog entry for 0.12.2. So here it is :)

- [x] Changelog updated / no changelog update needed
