### PR TITLE
Fix alpha not being considered when transparent_colour was absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Alpha channel is now considered by `include_gfx!()` even when `transparent_colour` is absent.
+
 ## [0.13.0] - 2023/01/19
 
 ### Added

--- a/agb-image-converter/src/lib.rs
+++ b/agb-image-converter/src/lib.rs
@@ -386,7 +386,7 @@ fn add_image_to_tile_data(
                         for i in inner_x * 8..inner_x * 8 + 8 {
                             let colour = image.colour(x * tile_size + i, y * tile_size + j);
                             tile_data
-                                .push(palette.colour_index(colour, optimiser.transparent_colour));
+                                .push(palette.colour_index(colour));
                         }
                     }
                 }

--- a/agb-image-converter/src/palette16.rs
+++ b/agb-image-converter/src/palette16.rs
@@ -41,15 +41,15 @@ impl Palette16 {
         true
     }
 
-    pub fn colour_index(&self, colour: Colour, transparent_colour: Option<Colour>) -> u8 {
-        let colour_to_search = match (transparent_colour, colour.is_transparent()) {
-            (Some(transparent_colour), true) => transparent_colour,
-            _ => colour,
-        };
+    pub fn colour_index(&self, colour: Colour) -> u8 {
+        // A transparent color is always index 0
+        if colour.is_transparent() {
+            return 0;
+        }
 
         self.colours
             .iter()
-            .position(|c| *c == colour_to_search)
+            .position(|c| *c == colour)
             .unwrap_or_else(|| {
                 panic!(
                     "Can't get a colour index without it existing, looking for {:?}, got {:?}",


### PR DESCRIPTION
Previously `include_image!()` would only set transparent pixels to index 0 if a `transparent_color` was specified. However, this in unnecessary as the transparency index is always 0.

- [X] Changelog updated / no changelog update needed
