### PR TITLE
Pause channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - You can now use include_aseprite and include_background_gfx to include files from the out directory using the `$OUT_DIR` token.
+- Added `.pause()` and `.resume()` methods to `SoundChannels` to let you pause and resume from where you left off.
 
 ## [0.18.0] - 2023/10/31
 

--- a/agb/examples/mixer_basic.rs
+++ b/agb/examples/mixer_basic.rs
@@ -46,6 +46,14 @@ fn main(mut gba: Gba) -> ! {
                 } else {
                     channel.volume(1);
                 }
+
+                if input.is_pressed(Button::A) {
+                    channel.resume();
+                }
+
+                if input.is_pressed(Button::B) {
+                    channel.pause();
+                }
             }
         }
 

--- a/agb/src/sound/mixer/mod.rs
+++ b/agb/src/sound/mixer/mod.rs
@@ -228,6 +228,7 @@ pub struct SoundChannel {
     should_loop: bool,
     restart_point: Num<u32, 8>,
 
+    is_playing: bool,
     playback_speed: Num<u32, 8>,
     volume: Num<i16, 8>, // between 0 and 1
 
@@ -272,6 +273,7 @@ impl SoundChannel {
             pos: 0.into(),
             should_loop: false,
             playback_speed: 1.into(),
+            is_playing: true,
             panning: 0.into(),
             is_done: false,
             priority: SoundPriority::Low,
@@ -316,6 +318,7 @@ impl SoundChannel {
             pos: 0.into(),
             should_loop: false,
             playback_speed: 1.into(),
+            is_playing: true,
             panning: 0.into(),
             is_done: false,
             priority: SoundPriority::High,
@@ -417,6 +420,20 @@ impl SoundChannel {
     #[inline]
     pub fn set_pos(&mut self, pos: impl Into<Num<u32, 8>>) -> &mut Self {
         self.pos = pos.into();
+        self
+    }
+
+    /// Pause this channel. You can resume later by using [`.resume()`](SoundChannel::resume())
+    #[inline]
+    pub fn pause(&mut self) -> &mut Self {
+        self.is_playing = false;
+        self
+    }
+
+    /// Resume a paused channel paused by [`.pause()`](SoundChannel::pause())
+    #[inline]
+    pub fn resume(&mut self) -> &mut Self {
+        self.is_playing = true;
         self
     }
 }

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -414,8 +414,8 @@ impl MixerBuffer {
         working_buffer: &mut [Num<i16, 4>],
         channels: impl Iterator<Item = &'a mut SoundChannel>,
     ) {
-        let mut channels =
-            channels.filter(|channel| !channel.is_done && channel.volume != 0.into());
+        let mut channels = channels
+            .filter(|channel| !channel.is_done && channel.volume != 0.into() && channel.is_playing);
 
         if let Some(channel) = channels.next() {
             if channel.is_stereo {


### PR DESCRIPTION
Requested here: https://github.com/agbrs/agb/discussions/547

Added methods to pause and resume playback of audio channels, and you can use it with the mixer_basic example to prove it works.

- [x] Changelog updated / no changelog update needed
