### PR TITLE
Fix colors of higher values being unable to be overwritten by colors of lower values in Bitmap4 mode.

### DIFF
--- a/agb/src/display/bitmap4.rs
+++ b/agb/src/display/bitmap4.rs
@@ -48,9 +48,9 @@ impl Bitmap4 {
 
         let c = addr.get(x_in_screen, y_in_screen);
         if x & 0b1 != 0 {
-            addr.set(x_in_screen, y_in_screen, (c & 0xff) | u16::from(colour) << 8);
+            addr.set(x_in_screen, y_in_screen, c & 0xff | u16::from(colour) << 8);
         } else {
-            addr.set(x_in_screen, y_in_screen, (c & 0xff00) | u16::from(colour));
+            addr.set(x_in_screen, y_in_screen, c & 0xff00 | u16::from(colour));
         }
     }
 

--- a/agb/src/display/bitmap4.rs
+++ b/agb/src/display/bitmap4.rs
@@ -48,9 +48,9 @@ impl Bitmap4 {
 
         let c = addr.get(x_in_screen, y_in_screen);
         if x & 0b1 != 0 {
-            addr.set(x_in_screen, y_in_screen, c | u16::from(colour) << 8);
+            addr.set(x_in_screen, y_in_screen, (c & 0xff) | u16::from(colour) << 8);
         } else {
-            addr.set(x_in_screen, y_in_screen, c | u16::from(colour));
+            addr.set(x_in_screen, y_in_screen, (c & 0xff00) | u16::from(colour));
         }
     }
 


### PR DESCRIPTION
Colors of lower values can now overwrite colors of higher values.
Before, this didn't happen, so it was impossible to clear the screen.

credit to origamiscienceguy in the GBA Dev discord for the fix.



- [ ] Changelog updated / no changelog update needed
