### PR TITLE
Improve z ordering

### DIFF
--- a/agb/src/display/object.rs
+++ b/agb/src/display/object.rs
@@ -947,6 +947,11 @@ impl ObjectController {
             .sprite_controller
             .try_get_sprite(sprite)
     }
+    /// Sort the sprites by z position so they are displayed in correct order.
+    /// Must be called before [ObjectController::commit].
+    pub fn update_z_ordering(&self) {
+        unsafe { self.inner.borrow_mut().update_z_ordering() };
+    }
 }
 
 impl<'a> Object<'a> {
@@ -1067,14 +1072,15 @@ impl<'a> Object<'a> {
     }
 
     /// Sets the z position of the sprite, this controls which sprites are above
-    /// each other. No change will be seen until [ObjectController::commit] is
+    /// each other. You must call [ObjectController::update_z_ordering] to actually
+    /// order all the sprites correctly.
+    /// No change will be seen until [ObjectController::commit] is
     /// called.
     pub fn set_z(&mut self, z: i32) -> &mut Self {
         {
             let mut object_inner = unsafe { self.object_inner() };
             object_inner.z = z;
         }
-        unsafe { self.loan.controller.borrow_mut().update_z_ordering() };
 
         self
     }
@@ -1321,6 +1327,7 @@ mod tests {
             x.set_z(100);
             x.set_sprite(object.sprite(BOSS.sprite(2)));
 
+            object.update_z_ordering();
             object.commit();
         }
 

--- a/examples/hyperspace-roll/src/battle/display.rs
+++ b/examples/hyperspace-roll/src/battle/display.rs
@@ -57,6 +57,7 @@ impl<'a> BattleScreenDisplay<'a> {
 
         player_obj.set_x(player_x).set_y(player_y).set_z(1).show();
         enemy_obj.set_x(enemy_x).set_y(player_y).set_z(1).show();
+        obj.update_z_ordering();
 
         misc_sprites.push(player_obj);
         misc_sprites.push(enemy_obj);

--- a/examples/the-hat-chooses-the-wizard/src/lib.rs
+++ b/examples/the-hat-chooses-the-wizard/src/lib.rs
@@ -361,6 +361,7 @@ impl<'a> Player<'a> {
         hat.sprite.show();
 
         hat.sprite.set_z(-1);
+        controller.update_z_ordering();
 
         wizard.position = start_position;
         hat.position = start_position - (0, 10).into();


### PR DESCRIPTION
Currently the `set_z` method sorts the sprites after every invocation. This is inefficient if you have a large number of z ordered sprites as you have to sort at every z set, rather than once at the frame end, and has a noticeable performance impact. This PR exposes the `update_z_ordering` method on the `ObjectController` and requires this method to be run at the frame end for the sprites to be correctly z ordered. I have updated the examples as well. 


- [ ] Changelog updated / no changelog update needed
