### PR TITLE
Fix linker scripts and their symbols

### DIFF
--- a/agb/gba.ld
+++ b/agb/gba.ld
@@ -36,45 +36,33 @@ SECTIONS {
         . = ALIGN(4);
     } > rom
 
-    __iwram_rom_start = .;
     .iwram : {
-        __iwram_data_start = ABSOLUTE(.);
-
         *(.iwram .iwram.*);
         . = ALIGN(4);
 
         *(.text_iwram .text_iwram.*);
         . = ALIGN(4);
-
-        __iwram_data_end = ABSOLUTE(.);
     } > iwram AT>rom
+    __iwram_data_start = ADDR(.iwram);
+    __iwram_rom_start = LOADADDR(.iwram);
+    __iwram_rom_length_halfwords = (SIZEOF(.iwram) + 1) / 2;
 
-    . = __iwram_rom_start + (__iwram_data_end - __iwram_data_start);
-
-    __ewram_rom_start = .;
     .ewram : {
-        __ewram_data_start = ABSOLUTE(.);
-
         *(.ewram .ewram.*);
         . = ALIGN(4);
 
         *(.data .data.*);
         . = ALIGN(4);
-
-        __ewram_data_end = ABSOLUTE(.);
     } > ewram AT>rom
+    __ewram_data_start = ADDR(.ewram);
+    __ewram_rom_start = LOADADDR(.ewram);
+    __ewram_rom_length_halfwords = (SIZEOF(.ewram) + 1) / 2;
     
     .bss : {
         *(.bss .bss.*);
         . = ALIGN(4);
         __iwram_end = ABSOLUTE(.);
     } > iwram
-
-    __iwram_rom_length_bytes = __iwram_data_end - __iwram_data_start;
-    __iwram_rom_length_halfwords = (__iwram_rom_length_bytes + 1) / 2;
-
-    __ewram_rom_length_bytes = __ewram_data_end - __ewram_data_start;
-    __ewram_rom_length_halfwords = (__ewram_rom_length_bytes + 1) / 2;
 
     .shstrtab : {
        *(.shstrtab)

--- a/agb/gba.ld
+++ b/agb/gba.ld
@@ -7,9 +7,13 @@ EXTERN(__RUST_INTERRUPT_HANDLER)
 EXTERN(__agbabi_memset)
 EXTERN(__agbabi_memcpy)
 
+/* The bios reserves the final 256 bytes of iwram for its exclusive use, so we
+ * need to avoid writing there */
+__bios_reserved_iwram = 256;
+
 MEMORY {
     ewram (w!x) : ORIGIN = 0x02000000, LENGTH = 256K
-    iwram (w!x) : ORIGIN = 0x03000000, LENGTH = 32K
+    iwram (w!x) : ORIGIN = 0x03000000, LENGTH = 32K - __bios_reserved_iwram
     rom (rx)    : ORIGIN = 0x08000000, LENGTH = 32M
 }
 

--- a/agb/src/agb_alloc/mod.rs
+++ b/agb/src/agb_alloc/mod.rs
@@ -129,8 +129,8 @@ fn iwram_data_end() -> usize {
         static __iwram_end: usize;
     }
 
-    // TODO: This seems completely wrong, but without the &, rust generates
-    // a double dereference :/. Maybe a bug in nightly?
+    // Symbols defined in the linker have an address *but no data or value*.
+    // As strange as this looks, they are only useful to take the address of.
     (unsafe { &__iwram_end }) as *const _ as usize
 }
 
@@ -139,8 +139,8 @@ fn data_end() -> usize {
         static __ewram_data_end: usize;
     }
 
-    // TODO: This seems completely wrong, but without the &, rust generates
-    // a double dereference :/. Maybe a bug in nightly?
+    // Symbols defined in the linker have an address *but no data or value*.
+    // As strange as this looks, they are only useful to take the address of.
     (unsafe { &__ewram_data_end }) as *const _ as usize
 }
 


### PR DESCRIPTION
- [ ] Propagate changes to other linker scripts in the repo
- [ ] Changelog updated / no changelog update needed

The main thing this addresses is a bug with the `__{e,i}wram_rom_start` symbols. Defined the way they were, they did not always actually correspond to the LMA address of the section. I'm not entirely sure the exact circumstances that caused this, but I ran into examples and they caused very strange bugs because all of that ram section was then offset by a few bytes, as the routine in `.startup` copied from the wrong location in rom.

For example, using `cargo objdump -- --headers` to check the actual section addresses and comparing to the symbol addresses (which I `info!` logged out) I found an example where `__iwram_rom_start = 0x0800676c` but the actual LMA address of `.iwram` was `0x08006770`: everything was off by 4-bytes and that could be clearly seen in mgba's memory view. When it occurs, it is a *very* fragile bug, and editing code can easily accidentally make it disappear as the linker moves things around.

The solution is to use ld's functions for setting these symbol addresses. This is also more readable (IMHO).

Once this has been reviewed, obviously I'll propagate changes to other *.ld files before it is merged.

--

A couple of misc other things I fixed:
1. The final 256 bytes of iwram are reserved for BIOS use, this can be accounted for by just pretending iwram is 256 bytes shorter.
2. Resolved some TODOs I noticed. Linker-defined symbols are symbols with addresses but no data, the only sensible use of them is to take their address (this looks strange in Rust or C, but looks very natural in asm)