### PR TITLE
Save useless zeroing of buffer

### DIFF
--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -35,7 +35,7 @@ agb_arm_func \fn_name
     ldrsb r6, [r4]           @ load the current sound sample to r6
     add r5, r5, r2           @ calculate the position to read the next sample from
 
-.ifc is_first,true
+.ifc \is_first,true
     mul r4, r6, r7           @ r4 = r6 * r7 (calculating both the left and right samples together)
 .else
     ldr r4, [r1]             @ read the current value
@@ -82,7 +82,7 @@ agb_arm_func \fn_name
     lsl r6, r6, #16
     orr r6, r6, lsr #16
 
-.ifc is_first,true
+.ifc \is_first,true
     mov r4, r6, lsl r3       @ r4 = r6 << r3
 .else
     ldr r4, [r1]             @ read the current value

--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -18,9 +18,9 @@ agb_arm_func agb_rs__mixer_add
     ldr r7, [sp, #20]        @ load the right channel modification amount into r7
 
     cmp r7, r3               @ check if left and right channel need the same modifications
-    beq same_modification
+    beq .Lsame_modification
 
-modifications_fallback:
+.Lmodifications_fallback:
     orr r7, r7, r3, lsl #16   @ r7 now is the left channel followed by the right channel modifications.
 
     mov r5, #0                   @ current index we're reading from
@@ -47,13 +47,13 @@ modifications_fallback:
     pop {{r4-r8}}
     bx lr
 
-same_modification:
+.Lsame_modification:
     @ check to see if this is a perfect power of 2
     @ r5 is a scratch register, r7 = r3 = amount to modify
     sub r5, r7, #1
     ands r5, r5, r7
 
-    bne modifications_fallback @ not 0 means we need to do the full modification
+    bne .Lmodifications_fallback @ not 0 means we need to do the full modification
 
     @ count leading zeros of r7 into r3
     mov r3, #0

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -29,6 +29,14 @@ extern "C" {
         right_amount: Num<i16, 4>,
     );
 
+    fn agb_rs__mixer_add_first(
+        sound_data: *const u8,
+        sound_buffer: *mut Num<i16, 4>,
+        playback_speed: Num<u32, 8>,
+        left_amount: Num<i16, 4>,
+        right_amount: Num<i16, 4>,
+    );
+
     fn agb_rs__mixer_add_stereo(
         sound_data: *const u8,
         sound_buffer: *mut Num<i16, 4>,
@@ -412,7 +420,7 @@ impl MixerBuffer {
         working_buffer: &mut [Num<i16, 4>],
         channels: impl Iterator<Item = &'a mut SoundChannel>,
     ) {
-        // working_buffer.fill(0.into());
+        working_buffer.fill(0.into());
 
         for channel in channels {
             if channel.is_done {

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -35,6 +35,12 @@ extern "C" {
         volume: Num<i16, 4>,
     );
 
+    fn agb_rs__mixer_add_stereo_first(
+        sound_data: *const u8,
+        sound_buffer: *mut Num<i16, 4>,
+        volume: Num<i16, 4>,
+    );
+
     fn agb_rs__mixer_collapse(
         sound_buffer: *mut i8,
         input_buffer: *const Num<i16, 4>,
@@ -406,7 +412,7 @@ impl MixerBuffer {
         working_buffer: &mut [Num<i16, 4>],
         channels: impl Iterator<Item = &'a mut SoundChannel>,
     ) {
-        working_buffer.fill(0.into());
+        // working_buffer.fill(0.into());
 
         for channel in channels {
             if channel.is_done {

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -422,11 +422,7 @@ impl MixerBuffer {
     ) {
         working_buffer.fill(0.into());
 
-        for channel in channels {
-            if channel.is_done {
-                continue;
-            }
-
+        for channel in channels.filter(|channel| !channel.is_done) {
             let playback_speed = if channel.is_stereo {
                 2.into()
             } else {

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -422,31 +422,31 @@ impl MixerBuffer {
     ) {
         working_buffer.fill(0.into());
 
-        for (channel, playback_speed) in
-            channels
-                .filter(|channel| !channel.is_done)
-                .filter_map(|channel| {
-                    let playback_speed = if channel.is_stereo {
-                        2.into()
+        let channels = channels
+            .filter(|channel| !channel.is_done)
+            .filter_map(|channel| {
+                let playback_speed = if channel.is_stereo {
+                    2.into()
+                } else {
+                    channel.playback_speed
+                };
+
+                if (channel.pos + playback_speed * self.frequency.buffer_size() as u32).floor()
+                    >= channel.data.len() as u32
+                {
+                    // TODO: This should probably play what's left rather than skip the last bit
+                    if channel.should_loop {
+                        channel.pos = 0.into();
                     } else {
-                        channel.playback_speed
-                    };
-
-                    if (channel.pos + playback_speed * self.frequency.buffer_size() as u32).floor()
-                        >= channel.data.len() as u32
-                    {
-                        // TODO: This should probably play what's left rather than skip the last bit
-                        if channel.should_loop {
-                            channel.pos = 0.into();
-                        } else {
-                            channel.is_done = true;
-                            return None;
-                        }
+                        channel.is_done = true;
+                        return None;
                     }
+                }
 
-                    Some((channel, playback_speed))
-                })
-        {
+                Some((channel, playback_speed))
+            });
+
+        for (channel, playback_speed) in channels {
             if channel.volume != 0.into() {
                 if channel.is_stereo {
                     unsafe {


### PR DESCRIPTION
I realised we don't need to zero the buffer or read the current buffer value for the first sound that we're writing per frame. Gets us from 17728 cycles per frame for 32768Hz down to 15291 cycles per frame.

From tests (and theory), this reduces the number of cycles per frame by 2,000 for 32768Hz.

- [x] No changelog update needed - already mentioned mixer improvements there
