### PR TITLE
Allow TileSetting palette to be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - There is now a multiboot feature which you can use to easily make multiboot ROMs.
+- Can now set palette on a TileSetting struct.
 
 ### Changed
 - You no longer need the gba.ld or gba_mb.ld files in your repository. You should delete these when upgrading.

--- a/agb/src/display/tiled/mod.rs
+++ b/agb/src/display/tiled/mod.rs
@@ -194,6 +194,11 @@ impl TileSetting {
         Self(self.0 ^ ((should_flip as u16) << 11))
     }
 
+    #[must_use]
+    pub const fn palette(self, palette_id: u8) -> Self {
+        Self(self.0 ^ ((palette_id as u16) << 12))
+    }
+
     fn index(self) -> u16 {
         self.0 & ((1 << 10) - 1)
     }


### PR DESCRIPTION
This PR adds the ability for a palette to be set on a TileSetting struct. This is useful when doing more advanced palette tricks on a background. For example, changing the palette for only a portion of a background or manually managing screen palettes.

- [x] Changelog updated / no changelog update needed
