### PR TITLE
Reduce codegen units to 1 to ensure build works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made Vector2D::new a const function.
 - The template now uses rust 2021 edition by default.
 - All objects which should only be created once now have the correct lifetimes to only allow one to exist.
+- Template now uses codegen-units=1 to workaround bug in nightly.
 
 ### Fixed
 - Alpha channel is now considered by `include_gfx!()` even when `transparent_colour` is absent.

--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -15,6 +15,7 @@ debug = true
 opt-level = 3
 lto = "fat"
 debug = true
+codegen-units = 1
 
 [features]
 default = ["testing"]

--- a/examples/combo/Cargo.toml
+++ b/examples/combo/Cargo.toml
@@ -20,3 +20,4 @@ debug = true
 panic = "abort"
 lto = true
 debug = true
+codegen-units = 1

--- a/examples/hyperspace-roll/Cargo.toml
+++ b/examples/hyperspace-roll/Cargo.toml
@@ -8,14 +8,13 @@ edition = "2021"
 
 [dependencies]
 agb = { version = "0.13.0", path = "../../agb" }
-bare-metal = "1"
 
 [profile.dev]
 opt-level = 2
 debug = true
 
-
 [profile.release]
 panic = "abort"
 lto = true
 debug = true
+codegen-units = 1

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -17,3 +17,4 @@ debug = true
 panic = "abort"
 lto = true
 debug = true
+codegen-units = 1


### PR DESCRIPTION
Workaround for #393 

- [x] Changelog updated / no changelog update needed
