### PR TITLE
Channel counts as finished if the channel position reaches the end of the effect

### DIFF
--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -538,11 +538,11 @@ impl MixerBuffer {
             (false, true) => call_mono_fn!(agb_rs__mixer_add_mono_loop),
             (true, false) => {
                 call_mono_fn!(agb_rs__mixer_add_mono_first);
-                channel.is_done = channel.pos > channel_len;
+                channel.is_done = channel.pos >= channel_len;
             }
             (false, false) => {
                 call_mono_fn!(agb_rs__mixer_add_mono);
-                channel.is_done = channel.pos > channel_len;
+                channel.is_done = channel.pos >= channel_len;
             }
         }
     }


### PR DESCRIPTION
Fixes an issue where you could only play 8 sounds until it would stop entirely.

- [x] no changelog update needed
