### PR TITLE
Fix 256 colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Alpha channel is now considered by `include_gfx!()` even when `transparent_colour` is absent.
+- 256 colour backgrounds are now correctly rendered (breaking change).
 
 ## [0.13.0] - 2023/01/19
 

--- a/agb/examples/animated_background.rs
+++ b/agb/examples/animated_background.rs
@@ -20,7 +20,11 @@ fn main(mut gba: agb::Gba) -> ! {
 
     vram.set_background_palettes(water_tiles::PALETTES);
 
-    let mut bg = gfx.background(Priority::P0, RegularBackgroundSize::Background32x32);
+    let mut bg = gfx.background(
+        Priority::P0,
+        RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
+    );
 
     for y in 0..20u16 {
         for x in 0..30u16 {

--- a/agb/examples/chicken.rs
+++ b/agb/examples/chicken.rs
@@ -58,6 +58,7 @@ fn main(mut gba: agb::Gba) -> ! {
     let mut background = gfx.background(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
     );
 
     for (i, &tile) in MAP_MAP.iter().enumerate() {

--- a/agb/examples/dynamic_tiles.rs
+++ b/agb/examples/dynamic_tiles.rs
@@ -3,7 +3,7 @@
 
 use agb::display::{
     palette16::Palette16,
-    tiled::{RegularBackgroundSize, TileSetting, TiledMap},
+    tiled::{RegularBackgroundSize, TileFormat, TileSetting, TiledMap},
     Priority,
 };
 
@@ -17,7 +17,11 @@ fn main(mut gba: agb::Gba) -> ! {
         0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
     ])]);
 
-    let mut bg = gfx.background(Priority::P0, RegularBackgroundSize::Background32x32);
+    let mut bg = gfx.background(
+        Priority::P0,
+        RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
+    );
 
     for y in 0..20u32 {
         for x in 0..30u32 {

--- a/agb/examples/mixer_32768.rs
+++ b/agb/examples/mixer_32768.rs
@@ -3,7 +3,9 @@
 
 use agb::{
     display::{
-        tiled::{RegularBackgroundSize, RegularMap, TileSetting, TiledMap, VRamManager},
+        tiled::{
+            RegularBackgroundSize, RegularMap, TileFormat, TileSetting, TiledMap, VRamManager,
+        },
         Font, Priority,
     },
     include_font, include_wav,
@@ -23,7 +25,11 @@ fn main(mut gba: Gba) -> ! {
     let vblank_provider = agb::interrupt::VBlank::get();
 
     let (gfx, mut vram) = gba.display.video.tiled0();
-    let mut bg = gfx.background(Priority::P0, RegularBackgroundSize::Background32x32);
+    let mut bg = gfx.background(
+        Priority::P0,
+        RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
+    );
 
     init_background(&mut bg, &mut vram);
 

--- a/agb/examples/stereo_sound.rs
+++ b/agb/examples/stereo_sound.rs
@@ -3,7 +3,9 @@
 
 use agb::{
     display::{
-        tiled::{RegularBackgroundSize, RegularMap, TileSetting, TiledMap, VRamManager},
+        tiled::{
+            RegularBackgroundSize, RegularMap, TileFormat, TileSetting, TiledMap, VRamManager,
+        },
         Font, Priority,
     },
     include_font, include_wav,
@@ -23,7 +25,11 @@ fn main(mut gba: Gba) -> ! {
     let vblank_provider = agb::interrupt::VBlank::get();
 
     let (gfx, mut vram) = gba.display.video.tiled0();
-    let mut bg = gfx.background(Priority::P0, RegularBackgroundSize::Background32x32);
+    let mut bg = gfx.background(
+        Priority::P0,
+        RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
+    );
 
     init_background(&mut bg, &mut vram);
 

--- a/agb/examples/test_logo.rs
+++ b/agb/examples/test_logo.rs
@@ -1,7 +1,10 @@
 #![no_std]
 #![no_main]
 
-use agb::display::{example_logo, tiled::RegularBackgroundSize};
+use agb::display::{
+    example_logo,
+    tiled::{RegularBackgroundSize, TileFormat},
+};
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
@@ -10,6 +13,7 @@ fn main(mut gba: agb::Gba) -> ! {
     let mut map = gfx.background(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
     );
 
     example_logo::display_logo(&mut map, &mut vram);

--- a/agb/examples/text_render.rs
+++ b/agb/examples/text_render.rs
@@ -3,11 +3,12 @@
 
 use agb::{
     display::{
-        tiled::{RegularBackgroundSize, TileSetting, TiledMap},
+        tiled::{RegularBackgroundSize, TileFormat, TileSetting, TiledMap},
         Font, Priority,
     },
     include_font,
 };
+use modular_bitfield::private::checks::FourMod8;
 
 use core::fmt::Write;
 
@@ -25,7 +26,11 @@ fn main(mut gba: agb::Gba) -> ! {
 
     let background_tile = vram.new_dynamic_tile().fill_with(0);
 
-    let mut bg = gfx.background(Priority::P0, RegularBackgroundSize::Background32x32);
+    let mut bg = gfx.background(
+        Priority::P0,
+        RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
+    );
 
     for y in 0..20u16 {
         for x in 0..30u16 {

--- a/agb/examples/text_render.rs
+++ b/agb/examples/text_render.rs
@@ -8,7 +8,6 @@ use agb::{
     },
     include_font,
 };
-use modular_bitfield::private::checks::FourMod8;
 
 use core::fmt::Write;
 

--- a/agb/examples/wave.rs
+++ b/agb/examples/wave.rs
@@ -4,7 +4,10 @@
 use core::cell::RefCell;
 
 use agb::{
-    display::{example_logo, tiled::RegularBackgroundSize},
+    display::{
+        example_logo,
+        tiled::{RegularBackgroundSize, TileFormat},
+    },
     fixnum::FixedNum,
     interrupt::{free, Interrupt},
 };
@@ -22,6 +25,7 @@ fn main(mut gba: agb::Gba) -> ! {
     let mut background = gfx.background(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
     );
 
     example_logo::display_logo(&mut background, &mut vram);

--- a/agb/examples/windows.rs
+++ b/agb/examples/windows.rs
@@ -2,6 +2,7 @@
 #![no_main]
 
 use agb::display::blend::{BlendMode, Layer};
+use agb::display::tiled::TileFormat;
 use agb::display::{example_logo, tiled::RegularBackgroundSize, window::WinIn};
 use agb::display::{HEIGHT, WIDTH};
 use agb::fixnum::{num, Num, Rect, Vector2D};
@@ -20,6 +21,7 @@ fn main(mut gba: agb::Gba) -> ! {
     let mut map = gfx.background(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
     );
     let mut window = gba.display.window.get();
     window

--- a/agb/src/display/example_logo.rs
+++ b/agb/src/display/example_logo.rs
@@ -32,7 +32,11 @@ mod tests {
     fn logo_display(gba: &mut crate::Gba) {
         let (gfx, mut vram) = gba.display.video.tiled0();
 
-        let mut map = gfx.background(Priority::P0, RegularBackgroundSize::Background32x32);
+        let mut map = gfx.background(
+            Priority::P0,
+            RegularBackgroundSize::Background32x32,
+            TileFormat::FourBpp,
+        );
 
         display_logo(&mut map, &mut vram);
 

--- a/agb/src/display/font.rs
+++ b/agb/src/display/font.rs
@@ -253,7 +253,7 @@ impl<'a, 'b> TextRenderer<'b> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::display::tiled::TiledMap;
+    use crate::display::tiled::{TileFormat, TiledMap};
     const FONT: Font = crate::include_font!("examples/font/yoster.ttf", 12);
 
     #[test_case]
@@ -263,6 +263,7 @@ mod tests {
         let mut bg = gfx.background(
             crate::display::Priority::P0,
             crate::display::tiled::RegularBackgroundSize::Background32x32,
+            TileFormat::FourBpp,
         );
 
         vram.set_background_palette_raw(&[

--- a/agb/src/display/tiled/infinite_scrolled_map.rs
+++ b/agb/src/display/tiled/infinite_scrolled_map.rs
@@ -54,7 +54,7 @@ use crate::{
 /// let tileset = TileSet::new(&tilemap::MAP_TILES, TileFormat::FourBpp);
 ///
 /// let mut backdrop = InfiniteScrolledMap::new(
-///     gfx.background(Priority::P2, RegularBackgroundSize::Background32x32),
+///     gfx.background(Priority::P2, RegularBackgroundSize::Background32x32, TileFormat::FourBpp),
 ///     Box::new(|pos| {
 ///         (
 ///             &tileset,
@@ -146,7 +146,7 @@ impl<'a> InfiniteScrolledMap<'a> {
     /// # let tileset = TileSet::new(&tilemap::MAP_TILES, TileFormat::FourBpp);
     /// #
     /// # let mut backdrop = InfiniteScrolledMap::new(
-    /// #    gfx.background(Priority::P2, RegularBackgroundSize::Background32x32),
+    /// #    gfx.background(Priority::P2, RegularBackgroundSize::Background32x32, TileFormat::FourBpp),
     /// #    Box::new(|pos| {
     /// #        (
     /// #            &tileset,
@@ -221,7 +221,7 @@ impl<'a> InfiniteScrolledMap<'a> {
     /// # let tileset = TileSet::new(&tilemap::MAP_TILES, TileFormat::FourBpp);
     /// #
     /// # let mut backdrop = InfiniteScrolledMap::new(
-    /// #    gfx.background(Priority::P2, RegularBackgroundSize::Background32x32),
+    /// #    gfx.background(Priority::P2, RegularBackgroundSize::Background32x32, TileFormat::FourBpp),
     /// #    Box::new(|pos| {
     /// #        (
     /// #            &tileset,

--- a/agb/src/display/tiled/map.rs
+++ b/agb/src/display/tiled/map.rs
@@ -26,6 +26,8 @@ trait TiledMapPrivate: TiledMapTypes {
     fn tiles_mut(&mut self) -> &mut [Self::TileType];
     fn tiles_dirty(&mut self) -> &mut bool;
 
+    fn colours(&self) -> TileFormat;
+
     fn background_id(&self) -> usize;
     fn screenblock(&self) -> usize;
     fn priority(&self) -> Priority;
@@ -79,25 +81,27 @@ where
     }
 
     fn commit(&mut self, vram: &mut VRamManager) {
-        let new_bg_control_value = (self.priority() as u16)
-            | ((self.screenblock() as u16) << 8)
-            | (self.map_size().size_flag() << 14);
-
-        self.bg_control_register().set(new_bg_control_value);
-        self.update_bg_registers();
-
         let screenblock_memory = self.screenblock_memory();
-        let x: TileIndex = unsafe { *self.tiles_mut().get_unchecked(0) }.into();
-        let x = x.format().tile_size() / TileFormat::FourBpp.tile_size();
+        let tile_count_divisor = self.colours().tile_size() / TileFormat::FourBpp.tile_size();
         if *self.tiles_dirty() {
             unsafe {
                 dma_copy16(
                     self.tiles_mut().as_ptr() as *const u16,
                     screenblock_memory,
-                    self.map_size().num_tiles() / x,
+                    self.map_size().num_tiles() / tile_count_divisor,
                 );
             }
         }
+
+        let tile_colour_flag: u16 = (tile_count_divisor == 2).into();
+
+        let new_bg_control_value = (self.priority() as u16)
+            | ((self.screenblock() as u16) << 8)
+            | (tile_colour_flag << 7)
+            | (self.map_size().size_flag() << 14);
+
+        self.bg_control_register().set(new_bg_control_value);
+        self.update_bg_registers();
 
         vram.gc();
 
@@ -114,6 +118,8 @@ pub struct RegularMap {
     screenblock: u8,
     priority: Priority,
     size: RegularBackgroundSize,
+
+    colours: TileFormat,
 
     scroll: Vector2D<i16>,
 
@@ -154,6 +160,9 @@ impl TiledMapPrivate for RegularMap {
         self.x_register().set(self.scroll.x);
         self.y_register().set(self.scroll.y);
     }
+    fn colours(&self) -> TileFormat {
+        self.colours
+    }
 }
 
 impl RegularMap {
@@ -162,6 +171,7 @@ impl RegularMap {
         screenblock: u8,
         priority: Priority,
         size: RegularBackgroundSize,
+        colours: TileFormat,
     ) -> Self {
         Self {
             background_id,
@@ -170,6 +180,8 @@ impl RegularMap {
             size,
 
             scroll: Default::default(),
+
+            colours,
 
             tiles: vec![Default::default(); size.num_tiles()],
             tiles_dirty: true,
@@ -266,6 +278,9 @@ impl TiledMapPrivate for AffineMap {
     }
     fn update_bg_registers(&self) {
         self.bg_affine_matrix().set(self.transform);
+    }
+    fn colours(&self) -> TileFormat {
+        TileFormat::EightBpp
     }
 }
 

--- a/agb/src/display/tiled/map.rs
+++ b/agb/src/display/tiled/map.rs
@@ -195,6 +195,14 @@ impl RegularMap {
         tileset: &TileSet<'_>,
         tile_setting: TileSetting,
     ) {
+        if tileset.format() != self.colours() {
+            panic!(
+                "Cannot set a {:?} colour tile on a {:?} colour background",
+                tileset.format(),
+                self.colours()
+            );
+        }
+
         let pos = self.map_size().gba_offset(pos);
 
         let old_tile = self.tiles_mut()[pos];

--- a/agb/src/display/tiled/mod.rs
+++ b/agb/src/display/tiled/mod.rs
@@ -229,6 +229,7 @@ trait RegularTiledMode {
         &self,
         priority: Priority,
         size: RegularBackgroundSize,
+        colours: TileFormat,
     ) -> MapLoan<'_, RegularMap>;
 }
 
@@ -248,6 +249,7 @@ where
         &self,
         priority: Priority,
         size: RegularBackgroundSize,
+        colours: TileFormat,
     ) -> MapLoan<'_, RegularMap> {
         let mut regular = self.regular().borrow_mut();
         let new_background = regular.first_zero().unwrap();
@@ -266,7 +268,13 @@ where
             screenblocks.set(id, true);
         }
 
-        let bg = RegularMap::new(new_background as u8, screenblock as u8 + 16, priority, size);
+        let bg = RegularMap::new(
+            new_background as u8,
+            screenblock as u8 + 16,
+            priority,
+            size,
+            colours,
+        );
 
         regular.set(new_background, true);
 

--- a/agb/src/display/tiled/tiled0.rs
+++ b/agb/src/display/tiled/tiled0.rs
@@ -2,7 +2,7 @@ use core::{cell::RefCell, marker::PhantomData};
 
 use super::{
     CreatableRegularTiledMode, MapLoan, RegularBackgroundSize, RegularMap, RegularTiledMode,
-    TiledMode,
+    TileFormat, TiledMode,
 };
 use crate::{
     bitarray::Bitarray,
@@ -30,8 +30,9 @@ impl Tiled0<'_> {
         &self,
         priority: Priority,
         size: RegularBackgroundSize,
+        colours: TileFormat,
     ) -> MapLoan<'_, RegularMap> {
-        self.regular_background(priority, size)
+        self.regular_background(priority, size, colours)
     }
 }
 

--- a/agb/src/display/tiled/tiled1.rs
+++ b/agb/src/display/tiled/tiled1.rs
@@ -3,7 +3,7 @@ use core::{cell::RefCell, marker::PhantomData};
 use super::{
     AffineBackgroundSize, AffineMap, AffineTiledMode, CreatableAffineTiledMode,
     CreatableRegularTiledMode, MapLoan, RegularBackgroundSize, RegularMap, RegularTiledMode,
-    TiledMode,
+    TileFormat, TiledMode,
 };
 use crate::{
     bitarray::Bitarray,
@@ -38,8 +38,9 @@ impl Tiled1<'_> {
         &self,
         priority: Priority,
         size: RegularBackgroundSize,
+        colours: TileFormat,
     ) -> MapLoan<'_, RegularMap> {
-        self.regular_background(priority, size)
+        self.regular_background(priority, size, colours)
     }
 
     pub fn affine(&self, priority: Priority, size: AffineBackgroundSize) -> MapLoan<'_, AffineMap> {

--- a/agb/src/display/tiled/vram_manager.rs
+++ b/agb/src/display/tiled/vram_manager.rs
@@ -57,6 +57,10 @@ impl<'a> TileSet<'a> {
     fn reference(&self) -> NonNull<[u8]> {
         self.tiles.into()
     }
+
+    pub(crate) fn format(&self) -> TileFormat {
+        self.format
+    }
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -96,7 +96,7 @@
 ///
 /// vram.set_background_palettes(water_tiles::PALETTES);
 ///
-/// let mut bg = gfx.background(Priority::P0, RegularBackgroundSize::Background32x32);
+/// let mut bg = gfx.background(Priority::P0, RegularBackgroundSize::Background32x32, TileFormat::FourBpp);
 ///
 /// for y in 0..20u16 {
 ///     for x in 0..30u16 {

--- a/examples/combo/src/lib.rs
+++ b/examples/combo/src/lib.rs
@@ -65,7 +65,11 @@ fn get_game(gba: &mut agb::Gba) -> Game {
     vram.set_background_palettes(games::PALETTES);
 
     let mut bg = InfiniteScrolledMap::new(
-        tile.background(Priority::P0, RegularBackgroundSize::Background32x32),
+        tile.background(
+            Priority::P0,
+            RegularBackgroundSize::Background32x32,
+            TileFormat::FourBpp,
+        ),
         Box::new(|pos| {
             let y = pos.y.rem_euclid(20);
             let x = pos.x.rem_euclid(30);

--- a/examples/hyperspace-roll/src/lib.rs
+++ b/examples/hyperspace-roll/src/lib.rs
@@ -13,7 +13,7 @@
 #![cfg_attr(test, test_runner(agb::test_runner::test_runner))]
 
 use agb::display::object::ObjectController;
-use agb::display::tiled::{TiledMap, VRamManager};
+use agb::display::tiled::{TileFormat, TiledMap, VRamManager};
 use agb::display::Priority;
 use agb::interrupt::VBlank;
 use agb::{display, sound::mixer::Frequency};

--- a/examples/hyperspace-roll/src/lib.rs
+++ b/examples/hyperspace-roll/src/lib.rs
@@ -111,19 +111,23 @@ pub fn main(mut gba: agb::Gba) -> ! {
     let mut background0 = tiled.background(
         Priority::P0,
         display::tiled::RegularBackgroundSize::Background64x32,
+        TileFormat::FourBpp,
     );
     let mut background1 = tiled.background(
         Priority::P0,
         display::tiled::RegularBackgroundSize::Background64x32,
+        TileFormat::FourBpp,
     );
     let mut card_descriptions = tiled.background(
         Priority::P1,
         display::tiled::RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
     );
 
     let mut help_background = tiled.background(
         Priority::P1,
         display::tiled::RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
     );
 
     let basic_die = Die {

--- a/examples/the-hat-chooses-the-wizard/src/lib.rs
+++ b/examples/the-hat-chooses-the-wizard/src/lib.rs
@@ -857,7 +857,11 @@ pub fn main(mut agb: agb::Gba) -> ! {
 
             let map_current_level = current_level;
             let mut background = InfiniteScrolledMap::new(
-                tiled.background(Priority::P2, RegularBackgroundSize::Background32x64),
+                tiled.background(
+                    Priority::P2,
+                    RegularBackgroundSize::Background32x64,
+                    TileFormat::FourBpp,
+                ),
                 Box::new(|pos: Vector2D<i32>| {
                     let level = &map_tiles::LEVELS[map_current_level as usize];
                     (
@@ -872,7 +876,11 @@ pub fn main(mut agb: agb::Gba) -> ! {
                 }),
             );
             let mut foreground = InfiniteScrolledMap::new(
-                tiled.background(Priority::P0, RegularBackgroundSize::Background64x32),
+                tiled.background(
+                    Priority::P0,
+                    RegularBackgroundSize::Background64x32,
+                    TileFormat::FourBpp,
+                ),
                 Box::new(|pos: Vector2D<i32>| {
                     let level = &map_tiles::LEVELS[map_current_level as usize];
                     (

--- a/examples/the-hat-chooses-the-wizard/src/lib.rs
+++ b/examples/the-hat-chooses-the-wizard/src/lib.rs
@@ -783,8 +783,16 @@ impl<'a, 'b> PlayingLevel<'a, 'b> {
 pub fn main(mut agb: agb::Gba) -> ! {
     let (tiled, mut vram) = agb.display.video.tiled0();
     vram.set_background_palettes(tile_sheet::PALETTES);
-    let mut splash_screen = tiled.background(Priority::P0, RegularBackgroundSize::Background32x32);
-    let mut world_display = tiled.background(Priority::P0, RegularBackgroundSize::Background32x32);
+    let mut splash_screen = tiled.background(
+        Priority::P0,
+        RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
+    );
+    let mut world_display = tiled.background(
+        Priority::P0,
+        RegularBackgroundSize::Background32x32,
+        TileFormat::FourBpp,
+    );
 
     let tileset = TileSet::new(tile_sheet::background.tiles, TileFormat::FourBpp);
 

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -2225,7 +2225,11 @@ fn game_with_level(gba: &mut agb::Gba) {
         let object = gba.display.object.get();
 
         let backdrop = InfiniteScrolledMap::new(
-            background.background(Priority::P2, RegularBackgroundSize::Background32x32),
+            background.background(
+                Priority::P2,
+                RegularBackgroundSize::Background32x32,
+                TileFormat::FourBpp,
+            ),
             Box::new(|pos| {
                 (
                     &tileset,
@@ -2239,7 +2243,11 @@ fn game_with_level(gba: &mut agb::Gba) {
         );
 
         let foreground = InfiniteScrolledMap::new(
-            background.background(Priority::P0, RegularBackgroundSize::Background32x32),
+            background.background(
+                Priority::P0,
+                RegularBackgroundSize::Background32x32,
+                TileFormat::FourBpp,
+            ),
             Box::new(|pos| {
                 (
                     &tileset,
@@ -2253,7 +2261,11 @@ fn game_with_level(gba: &mut agb::Gba) {
         );
 
         let clouds = InfiniteScrolledMap::new(
-            background.background(Priority::P3, RegularBackgroundSize::Background32x32),
+            background.background(
+                Priority::P3,
+                RegularBackgroundSize::Background32x32,
+                TileFormat::FourBpp,
+            ),
             Box::new(|pos| {
                 (
                     &tileset,


### PR DESCRIPTION
Fixes #386.

Turns out we weren't correctly setting the 256 colour mode flag :facepalm:. It worked fine in affine mode because those are 256 colour mode by default, but now it'll also work for regular backgrounds.

- [x] Changelog updated / no changelog update needed
