### PR TITLE
Even faster mixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the default template game.
 - `DynamicSprite` has a new API which changes the constructor and adds a `set_pixel` method.
 - You no longer need to install arm-none-eabi-binutils. In order to write games using `agb`, you now only need to install rust nightly.
+- 10% performance improvement with the software mixer.
 
 ## [0.15.0] - 2023/04/25
 

--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -152,6 +152,7 @@ agb_arm_func agb_rs__mixer_collapse
     @ Arguments:
     @ r0 = target buffer (i8)
     @ r1 = input buffer (i16) of fixnums with 4 bits of precision (read in sets of i16 in an i32)
+    @ r2 = loop counter
 
     push {{r4-r11,lr}}
 
@@ -164,8 +165,6 @@ SWAP_SIGN .req r11
     ldr CONST_127, =127
     ldr SWAP_SIGN, =0x80808080
 
-    ldr r2, =agb_rs__buffer_size @ loop counter
-    ldr r2, [r2]
     mov r4, r2
 
 @ The idea for this solution came from pimpmobile:

--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -98,17 +98,15 @@ agb_arm_func agb_rs__mixer_add_stereo
     @ r2 - volume to play the sound at
     @
     @ The sound buffer must be SOUND_BUFFER_SIZE * 2 in size = 176 * 2
-    push {{r4-r9}}
+    push {{r4-r12}}
 
     ldr r5, =0x00000FFF
 
     ldr r8, =agb_rs__buffer_size
     ldr r8, [r8]
-1:
-.rept 4
-    ldrsh r6, [r0], #2        @ load the current sound sample to r6
 
-    ldr r4, [r1]             @ read the current value
+.macro add_stereo_sample sample_reg:req
+    ldrsh r6, [r0], #2        @ load the current sound sample to r6
 
     @ This is slightly convoluted, but is mainly done for performance reasons. It is better
     @ to hit ROM just once and then do 3 really simple instructions then do 2 ldrsbs however annoying
@@ -129,7 +127,14 @@ agb_arm_func agb_rs__mixer_add_stereo
     lsl r6, r6, #24        @ r6 = | R | 0 | 0 | 0 | drop everything except the right sample
     orr r6, r7, r6, asr #8 @ r6 = | 1 | R | 1 | L | now we have it perfectly set up
 
-    mla r4, r6, r2, r4     @ r4 += r6 * r2 (calculating both the left and right samples together)
+    mla \sample_reg, r6, r2, \sample_reg     @ r4 += r6 * r2 (calculating both the left and right samples together)
+.endm
+
+1:
+.rept 4
+    ldr r4, [r1]             @ read the current value
+
+    add_stereo_sample r4
 
     str r4, [r1], #4         @ store the new value, and increment the pointer
 .endr
@@ -137,7 +142,7 @@ agb_arm_func agb_rs__mixer_add_stereo
     subs r8, r8, #4          @ loop counter
     bne 1b                   @ jump back if we're done with the loop
 
-    pop {{r4-r9}}
+    pop {{r4-r12}}
     bx lr
 
 agb_arm_end agb_rs__mixer_add_stereo

--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -157,12 +157,12 @@ agb_arm_func agb_rs__mixer_collapse
     push {{r4-r11,lr}}
 
 CONST_0   .req r7
-CONST_127 .req r8
+CONST_128 .req r8
 TEMP      .req r10
 SWAP_SIGN .req r11
 
     ldr CONST_0, =0
-    ldr CONST_127, =127
+    ldr CONST_128, =128
     ldr SWAP_SIGN, =0x80808080
 
     mov r4, r2
@@ -192,8 +192,8 @@ SWAP_SIGN .req r11
 
 .macro load_sample left_reg:req right_reg:req
     mov \right_reg, \left_reg, lsl #16                 @ push the sample 16 bits first
-    add \right_reg, CONST_127, \right_reg, asr #20     @ move right sample back to being the correct value
-    add \left_reg, CONST_127, \left_reg, asr #20       @ now we only have the left sample
+    add \right_reg, CONST_128, \right_reg, asr #20     @ move right sample back to being the correct value
+    add \left_reg, CONST_128, \left_reg, asr #20       @ now we only have the left sample
 
     clamp_s8 \left_reg                                 @ clamp the audio to 8 bit values
     clamp_s8 \right_reg

--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -131,13 +131,14 @@ agb_arm_func agb_rs__mixer_add_stereo
 .endm
 
 1:
-.rept 4
-    ldr r4, [r1]             @ read the current value
+    ldmia r1, {{r9-r12}}       @ read the current values
 
-    add_stereo_sample r4
+    add_stereo_sample r9
+    add_stereo_sample r10
+    add_stereo_sample r11
+    add_stereo_sample r12
 
