### PR TITLE
Allow debugging via vscode for dungeon puzzler

### DIFF
--- a/examples/the-dungeon-puzzlers-lament/.vscode/extensions.json
+++ b/examples/the-dungeon-puzzlers-lament/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "rust-lang.rust-analyzer",
+        "ms-vscode.cpptools",
+        "tamasfe.even-better-toml",
+    ],
+}

--- a/examples/the-dungeon-puzzlers-lament/.vscode/launch.json
+++ b/examples/the-dungeon-puzzlers-lament/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    "configurations": [
+        {
+            "name": "(gdb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "targetArchitecture": "arm",
+            "args": [],
+            "stopAtEntry": false,
+            "cwd": "${fileDirname}",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "miDebuggerServerAddress": "localhost:2345",
+            "preLaunchTask": "Rust build: debug",
+            "program": "${workspaceFolder}/target/thumbv4t-none-eabi/debug/the-dungeon-puzzlers-lament",
+            "linux": {
+                "miDebuggerPath": "arm-none-eabi-gdb",
+                "setupCommands": [
+                    {
+                        "text": "shell \"mgba-qt\" -g \"${workspaceFolder}/target/thumbv4t-none-eabi/debug/the-dungeon-puzzlers-lament\" &"
+                    }
+                ]
+            },
+        }
+    ]
+}

--- a/examples/the-dungeon-puzzlers-lament/.vscode/launch.json
+++ b/examples/the-dungeon-puzzlers-lament/.vscode/launch.json
@@ -7,13 +7,18 @@
             "targetArchitecture": "arm",
             "args": [],
             "stopAtEntry": false,
-            "cwd": "${fileDirname}",
-            "environment": [],
+            "environment": [
+                {
+                    "name": "CARGO_TARGET_DIR",
+                    "value": "${workspaceFolder/target}",
+                },
+            ],
             "externalConsole": false,
             "MIMode": "gdb",
             "miDebuggerServerAddress": "localhost:2345",
             "preLaunchTask": "Rust build: debug",
             "program": "${workspaceFolder}/target/thumbv4t-none-eabi/debug/the-dungeon-puzzlers-lament",
+            "cwd": "${workspaceFolder}",
             "linux": {
                 "miDebuggerPath": "arm-none-eabi-gdb",
                 "setupCommands": [
@@ -22,6 +27,6 @@
                     }
                 ]
             },
-        }
-    ]
+        },
+    ],
 }

--- a/examples/the-dungeon-puzzlers-lament/.vscode/tasks.json
+++ b/examples/the-dungeon-puzzlers-lament/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Rust build: debug",
+            "command": "cargo",
+            "args": [
+                "build"
+            ]
+        }
+    ]
+}

--- a/examples/the-dungeon-puzzlers-lament/.vscode/tasks.json
+++ b/examples/the-dungeon-puzzlers-lament/.vscode/tasks.json
@@ -6,7 +6,12 @@
             "command": "cargo",
             "args": [
                 "build"
-            ]
-        }
-    ]
+            ],
+            "options": {
+                "env": {
+                    "CARGO_TARGET_DIR": "${workspaceRoot}/target"
+                }
+            }
+        },
+    ],
 }


### PR DESCRIPTION
It actually works! Will want to test this and work out how best to support non-linux operating systems too before putting it in the template.

Based on https://felixjones.co.uk/mgba_gdb/vscode.html

- [x] no changelog update needed
