### PR TITLE
Better error message for #[agb::entry] errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Alpha channel is now considered by `include_gfx!()` even when `transparent_colour` is absent.
 - 256 colour backgrounds are now correctly rendered (breaking change).
+- The `#[agb::entry]` macro now reports errors better.
 
 ## [0.13.0] - 2023/01/19
 


### PR DESCRIPTION
Generates compile error calls when something goes wrong.

- [x] Changelog updated / no changelog update needed
