### PR TITLE
Minor speed up for tiles

### DIFF
--- a/agb-hashmap/src/lib.rs
+++ b/agb-hashmap/src/lib.rs
@@ -339,6 +339,10 @@ where
     }
 
     unsafe fn insert_new_and_get(&mut self, key: K, value: V, hash: HashType) -> &'_ mut V {
+        if self.nodes.capacity() <= self.len() {
+            self.resize(self.nodes.backing_vec_size() * 2);
+        }
+
         let location = self.nodes.insert_new(key, value, hash);
 
         // SAFETY: location is always valid


### PR DESCRIPTION
We currently do lots of redundant hash calculations while changing a tile in vram. We can cache the value and then use the entry API to reuse it.

- [x] no changelog update needed
