### PR TITLE
Fix num multiply checks

### DIFF
--- a/agb-fixnum/Cargo.toml
+++ b/agb-fixnum/Cargo.toml
@@ -8,3 +8,7 @@ repository = "https://github.com/agbrs/agb"
 
 [dependencies]
 agb_macros = { version = "0.15.0", path = "../agb-macros" }
+
+
+[dev-dependencies]
+rand = "0.8.5"

--- a/agb-fixnum/src/lib.rs
+++ b/agb-fixnum/src/lib.rs
@@ -129,9 +129,8 @@ macro_rules! upcast_multiply_impl {
 
             // maintain correct overflow behaviour
             // this checks that we are not losing precision when shifting the integer part up
-            debug_assert!(a_floor * b_floor < (1 << (core::mem::size_of::<$T>() * 8 - n)));
-
             check_i32_overflow!($T, a_floor, b_floor, n);
+            debug_assert!(a_floor * b_floor < (1 << (core::mem::size_of::<$T>() * 8 - n)));
 
             ((a_floor * b_floor) << n)
                 + (a_floor * b_frac + b_floor * a_frac)
@@ -148,7 +147,8 @@ macro_rules! upcast_multiply_impl {
 
 macro_rules! check_i32_overflow {
     (i32, $A: ident, $B: ident, $N: ident) => {
-        debug_assert!($A * $B > !(1 << (core::mem::size_of::<i32>() * 8 - $N)));
+        debug_assert!($A * $B > !(1 << (core::mem::size_of::<i32>() * 8 - $N - 1)));
+        debug_assert!($A * $B < (1 << (core::mem::size_of::<i32>() * 8 - $N - 1)));
     };
     ($T: ty, $A: ident, $B: ident, $N: ident) => {};
 }


### PR DESCRIPTION
Checks the overflowing behaviour is correct in debug mode.

* Note that for `N` >= 16 this will (almost) never not overflow.

- [x] no changelog update needed


* Debug codegen (truncating the panic code):
```
;     fn mul(self, rhs: Num<I, N>) -> Self::Output {
 80011cc: b5f0         	push	{r4, r5, r6, r7, lr}
 80011ce: b081         	sub	sp, #4
 80011d0: 000d         	movs	r5, r1
 80011d2: 0004         	movs	r4, r0
;             let a_floor = a >> n;
 80011d4: 1206         	asrs	r6, r0, #8
;             check_i32_overflow!($T, a_floor, b_floor, n);
 80011d6: 17c1         	asrs	r1, r0, #31
;             let b_floor = b >> n;
 80011d8: 122f         	asrs	r7, r5, #8
;             check_i32_overflow!($T, a_floor, b_floor, n);
 80011da: 17eb         	asrs	r3, r5, #31
 80011dc: 0030         	movs	r0, r6
 80011de: 003a         	movs	r2, r7
 80011e0: f00f ff9a    	bl	0x8011118 <.text+0x11118> @ imm = #65332
 80011e4: 17c2         	asrs	r2, r0, #31
 80011e6: 1a89         	subs	r1, r1, r2
 80011e8: 1e4a         	subs	r2, r1, #1
 80011ea: 4191         	sbcs	r1, r2
 80011ec: d121         	bne	0x8001232 <.text+0x1232> @ imm = #66
 80011ee: 491a         	ldr	r1, [pc, #104]          @ 0x8001258 <.text+0x1258>
;             check_i32_overflow!($T, a_floor, b_floor, n);
 80011f0: 4288         	cmp	r0, r1
 80011f2: db24         	blt	0x800123e <.text+0x123e> @ imm = #72
 80011f4: 2101         	movs	r1, #1
 80011f6: 05c9         	lsls	r1, r1, #23
;             check_i32_overflow!($T, a_floor, b_floor, n);
 80011f8: 4288         	cmp	r0, r1
 80011fa: da26         	bge	0x800124a <.text+0x124a> @ imm = #76
 80011fc: 21ff         	movs	r1, #255
 80011fe: 400d         	ands	r5, r1
 8001200: 400c         	ands	r4, r1
;                 + (a_floor * b_frac + b_floor * a_frac)
 8001202: 4367         	muls	r7, r4, r7
 8001204: 436e         	muls	r6, r5, r6
 8001206: 19f1         	adds	r1, r6, r7
 8001208: 42b1         	cmp	r1, r6
 800120a: d60c         	bvs	0x8001226 <.text+0x1226> @ imm = #24
;             ((a_floor * b_floor) << n)
 800120c: 0200         	lsls	r0, r0, #8
 800120e: 1841         	adds	r1, r0, r1
 8001210: 4281         	cmp	r1, r0
 8001212: d608         	bvs	0x8001226 <.text+0x1226> @ imm = #16
;                 + ((a_frac * b_frac) >> n)
 8001214: 436c         	muls	r4, r5, r4
 8001216: 0a20         	lsrs	r0, r4, #8
;             ((a_floor * b_floor) << n)
 8001218: 1808         	adds	r0, r1, r0
 800121a: 4288         	cmp	r0, r1
 800121c: d603         	bvs	0x8001226 <.text+0x1226> @ imm = #6
;     }
 800121e: b001         	add	sp, #4
 8001220: bcf0         	pop	{r4, r5, r6, r7}
 8001222: bc02         	pop	{r1}
 8001224: 4708         	bx	r1
```

* Release codegen
```
;     fn mul(self, rhs: Num<I, N>) -> Self::Output {
 800ca34: b510         	push	{r4, lr}
;             let a_floor = a >> n;
 800ca36: 1202         	asrs	r2, r0, #8
 800ca38: 434a         	muls	r2, r1, r2
 800ca3a: 23ff         	movs	r3, #255
;             let a_frac = a & mask;
 800ca3c: 4018         	ands	r0, r3
;             let b_floor = b >> n;
 800ca3e: 120c         	asrs	r4, r1, #8
;                 + (a_floor * b_frac + b_floor * a_frac)
 800ca40: 4344         	muls	r4, r0, r4
;             ((a_floor * b_floor) << n)
 800ca42: 18a2         	adds	r2, r4, r2
;             let b_frac = b & mask;
 800ca44: 4019         	ands	r1, r3
;                 + ((a_frac * b_frac) >> n)
 800ca46: 4341         	muls	r1, r0, r1
 800ca48: 0a08         	lsrs	r0, r1, #8
;             ((a_floor * b_floor) << n)
 800ca4a: 1810         	adds	r0, r2, r0
;     }
 800ca4c: bc10         	pop	{r4}
 800ca4e: bc02         	pop	{r1}
 800ca50: 4708         	bx	r1
```