### PR TITLE
Add missing #[cfg(test)]

### DIFF
--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -345,6 +345,7 @@ pub mod test_runner {
     }
 
     // needed to fudge the #[entry] below
+    #[cfg(test)]
     mod agb {
         pub mod test_runner {
             pub use super::super::agb_start_tests;


### PR DESCRIPTION
Linter updates caused it to start complaining.

- [x] no changelog update needed
