### PR TITLE
Remove option to manage your own interrupts in the mixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Text renderer can now be re-used which is useful for rpg style character/word at a time text boxes.
+- Audio now automatically uses interrupts, so you can remove the `setup_interrupt_handler` or `after_vblank` calls to the mixer.
 
 ## [0.12.2] - 2022/10/22
 

--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -12,7 +12,8 @@ opt-level = 3
 debug = true
 
 [profile.release]
-lto = true
+opt-level = "s"
+lto = "thin"
 debug = true
 
 [features]

--- a/agb/examples/mixer_32768.rs
+++ b/agb/examples/mixer_32768.rs
@@ -43,7 +43,6 @@ fn main(mut gba: Gba) -> ! {
 
     let mut mixer = gba.mixer.mixer(Frequency::Hz32768);
     mixer.enable();
-    let _interrupt = mixer.setup_interrupt_handler();
 
     let mut channel = SoundChannel::new(CRAZY_GLUE);
     channel.stereo();

--- a/agb/examples/mixer_32768.rs
+++ b/agb/examples/mixer_32768.rs
@@ -39,7 +39,9 @@ fn main(mut gba: Gba) -> ! {
 
     let timer_controller = gba.timers.timers();
     let mut timer = timer_controller.timer2;
+    let mut timer2 = timer_controller.timer3;
     timer.set_enabled(true);
+    timer2.set_cascade(true).set_enabled(true);
 
     let mut mixer = gba.mixer.mixer(Frequency::Hz32768);
     mixer.enable();
@@ -56,14 +58,22 @@ fn main(mut gba: Gba) -> ! {
         vblank_provider.wait_for_vblank();
         bg.commit(&mut vram);
 
-        let before_mixing_cycles = timer.value();
+        let before_mixing_cycles_high = timer2.value();
+        let before_mixing_cycles_low = timer.value();
+
         mixer.frame();
-        let after_mixing_cycles = timer.value();
+
+        let after_mixing_cycles_low = timer.value();
+        let after_mixing_cycles_high = timer2.value();
 
         frame_counter = frame_counter.wrapping_add(1);
 
         if frame_counter % 128 == 0 && !has_written_frame_time {
-            let total_cycles = after_mixing_cycles.wrapping_sub(before_mixing_cycles) as u32;
+            let before_mixing_cycles =
+                ((before_mixing_cycles_high as u32) << 16) + before_mixing_cycles_low as u32;
+            let after_mixing_cycles =
+                ((after_mixing_cycles_high as u32) << 16) + after_mixing_cycles_low as u32;
+            let total_cycles = after_mixing_cycles.wrapping_sub(before_mixing_cycles);
 
             let percent = (total_cycles * 100) / 280896;
 

--- a/agb/examples/mixer_basic.rs
+++ b/agb/examples/mixer_basic.rs
@@ -51,6 +51,5 @@ fn main(mut gba: Gba) -> ! {
 
         mixer.frame();
         vblank_provider.wait_for_vblank();
-        mixer.after_vblank();
     }
 }

--- a/agb/examples/stereo_sound.rs
+++ b/agb/examples/stereo_sound.rs
@@ -32,7 +32,6 @@ fn main(mut gba: Gba) -> ! {
 
     writeln!(&mut writer, "Let it in by Josh Woodward").unwrap();
 
-
     writer.commit();
 
     bg.commit(&mut vram);
@@ -58,7 +57,6 @@ fn main(mut gba: Gba) -> ! {
         bg.commit(&mut vram);
 
         let before_mixing_cycles = timer.value();
-        mixer.after_vblank();
         mixer.frame();
         let after_mixing_cycles = timer.value();
 

--- a/agb/src/sound/mixer/hw.rs
+++ b/agb/src/sound/mixer/hw.rs
@@ -46,23 +46,23 @@ pub(super) enum LeftOrRight {
     Right,
 }
 
-pub(super) fn enable_dma_for_sound(sound_memory: &[i8], lr: LeftOrRight) {
+pub(super) fn enable_dma_for_sound(sound_memory: *const i8, lr: LeftOrRight) {
     match lr {
         LeftOrRight::Left => enable_dma1_for_sound(sound_memory),
         LeftOrRight::Right => enable_dma2_for_sound(sound_memory),
     }
 }
 
-fn enable_dma1_for_sound(sound_memory: &[i8]) {
+fn enable_dma1_for_sound(sound_memory: *const i8) {
     DMA1_CONTROL.set(0);
-    DMA1_SOURCE_ADDR.set(sound_memory.as_ptr() as u32);
+    DMA1_SOURCE_ADDR.set(sound_memory as u32);
     DMA1_DEST_ADDR.set(FIFO_A_DEST_ADDR);
     DMA1_CONTROL.set(DMA_CONTROL_SETTING_FOR_SOUND);
 }
 
-fn enable_dma2_for_sound(sound_memory: &[i8]) {
+fn enable_dma2_for_sound(sound_memory: *const i8) {
     DMA2_CONTROL.set(0);
-    DMA2_SOURCE_ADDR.set(sound_memory.as_ptr() as u32);
+    DMA2_SOURCE_ADDR.set(sound_memory as u32);
     DMA2_DEST_ADDR.set(FIFO_B_DEST_ADDR);
     DMA2_CONTROL.set(DMA_CONTROL_SETTING_FOR_SOUND);
 }

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -75,7 +75,6 @@ extern "C" {
 /// loop {
 ///    mixer.frame();
 ///    vblank.wait_for_vblank();
-///    mixer.after_vblank();
 /// }
 /// # }
 /// ```

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -187,7 +187,6 @@ impl Mixer {
     /// loop {
     ///     mixer.frame();
     ///     vblank.wait_for_vblank();
-    ///     mixer.after_vblank(); // optional, only if not using interrupts
     /// }
     /// # }
     /// ```

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -84,7 +84,7 @@ pub struct Mixer {
     // SAFETY: Has to go before buffer because it holds a reference to it
     _interrupt_handler: InterruptHandler<'static>,
 
-    buffer: Pin<Box<MixerBuffer>>,
+    buffer: Pin<Box<MixerBuffer, InternalAllocator>>,
     channels: [Option<SoundChannel>; 8],
     indices: [i32; 8],
     frequency: Frequency,
@@ -117,7 +117,7 @@ pub struct ChannelId(usize, i32);
 
 impl Mixer {
     pub(super) fn new(frequency: Frequency) -> Self {
-        let buffer = Box::pin(MixerBuffer::new(frequency));
+        let buffer = Box::pin_in(MixerBuffer::new(frequency), InternalAllocator);
 
         // SAFETY: you can only ever have 1 Mixer at a time
         let fifo_timer = unsafe { Timer::new(0) };

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -140,6 +140,8 @@ impl Mixer {
             buffer_pointer_for_interrupt_handler.swap(cs);
         });
 
+        set_asm_buffer_size(frequency);
+
         Self {
             frequency,
             buffer,
@@ -391,8 +393,6 @@ impl MixerBuffer {
     }
 
     fn write_channels<'a>(&mut self, channels: impl Iterator<Item = &'a mut SoundChannel>) {
-        set_asm_buffer_size(self.frequency);
-
         self.working_buffer.fill(0.into());
 
         for channel in channels {

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -337,7 +337,7 @@ const fn mod3_estimate(x: usize) -> usize {
 
 impl MixerBufferState {
     fn should_calculate(&self) -> bool {
-        mod3_estimate(self.active_buffer + 1) != mod3_estimate(self.playing_buffer)
+        mod3_estimate(self.active_buffer + 1) != self.playing_buffer
     }
 
     fn playing_advanced(&mut self) -> usize {

--- a/examples/hyperspace-roll/src/lib.rs
+++ b/examples/hyperspace-roll/src/lib.rs
@@ -142,7 +142,6 @@ pub fn main(mut gba: agb::Gba) -> ! {
 
     let mut mixer = gba.mixer.mixer(Frequency::Hz32768);
     mixer.enable();
-    let _interrupt_handler = mixer.setup_interrupt_handler();
 
     let sfx = Sfx::new(&mut mixer);
 

--- a/examples/the-hat-chooses-the-wizard/src/lib.rs
+++ b/examples/the-hat-chooses-the-wizard/src/lib.rs
@@ -832,7 +832,6 @@ pub fn main(mut agb: agb::Gba) -> ! {
             music_box.before_frame(&mut mixer);
             mixer.frame();
             vblank.wait_for_vblank();
-            mixer.after_vblank();
 
             level_display::write_level(
                 &mut world_display,
@@ -848,7 +847,6 @@ pub fn main(mut agb: agb::Gba) -> ! {
             music_box.before_frame(&mut mixer);
             mixer.frame();
             vblank.wait_for_vblank();
-            mixer.after_vblank();
 
             let map_current_level = current_level;
             let mut background = InfiniteScrolledMap::new(
@@ -894,21 +892,18 @@ pub fn main(mut agb: agb::Gba) -> ! {
                 music_box.before_frame(&mut mixer);
                 mixer.frame();
                 vblank.wait_for_vblank();
-                mixer.after_vblank();
             }
 
             while level.background.init_foreground(&mut vram) != PartialUpdateStatus::Done {
                 music_box.before_frame(&mut mixer);
                 mixer.frame();
                 vblank.wait_for_vblank();
-                mixer.after_vblank();
             }
 
             for _ in 0..20 {
                 music_box.before_frame(&mut mixer);
                 mixer.frame();
                 vblank.wait_for_vblank();
-                mixer.after_vblank();
             }
 
             object.commit();
@@ -930,7 +925,6 @@ pub fn main(mut agb: agb::Gba) -> ! {
                             music_box.before_frame(&mut mixer);
                             mixer.frame();
                             vblank.wait_for_vblank();
-                            mixer.after_vblank();
                             object.commit();
                         }
                         break;
@@ -944,7 +938,6 @@ pub fn main(mut agb: agb::Gba) -> ! {
                 music_box.before_frame(&mut mixer);
                 mixer.frame();
                 vblank.wait_for_vblank();
-                mixer.after_vblank();
                 object.commit();
             }
 

--- a/examples/the-hat-chooses-the-wizard/src/splash_screen.rs
+++ b/examples/the-hat-chooses-the-wizard/src/splash_screen.rs
@@ -41,10 +41,6 @@ pub fn show_splash_screen(
 
     vblank.wait_for_vblank();
 
-    if let Some(ref mut mixer) = mixer {
-        mixer.after_vblank();
-    }
-
     for y in 0..20u16 {
         for x in 0..30u16 {
             map.set_tile(
@@ -63,10 +59,6 @@ pub fn show_splash_screen(
         }
 
         vblank.wait_for_vblank();
-
-        if let Some(ref mut mixer) = mixer {
-            mixer.after_vblank();
-        }
     }
 
     map.commit(vram);
@@ -83,17 +75,13 @@ pub fn show_splash_screen(
         ) {
             break;
         }
-        if let Some(ref mut mixer) = mixer {
-            if let Some(ref mut music_box) = music_box {
+        if let Some(mixer) = &mut mixer {
+            if let Some(music_box) = &mut music_box {
                 music_box.before_frame(mixer);
             }
             mixer.frame();
         }
         vblank.wait_for_vblank();
-
-        if let Some(ref mut mixer) = mixer {
-            mixer.after_vblank();
-        }
     }
 
     map.hide();

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -85,7 +85,6 @@ impl<'a> Level<'a> {
         let mut between_updates = || {
             sfx.frame();
             vblank.wait_for_vblank();
-            sfx.after_vblank();
         };
 
         backdrop.init(vram, start_pos, &mut between_updates);
@@ -2283,7 +2282,6 @@ fn game_with_level(gba: &mut agb::Gba) {
         start_at_boss = loop {
             sfx.frame();
             vblank.wait_for_vblank();
-            sfx.after_vblank();
             object.commit();
             match game.advance_frame(&object, &mut vram, &mut sfx) {
                 GameStatus::Continue => {}

--- a/examples/the-purple-night/src/sfx.rs
+++ b/examples/the-purple-night/src/sfx.rs
@@ -39,10 +39,6 @@ impl<'a> Sfx<'a> {
         self.mixer.frame();
     }
 
-    pub fn after_vblank(&mut self) {
-        self.mixer.after_vblank();
-    }
-
     pub fn stop_music(&mut self) {
         if let Some(bgm) = &self.bgm {
             let channel = self.mixer.channel(bgm).unwrap();


### PR DESCRIPTION
Simplify the audio mixer to always use the interrupt system which fixes a soundness issue (pun intended) if you forget the mixer but not the interrupt handler.

- [x] Changelog updated / no changelog update needed
