### PR TITLE
remove feature not required in later nightlies

### DIFF
--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -13,7 +13,6 @@
 #![feature(alloc_error_handler)]
 #![feature(allocator_api)]
 #![feature(asm_const)]
-#![feature(isa_attribute)]
 #![warn(clippy::all)]
 #![deny(clippy::must_use_candidate)]
 #![deny(clippy::trivially_copy_pass_by_ref)]


### PR DESCRIPTION
This will require a very recent nightly as the minimum supported compiler version

- [ ] Changelog updated / no changelog update needed
