### PR TITLE
Make missing a vblank interrupt wait less painful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Text renderer can now be re-used which is useful for rpg style character/word at a time text boxes.
+- If a vblank happens outside of `wait_for_vblank`, then next call will immediately return.
 
 ## [0.12.2] - 2022/10/22
 

--- a/agb/src/syscall.rs
+++ b/agb/src/syscall.rs
@@ -56,7 +56,7 @@ pub fn wait_for_interrupt() {
 
 /// The vblank interrupt handler [VBlank][crate::interrupt::VBlank] should be
 /// used instead of calling this function directly.
-pub fn wait_for_vblank() {
+pub(crate) fn wait_for_vblank() {
     unsafe {
         asm!(
             "swi {SWI}",


### PR DESCRIPTION
If you missed a vblank, then the next call to wait_for_vblank would pointlessly wait rather than returning immediately. Meaning if you missed a vblank by a few cycles, you'd be waiting for the entire next one :(.

- [x] Changelog updated / no changelog update needed