-    str r4, [r1], #4         @ store the new value, and increment the pointer
-.endr
+    stmia r1!, {{r9-r12}}         @ store the new value, and increment the pointer
 
     subs r8, r8, #4          @ loop counter
     bne 1b                   @ jump back if we're done with the loop

--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -190,7 +190,7 @@ SWAP_SIGN .req r11
 @ So (-1 logical >> 24) gives 11111111 and (1 logical >> 24) gives 00000000 so register is clamped between these two values.
 .macro clamp_s8 reg:req
     subs TEMP, CONST_0, \reg, asr #8
-    andne \reg, CONST_FF, TEMP, lsr #24
+    movne \reg, TEMP, lsr #24
 .endm
 
 .macro load_sample left_reg:req right_reg:req

--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -98,7 +98,7 @@ agb_arm_func agb_rs__mixer_add_stereo
     @ r2 - volume to play the sound at
     @
     @ The sound buffer must be SOUND_BUFFER_SIZE * 2 in size = 176 * 2
-    push {{r4-r12}}
+    push {{r4-r11}}
 
     ldr r5, =0x00000FFF
 
@@ -143,7 +143,7 @@ agb_arm_func agb_rs__mixer_add_stereo
     subs r8, r8, #4          @ loop counter
     bne 1b                   @ jump back if we're done with the loop
 
-    pop {{r4-r12}}
+    pop {{r4-r11}}
     bx lr
 
 agb_arm_end agb_rs__mixer_add_stereo

--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -100,7 +100,6 @@ agb_arm_func agb_rs__mixer_add_stereo
     @ The sound buffer must be SOUND_BUFFER_SIZE * 2 in size = 176 * 2
     push {{r4-r9}}
 
-    mov r9, r2
     ldr r5, =0x00000FFF
 
     ldr r8, =agb_rs__buffer_size
@@ -130,7 +129,7 @@ agb_arm_func agb_rs__mixer_add_stereo
     lsl r6, r6, #24        @ r6 = | R | 0 | 0 | 0 | drop everything except the right sample
     orr r6, r7, r6, asr #8 @ r6 = | 1 | R | 1 | L | now we have it perfectly set up
 
-    mla r4, r6, r9, r4     @ r4 += r6 * r9 (calculating both the left and right samples together)
+    mla r4, r6, r2, r4     @ r4 += r6 * r2 (calculating both the left and right samples together)
 
     str r4, [r1], #4         @ store the new value, and increment the pointer
 .endr

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -531,13 +531,16 @@ mod test {
         }
 
         // output will be unzipped, so input is LRLRLRLRLRLRLR... and output is LLLLLLRRRRRR
