### PR TITLE
Inline always in new_from_parts

### DIFF
--- a/agb-fixnum/src/lib.rs
+++ b/agb-fixnum/src/lib.rs
@@ -416,6 +416,7 @@ impl<I: FixedWidthUnsignedInteger, const N: usize> Num<I, N> {
     }
 
     #[doc(hidden)]
+    #[inline(always)]
     /// Called by the [num!] macro in order to create a fixed point number
     pub fn new_from_parts(num: (i32, i32)) -> Self {
         Self(I::from_as_i32(((num.0) << N) + (num.1 >> (30 - N))))


### PR DESCRIPTION
Mentioned here that we should probably do it: https://github.com/agbrs/agb/discussions/370#discussioncomment-4650702

From decompiling, it seems that this normally happens, but lets at least ensure it if you don't have lto enabled.

- [x] no changelog update needed
