### PR TITLE
Add missing methods for tiled1 to allow creating backgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added missed implementations of `regular()` and `affine()` to `Tiled1` which made `Tiled1` impossible to use.
+
 ### Changed
 - Text renderer can now be re-used which is useful for rpg style character/word at a time text boxes.
 

--- a/agb/src/display/tiled/tiled1.rs
+++ b/agb/src/display/tiled/tiled1.rs
@@ -1,9 +1,13 @@
 use core::cell::RefCell;
 
-use super::{CreatableAffineTiledMode, CreatableRegularTiledMode, TiledMode};
+use super::{
+    AffineBackgroundSize, AffineMap, AffineTiledMode, CreatableAffineTiledMode,
+    CreatableRegularTiledMode, MapLoan, RegularBackgroundSize, RegularMap, RegularTiledMode,
+    TiledMode,
+};
 use crate::{
     bitarray::Bitarray,
-    display::{set_graphics_mode, tiled::AFFINE_BG_ID_OFFSET, DisplayMode},
+    display::{set_graphics_mode, tiled::AFFINE_BG_ID_OFFSET, DisplayMode, Priority},
 };
 
 pub struct Tiled1 {
@@ -26,6 +30,18 @@ impl Tiled1 {
             affine,
             screenblocks: Default::default(),
         }
+    }
+
+    pub fn regular(
+        &self,
+        priority: Priority,
+        size: RegularBackgroundSize,
+    ) -> MapLoan<'_, RegularMap> {
+        self.regular_background(priority, size)
+    }
+
+    pub fn affine(&self, priority: Priority, size: AffineBackgroundSize) -> MapLoan<'_, AffineMap> {
+        self.affine_background(priority, size)
     }
 }
 


### PR DESCRIPTION
Fixes #367

Had missed implementations to actually get the backgrounds if you were using tiled1 mode.

- [x] Changelog updated / no changelog update needed
