### PR TITLE
Fix volume zero and power of 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Text renderer can now be re-used which is useful for rpg style character/word at a time text boxes.
 
+### Fixed
+- Zero volume now plays no sound.
+- Fixed issue where volume was incorrect for volumes which were powers of 2.
+
 ## [0.12.2] - 2022/10/22
 
 This is a minor release to fix an alignment issue with background tiles.

--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -64,6 +64,8 @@ same_modification:
     lsrs r7, r7, #1
     bne 1b
 
+    sub r3, r3, #1
+
     mov r5, #0                   @ current index we're reading from
     ldr r8, =agb_rs__buffer_size @ the number of steps left
     ldr r8, [r8]

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -446,26 +446,28 @@ impl MixerBuffer {
                 }
             }
 
-            if channel.is_stereo {
-                unsafe {
-                    agb_rs__mixer_add_stereo(
-                        channel.data.as_ptr().add(channel.pos.floor()),
-                        self.working_buffer.as_mut_ptr(),
-                        channel.volume,
-                    );
-                }
-            } else {
-                let right_amount = ((channel.panning + 1) / 2) * channel.volume;
-                let left_amount = ((-channel.panning + 1) / 2) * channel.volume;
+            if channel.volume != 0.into() {
+                if channel.is_stereo {
+                    unsafe {
+                        agb_rs__mixer_add_stereo(
+                            channel.data.as_ptr().add(channel.pos.floor()),
+                            self.working_buffer.as_mut_ptr(),
+                            channel.volume,
+                        );
+                    }
+                } else {
+                    let right_amount = ((channel.panning + 1) / 2) * channel.volume;
+                    let left_amount = ((-channel.panning + 1) / 2) * channel.volume;
 
-                unsafe {
-                    agb_rs__mixer_add(
-                        channel.data.as_ptr().add(channel.pos.floor()),
-                        self.working_buffer.as_mut_ptr(),
-                        playback_speed,
-                        left_amount,
-                        right_amount,
-                    );
+                    unsafe {
+                        agb_rs__mixer_add(
+                            channel.data.as_ptr().add(channel.pos.floor()),
+                            self.working_buffer.as_mut_ptr(),
+                            playback_speed,
+                            left_amount,
+                            right_amount,
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #371.

If the volume was zero, the calculation for leading zeros was incorrect. So both reduce the amount of work done for 0 volume and also count the leading zeros correctly in the fast path.

- [x] Changelog updated / no changelog update needed
