### PR TITLE
Fix clippy lint for inline format args

### DIFF
--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agb"
 version = "0.12.2"
 authors = ["Corwin Kuiper <corwin@kuiper.dev>", "Gwilym Kuiper <gw@ilym.me>"]
-edition = "2018"
+edition = "2021"
 description = "Library for Game Boy Advance Development"
 license = "MPL-2.0"
 repository = "https://github.com/agbrs/agb"

--- a/agb/build.rs
+++ b/agb/build.rs
@@ -22,7 +22,7 @@ fn main() {
     let mut o_files = vec![];
 
     for &a in asm.iter() {
-        println!("cargo:rerun-if-changed={}", a);
+        println!("cargo:rerun-if-changed={a}");
         let filename = path::Path::new(a);
         let filename = filename.with_extension("o");
         let filename = filename
@@ -31,7 +31,7 @@ fn main() {
             .to_str()
             .expect("Please make it valid utf-8");
 
-        let out_file_path = format!("{}/{}", out_dir, filename);
+        let out_file_path = format!("{out_dir}/{filename}");
 
         let out = std::process::Command::new("arm-none-eabi-as")
             .arg("-mthumb-interwork")
@@ -40,7 +40,7 @@ fn main() {
             .args(["-o", out_file_path.as_str()])
             .arg(a)
             .output()
-            .unwrap_or_else(|_| panic!("failed to compile {}", a));
+            .unwrap_or_else(|_| panic!("failed to compile {a}"));
 
         assert!(
             out.status.success(),
@@ -50,7 +50,7 @@ fn main() {
 
         for warning_line in String::from_utf8_lossy(&out.stderr).split('\n') {
             if !warning_line.is_empty() {
-                println!("cargo:warning={}", warning_line);
+                println!("cargo:warning={warning_line}");
             }
         }
 

--- a/agb/examples/text_render.rs
+++ b/agb/examples/text_render.rs
@@ -57,7 +57,7 @@ fn main(mut gba: agb::Gba) -> ! {
         let mut renderer = FONT.render_text((4u16, 0u16).into());
         let mut writer = renderer.writer(1, 2, &mut bg, &mut vram);
 
-        writeln!(&mut writer, "Frame {}", frame).unwrap();
+        writeln!(&mut writer, "Frame {frame}").unwrap();
         writer.commit();
 
         frame += 1;

--- a/agb/src/agb_alloc/mod.rs
+++ b/agb/src/agb_alloc/mod.rs
@@ -170,8 +170,7 @@ mod test {
         let address = &*first_box as *const _ as usize;
         assert!(
             (EWRAM_START..EWRAM_END).contains(&address),
-            "ewram is located between 0x0200_0000 and 0x0204_0000, address was actually found to be {:#010X}",
-            address
+            "ewram is located between 0x0200_0000 and 0x0204_0000, address was actually found to be {address:#010X}"
         );
     }
 
@@ -197,8 +196,7 @@ mod test {
             let address = &*x as *const _ as usize;
             assert!(
                 (EWRAM_START..EWRAM_END).contains(&address),
-                "ewram is located between 0x0200_0000 and 0x0204_0000, address was actually found to be {:#010X}",
-                address
+                "ewram is located between 0x0200_0000 and 0x0204_0000, address was actually found to be {address:#010X}"
             );
         }
 
@@ -225,8 +223,7 @@ mod test {
 
         assert!(
             0x0200_0000 <= data_end,
-            "data end should be bigger than 0x0200_0000, got {}",
-            data_end
+            "data end should be bigger than 0x0200_0000, got {data_end}"
         );
         assert!(
             0x0204_0000 > data_end,
@@ -240,8 +237,7 @@ mod test {
 
         assert!(
             (0x0300_0000..0x0300_8000).contains(&data_end),
-            "iwram data end should be in iwram, instead was {}",
-            data_end
+            "iwram data end should be in iwram, instead was {data_end}"
         );
     }
 
@@ -252,8 +248,7 @@ mod test {
         let addr = p as usize;
         assert!(
             (0x0300_0000..0x0300_8000).contains(&addr),
-            "address of allocation should be within iwram, instead at {:?}",
-            p
+            "address of allocation should be within iwram, instead at {p:?}"
         );
     }
 }

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -313,7 +313,7 @@ pub mod test_runner {
         if let Some(mut mgba) = mgba::Mgba::new() {
             mgba.print(format_args!("[failed]"), mgba::DebugLevel::Error)
                 .unwrap();
-            mgba.print(format_args!("Error: {}", info), mgba::DebugLevel::Fatal)
+            mgba.print(format_args!("Error: {info}"), mgba::DebugLevel::Fatal)
                 .unwrap();
         }
 
@@ -370,11 +370,8 @@ pub mod test_runner {
         display::busy_wait_for_vblank();
         display::busy_wait_for_vblank();
         let mut mgba = crate::mgba::Mgba::new().unwrap();
-        mgba.print(
-            format_args!("image:{}", image),
-            crate::mgba::DebugLevel::Info,
-        )
-        .unwrap();
+        mgba.print(format_args!("image:{image}"), crate::mgba::DebugLevel::Info)
+            .unwrap();
         display::busy_wait_for_vblank();
     }
 }
@@ -422,8 +419,7 @@ mod test {
             let address = ewram_ptr as usize;
             assert!(
                 (0x0200_0000..0x0204_0000).contains(&address),
-                "ewram is located between 0x0200_0000 and 0x0204_0000, address was actually found to be {:#010X}",
-                address
+                "ewram is located between 0x0200_0000 and 0x0204_0000, address was actually found to be {address:#010X}",
             );
         }
     }
@@ -437,8 +433,7 @@ mod test {
             let address = iwram_ptr as usize;
             assert!(
                 (0x0300_0000..0x0300_8000).contains(&address),
-                "iwram is located between 0x0300_0000 and 0x0300_8000, but was actually found to be at {:#010X}",
-                address
+                "iwram is located between 0x0300_0000 and 0x0300_8000, but was actually found to be at {address:#010X}"
             );
             let c = iwram_ptr.read_volatile();
             assert_eq!(c, 9, "expected content to be 9");
@@ -456,9 +451,7 @@ mod test {
             let address = iwram_ptr as usize;
             assert!(
                 (0x0200_0000..0x0204_0000).contains(&address),
-                "implicit data storage is expected to be in ewram, which is between 0x0300_0000 and 0x0300_8000, but was actually found to be at {:#010X}",
-                address
-            );
+                "implicit data storage is expected to be in ewram, which is between 0x0300_0000 and 0x0300_8000, but was actually found to be at {address:#010X}"            );
             let c = iwram_ptr.read_volatile();
             assert_eq!(c, 9, "expected content to be 9");
             iwram_ptr.write_volatile(u32::MAX);

--- a/agb/src/mgba.rs
+++ b/agb/src/mgba.rs
@@ -51,7 +51,7 @@ impl Mgba {
         output: core::fmt::Arguments,
         level: DebugLevel,
     ) -> Result<(), core::fmt::Error> {
-        write!(self, "{}", output)?;
+        write!(self, "{output}")?;
         self.set_level(level);
         Ok(())
     }

--- a/agb/src/rng.rs
+++ b/agb/src/rng.rs
@@ -78,9 +78,7 @@ mod test {
         for (i, &value) in values.iter().enumerate() {
             assert!(
                 value >= 500 / 10 / 3,
-                "{} came up less than expected {}",
-                i,
-                value
+                "{i} came up less than expected {value}"
             );
         }
     }
@@ -96,9 +94,7 @@ mod test {
         for (i, &value) in values.iter().enumerate() {
             assert!(
                 value >= 500 / 10 / 3,
-                "{} came up less than expected {}",
-                i,
-                value
+                "{i} came up less than expected {value}"
             );
         }
     }

--- a/examples/the-hat-chooses-the-wizard/build.rs
+++ b/examples/the-hat-chooses-the-wizard/build.rs
@@ -24,13 +24,13 @@ mod tiled_export {
 
     pub fn export_tilemap(out_dir: &str) -> std::io::Result<()> {
         let filename = "map/tilemap.json";
-        println!("cargo:rerun-if-changed={}", filename);
+        println!("cargo:rerun-if-changed={filename}");
         let file = File::open(filename)?;
         let reader = BufReader::new(file);
 
         let tilemap: TiledTilemap = serde_json::from_reader(reader)?;
 
-        let output_file = File::create(format!("{}/tilemap.rs", out_dir))?;
+        let output_file = File::create(format!("{out_dir}/tilemap.rs"))?;
         let mut writer = BufWriter::new(output_file);
 
         let tile_data: HashMap<_, _> = tilemap
@@ -57,31 +57,26 @@ mod tiled_export {
 
         writeln!(
             &mut writer,
-            "pub const COLLISION_TILE: i32 = {};",
-            COLLISION_TILE
+            "pub const COLLISION_TILE: i32 = {COLLISION_TILE};",
         )?;
 
-        writeln!(&mut writer, "pub const KILL_TILE: i32 = {};", KILL_TILE)?;
-        writeln!(&mut writer, "pub const WIN_TILE: i32 = {};", WIN_TILE)?;
+        writeln!(&mut writer, "pub const KILL_TILE: i32 = {KILL_TILE};")?;
+        writeln!(&mut writer, "pub const WIN_TILE: i32 = {WIN_TILE};")?;
 
-        writeln!(
-            &mut writer,
-            "pub const TILE_DATA: &[u32] = &[{}];",
-            tile_info
-        )?;
+        writeln!(&mut writer, "pub const TILE_DATA: &[u32] = &[{tile_info}];")?;
 
         Ok(())
     }
 
     pub fn export_level(out_dir: &str, level_file: &str) -> std::io::Result<()> {
-        let filename = format!("map/{}", level_file);
-        println!("cargo:rerun-if-changed={}", filename);
+        let filename = format!("map/{level_file}");
+        println!("cargo:rerun-if-changed={filename}");
         let file = File::open(filename)?;
         let reader = BufReader::new(file);
 
         let level: TiledLevel = serde_json::from_reader(reader)?;
 
-        let output_file = File::create(format!("{}/{}.rs", out_dir, level_file))?;
+        let output_file = File::create(format!("{out_dir}/{level_file}.rs"))?;
         let mut writer = BufWriter::new(output_file);
 
         let layer_1 = level.layers[0]
@@ -103,8 +98,8 @@ mod tiled_export {
 
         writeln!(&mut writer, "const WIDTH: u32 = {};", level.width)?;
         writeln!(&mut writer, "const HEIGHT: u32 = {};", level.height)?;
-        writeln!(&mut writer, "const TILEMAP: &[u16] = &[{}];", layer_1)?;
-        writeln!(&mut writer, "const BACKGROUND: &[u16] = &[{}];", layer_2)?;
+        writeln!(&mut writer, "const TILEMAP: &[u16] = &[{layer_1}];")?;
+        writeln!(&mut writer, "const BACKGROUND: &[u16] = &[{layer_2}];")?;
 
         let objects = level.layers[2]
             .objects
@@ -147,18 +142,15 @@ mod tiled_export {
 
         writeln!(
             &mut writer,
-            "const SNAILS: &[(i32, i32)] = &[{}];",
-            snails_str
+            "const SNAILS: &[(i32, i32)] = &[{snails_str}];",
         )?;
         writeln!(
             &mut writer,
-            "const SLIMES: &[(i32, i32)] = &[{}];",
-            slimes_str
+            "const SLIMES: &[(i32, i32)] = &[{slimes_str}];",
         )?;
         writeln!(
             &mut writer,
-            "const ENEMY_STOPS: &[(i32, i32)] = &[{}];",
-            enemy_stop_str
+            "const ENEMY_STOPS: &[(i32, i32)] = &[{enemy_stop_str}];",
         )?;
         writeln!(
             &mut writer,

--- a/examples/the-purple-night/build.rs
+++ b/examples/the-purple-night/build.rs
@@ -10,7 +10,7 @@ fn main() {
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR environment variable must be specified");
 
     let playground_filename = "map/map.tmx";
-    println!("cargo:rerun-if-changed={}", playground_filename);
+    println!("cargo:rerun-if-changed={playground_filename}");
 
     let map = tiled::parse_file(Path::new(playground_filename)).unwrap();
 
@@ -60,11 +60,11 @@ fn main() {
         pub const TILE_TYPES: &[u8] = &[#(#tile_types),*];
     };
 
-    let output_file = File::create(format!("{}/tilemap.rs", out_dir))
+    let output_file = File::create(format!("{out_dir}/tilemap.rs"))
         .expect("failed to open tilemap.rs file for writing");
     let mut writer = BufWriter::new(output_file);
 
-    write!(&mut writer, "{}", output).unwrap();
+    write!(&mut writer, "{output}").unwrap();
 }
 
 fn extract_tiles(layer: &'_ tiled::LayerData) -> impl Iterator<Item = u16> + '_ {


### PR DESCRIPTION
Also updates the rust edition to 2021 for agb since I couldn't do both

- [x] Changelog updated / no changelog update needed
