### PR TITLE
workaround the rust issue

### DIFF
--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -13,7 +13,7 @@ debug = true
 
 [profile.release]
 opt-level = 3
-lto = "thin"
+lto = "fat"
 debug = true
 
 [features]

--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -12,7 +12,7 @@ opt-level = 3
 debug = true
 
 [profile.release]
-opt-level = "s"
+opt-level = 3
 lto = "thin"
 debug = true
 


### PR DESCRIPTION
This works around rust-lang/rust#108853 by using an `opt-level` of `3` rather than `s`.

- [x] Changelog updated / no changelog update needed
