### PR TITLE
Changes the default runner to log to console

### DIFF
--- a/template/.cargo/config.toml
+++ b/template/.cargo/config.toml
@@ -7,8 +7,8 @@ target = "thumbv4t-none-eabi"
 
 [target.thumbv4t-none-eabi]
 rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
-runner = "mgba-qt"
+runner = ["mgba-qt", "-C", "logToStdout=1", "-C", "logLevel.gba.debug=127"]
 
 [target.armv4t-none-eabi]
 rustflags = ["-Clink-arg=-Tgba.ld", "-Ctarget-cpu=arm7tdmi"]
-runner = "mgba-qt"
+runner = ["mgba-qt", "-C", "logToStdout=1", "-C", "logLevel.gba.debug=127"]


### PR DESCRIPTION

- [ x] Changelog updated / no changelog update needed

This closes issue #554 and allows the template project have logging to console on by default when you run `cargo run`