-        assert!(output_buffer
-            .iter()
-            .flat_map(|x| x.to_le_bytes())
-            .map(|x| x as i8)
-            .eq([
+        assert_eq!(
+            output_buffer
+                .iter()
+                .flat_map(|x| x.to_le_bytes())
+                .map(|x| x as i8)
+                .collect::<alloc::vec::Vec<_>>(),
+            &[
                 10, 5, -10, -6, 0, 2, 127, 127, 10, 5, -10, -6, 0, 2, 127, 127, 10, 5, -11, -6, 1,
                 3, -128, -128, 10, 5, -11, -6, 1, 3, -128, -128
-            ]));
+            ]
+        );
     }
 }

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -470,3 +470,64 @@ impl MixerBuffer {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::fixnum::num;
+    use alloc::vec;
+
+    use super::*;
+
+    #[test_case]
+    fn collapse_should_correctly_reduce_size_of_input(_: &mut crate::Gba) {
+        let input: &[Num<i16, 4>] = &[
+            num!(10.0),
+            num!(10.0),
+            num!(5.0),
+            num!(5.0),
+            num!(-10.0),
+            num!(-10.5),
+            num!(-5.9),
+            num!(-5.2),
+            num!(0.0),
+            num!(1.1),
+            num!(2.2),
+            num!(3.3),
+            num!(155.4),
+            num!(-230.5),
+            num!(400.6),
+            num!(-700.7),
+            num!(10.0),
+            num!(10.0),
+            num!(5.0),
+            num!(5.0),
+            num!(-10.0),
+            num!(-10.5),
+            num!(-5.9),
+            num!(-5.2),
+            num!(0.0),
+            num!(1.1),
+            num!(2.2),
+            num!(3.3),
+            num!(155.4),
+            num!(-230.5),
+            num!(400.6),
+            num!(-700.7),
+        ];
+
+        let mut output_buffer = vec![0i8; input.len()];
+
+        unsafe {
+            agb_rs__mixer_collapse(output_buffer.as_mut_ptr(), input.as_ptr(), input.len() / 2);
+        }
+
+        // output will be unzipped, so input is LRLRLRLRLRLRLR... and output is LLLLLLRRRRRR
+        assert_eq!(
+            output_buffer,
+            &[
+                10, 5, -10, -6, 0, 2, 127, 127, 10, 5, -10, -6, 0, 2, 127, 127, 10, 5, -11, -6, 1,
+                3, -128, -128, 10, 5, -11, -6, 1, 3, -128, -128
+            ]
+        );
+    }
+}

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -480,54 +480,64 @@ mod test {
 
     #[test_case]
     fn collapse_should_correctly_reduce_size_of_input(_: &mut crate::Gba) {
-        let input: &[Num<i16, 4>] = &[
-            num!(10.0),
-            num!(10.0),
-            num!(5.0),
-            num!(5.0),
-            num!(-10.0),
-            num!(-10.5),
-            num!(-5.9),
-            num!(-5.2),
-            num!(0.0),
-            num!(1.1),
-            num!(2.2),
-            num!(3.3),
-            num!(155.4),
-            num!(-230.5),
-            num!(400.6),
-            num!(-700.7),
-            num!(10.0),
-            num!(10.0),
-            num!(5.0),
-            num!(5.0),
-            num!(-10.0),
-            num!(-10.5),
-            num!(-5.9),
-            num!(-5.2),
-            num!(0.0),
-            num!(1.1),
-            num!(2.2),
-            num!(3.3),
-            num!(155.4),
-            num!(-230.5),
-            num!(400.6),
-            num!(-700.7),
-        ];
+        #[repr(align(4))]
+        struct AlignedNumbers<const N: usize>([Num<i16, 4>; N]);
 
-        let mut output_buffer = vec![0i8; input.len()];
+        let input = &AlignedNumbers([
+            num!(10.0),
+            num!(10.0),
+            num!(5.0),
+            num!(5.0),
+            num!(-10.0),
+            num!(-10.5),
+            num!(-5.9),
+            num!(-5.2),
+            num!(0.0),
+            num!(1.1),
+            num!(2.2),
+            num!(3.3),
+            num!(155.4),
+            num!(-230.5),
+            num!(400.6),
+            num!(-700.7),
+            num!(10.0),
+            num!(10.0),
+            num!(5.0),
+            num!(5.0),
+            num!(-10.0),
+            num!(-10.5),
+            num!(-5.9),
+            num!(-5.2),
+            num!(0.0),
+            num!(1.1),
+            num!(2.2),
+            num!(3.3),
+            num!(155.4),
+            num!(-230.5),
+            num!(400.6),
+            num!(-700.7),
+        ]);
+
+        let input = &input.0;
+
+        let mut output_buffer = vec![0i32; input.len() / 4];
 
         unsafe {
-            agb_rs__mixer_collapse(output_buffer.as_mut_ptr(), input.as_ptr(), input.len() / 2);
+            agb_rs__mixer_collapse(
+                output_buffer.as_mut_ptr().cast(),
+                input.as_ptr(),
+                input.len() / 2,
+            );
         }
 
         // output will be unzipped, so input is LRLRLRLRLRLRLR... and output is LLLLLLRRRRRR
-        assert_eq!(
-            output_buffer,
-            &[
+        assert!(output_buffer
+            .iter()
+            .flat_map(|x| x.to_le_bytes())
+            .map(|x| x as i8)
+            .eq([
                 10, 5, -10, -6, 0, 2, 127, 127, 10, 5, -10, -6, 0, 2, 127, 127, 10, 5, -11, -6, 1,
                 3, -128, -128, 10, 5, -11, -6, 1, 3, -128, -128
-            ]
-        );
+            ]));
     }
 }

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -35,7 +35,11 @@ extern "C" {
         volume: Num<i16, 4>,
     );
 
-    fn agb_rs__mixer_collapse(sound_buffer: *mut i8, input_buffer: *const Num<i16, 4>);
+    fn agb_rs__mixer_collapse(
+        sound_buffer: *mut i8,
+        input_buffer: *const Num<i16, 4>,
+        num_samples: usize,
+    );
 }
 
 /// The main software mixer struct.
@@ -458,7 +462,11 @@ impl MixerBuffer {
         let write_buffer = free(|cs| self.state.borrow(cs).borrow_mut().active_advanced());
 
         unsafe {
-            agb_rs__mixer_collapse(write_buffer, working_buffer.as_ptr());
+            agb_rs__mixer_collapse(
+                write_buffer,
+                working_buffer.as_ptr(),
+                self.frequency.buffer_size(),
+            );
         }
     }
 }


### PR DESCRIPTION
If you do an ldmia for loading lots of samples at once, the mixer uses significantly less CPU (10% compared to previous, 19800 cycles per frame -> 17701 cycles per frame for 32768Hz).

I've also added a really simple unit test for the `collapse` function to at least gain some confidence in it.

- [x] Changelog updated / no changelog update needed
