### PR TITLE
Add a symlink for the readme to the agb directory

### DIFF
--- a/agb/README.md
+++ b/agb/README.md
@@ -1,0 +1,1 @@
+../README.md


### PR DESCRIPTION
This is an attempt to make the readme show up on crates.io

- [x] no changelog update needed
