### PR TITLE
Purple night fixes

### DIFF
--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -1978,7 +1978,7 @@ impl<'a> Game<'a> {
             self.particles.insert(new_particle);
         }
 
-        let mut remove = Vec::with_capacity(10);
+        let mut remove = Vec::new();
         for (idx, enemy) in self.enemies.iter_mut() {
             if enemy.entity.position.x < self.offset.x - 8 {
                 remove.push(idx);

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -2066,10 +2066,6 @@ impl<'a> Game<'a> {
                 .commit_with_fudge(this_frame_offset, (0, 0).into());
         }
 
-        self.level.background.commit(vram);
-        self.level.foreground.commit(vram);
-        self.level.clouds.commit(vram);
-
         for i in remove {
             self.particles.remove(i);
         }
@@ -2274,6 +2270,9 @@ fn game_with_level(gba: &mut agb::Gba) {
             sfx.frame();
             vblank.wait_for_vblank();
             object.commit();
+            game.level.background.commit(&mut vram);
+            game.level.foreground.commit(&mut vram);
+            game.level.clouds.commit(&mut vram);
             match game.advance_frame(&object, &mut vram, &mut sfx) {
                 GameStatus::Continue => {}
                 GameStatus::Lost => {

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -1966,6 +1966,8 @@ impl<'a> Game<'a> {
             self.shake_time -= 1;
         }
 
+        let this_frame_offset = this_frame_offset.floor().into();
+
         self.input.update();
         if let UpdateInstruction::CreateParticle(data, position) =
             self.player

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -600,7 +600,7 @@ impl<'a> Player<'a> {
                     AttackTimer::Attack(a) => {
                         *a -= 1;
                         let frame = self.sword.attack_frame(*a);
-                        self.fudge_factor.x += self.sword.fudge(frame) * self.facing as i32;
+                        self.fudge_factor.x = (self.sword.fudge(frame) * self.facing as i32).into();
                         let tag = self.sword.attack_tag();
                         let sprite = controller.sprite(tag.animation_sprite(frame as usize));
                         self.entity.sprite.set_sprite(sprite);
@@ -614,7 +614,7 @@ impl<'a> Player<'a> {
                     AttackTimer::Cooldown(a) => {
                         *a -= 1;
                         let frame = self.sword.hold_frame();
-                        self.fudge_factor.x += self.sword.fudge(frame) * self.facing as i32;
+                        self.fudge_factor.x = (self.sword.fudge(frame) * self.facing as i32).into();
                         let tag = self.sword.attack_tag();
                         let sprite = controller.sprite(tag.animation_sprite(frame as usize));
                         self.entity.sprite.set_sprite(sprite);

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -2193,15 +2193,12 @@ fn game_with_level(gba: &mut agb::Gba) {
 
     let mut start_at_boss = false;
 
+    let (background, mut vram) = gba.display.video.tiled0();
+    vram.set_background_palettes(background::PALETTES);
+    let tileset = TileSet::new(background::background.tiles, TileFormat::FourBpp);
+    let object = gba.display.object.get();
+
     loop {
-        let (background, mut vram) = gba.display.video.tiled0();
-
-        vram.set_background_palettes(background::PALETTES);
-
-        let tileset = TileSet::new(background::background.tiles, TileFormat::FourBpp);
-
-        let object = gba.display.object.get();
-
         let backdrop = InfiniteScrolledMap::new(
             background.background(
                 Priority::P2,

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -2269,12 +2269,12 @@ fn game_with_level(gba: &mut agb::Gba) {
         );
 
         start_at_boss = loop {
-            sfx.frame();
             vblank.wait_for_vblank();
-            object.commit();
+            sfx.frame();
             game.level.background.commit(&mut vram);
             game.level.foreground.commit(&mut vram);
             game.level.clouds.commit(&mut vram);
+            object.commit();
             match game.advance_frame(&object, &mut vram, &mut sfx) {
                 GameStatus::Continue => {}
                 GameStatus::Lost => {

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -524,7 +524,7 @@ struct Player<'a> {
 
 impl<'a> Player<'a> {
     fn new(object_controller: &'a ObjectController<'a>) -> Player {
-        let mut entity = Entity::new(object_controller, Rect::new((0, 0).into(), (5, 12).into()));
+        let mut entity = Entity::new(object_controller, Rect::new((0, 1).into(), (5, 10).into()));
         let s = object_controller.sprite(LONG_SWORD_IDLE.sprite(0));
         entity.sprite.set_sprite(s);
         entity.sprite.show();


### PR DESCRIPTION
A few changes to the purple night to make it so much better!
* Fixes player positioning to be in the centre, no more drastic change of position when changing directions, and you don't go all the way into walls.
* Fixes rounding of collision to round rather than floor, this means the left and right walls are more equivalent.
* Fixes the "jitter" between objects and backgrounds where objects would move by a pixel, but the background wouldn't.
  - In general we're more careful to do all display changes at once rather than throughout the frame.
  - Note that for future games this is the correct way of doing things.
* Fixes slime collision boxes to match the extent of the animation.
* Use more i32 rather than u16, we're not running out of memory!
* Fixes memory leak caused by dying (previously you could only die a certain number of times before the game crashes).
* Moved sound to be during vblank
  - This is a negative change but resolves some cracking issues. I can't see why this should be the case, further work may be required here.

- [x] No changelog update needed
