### PR TITLE
Hide objects by default

### DIFF
--- a/agb/src/display/object/unmanaged/attributes.rs
+++ b/agb/src/display/object/unmanaged/attributes.rs
@@ -19,11 +19,11 @@ impl Default for Attributes {
         Self {
             a0: ObjectAttribute0::new(
                 0,
-                ObjectMode::Normal,
+                ObjectMode::Disabled,
                 GraphicsMode::Normal,
                 false,
                 ColourMode::Four,
-                u2::new(1),
+                u2::new(0),
             ),
             a1s: Default::default(),
             a1a: Default::default(),


### PR DESCRIPTION
Fixes bug introduced in #430 
- [x] no changelog update needed
