### PR TITLE
Make it so that the release tag includes the entire release notes

### DIFF
--- a/tools/src/release.rs
+++ b/tools/src/release.rs
@@ -72,6 +72,7 @@ pub fn release(matches: &clap::ArgMatches) -> Result<(), Error> {
                 "tag",
                 "-a",
                 &format!("v{version}"),
+                "--cleanup=whitespace",
                 "-m",
                 &format!("#v{version}\n{changelog_text}"),
             ],


### PR DESCRIPTION
Add `--cleanup=whitespace` to keep lines starting with # in the `git tag` command for releases.

- [x] Changelog updated / no changelog update needed
