### PR TITLE
Expose hflip, vflip, priority, position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `.priority()`, `.set_priority()` and `.is_visible()` to `RegularMap`, `AffineMap` and `InfiniteScrolledMap`.
 - Replaced `.show()` and `.hide()` with `.set_visible()`in `RegularMap`, `AffineMap` and `InfiniteScrolledMap`.
+- Added `.hflip()`, `.vflip()`, `.priority()`, `.position()` to `ObjectUnmanaged` and `Object`.
 
 ## [0.18.1] - 2024/02/06
 

--- a/agb/src/display/object/managed.rs
+++ b/agb/src/display/object/managed.rs
@@ -395,7 +395,8 @@ impl Object<'_> {
         self
     }
 
-    /// Sets the horizontal flip, note that this only has a visible affect in Normal mode.
+    /// Sets the horizontal flip, note that this only has a visible affect in Normal mode.  
+    /// Use [hflip](Self::hflip) to get the value
     pub fn set_hflip(&mut self, flip: bool) -> &mut Self {
         // safety: only have one of these, doesn't modify slotmap
         unsafe { self.object().set_hflip(flip) };
@@ -403,7 +404,15 @@ impl Object<'_> {
         self
     }
 
-    /// Sets the vertical flip, note that this only has a visible affect in Normal mode.
+    /// Returns the horizontal flip
+    /// Use [set_hflip](Self::set_hflip) to set the value
+    #[must_use]
+    pub fn hflip(&self) -> bool {
+        unsafe { self.object_shared().hflip() }
+    }
+
+    /// Sets the vertical flip, note that this only has a visible affect in Normal mode.  
+    /// Use [vflip](Self::vflip) to get the value
     pub fn set_vflip(&mut self, flip: bool) -> &mut Self {
         // safety: only have one of these, doesn't modify slotmap
         unsafe { self.object().set_vflip(flip) };
@@ -411,12 +420,27 @@ impl Object<'_> {
         self
     }
 
-    /// Sets the priority of the object relative to the backgrounds priority.
+    /// Returns the vertical flip
+    /// Use [set_vflip](Self::set_vflip) to set the value
+    #[must_use]
+    pub fn vflip(&self) -> bool {
+        unsafe { self.object_shared().vflip() }
+    }
+
+    /// Sets the priority of the object relative to the backgrounds priority.  
+    /// Use [priority](Self::priority) to get the value
     pub fn set_priority(&mut self, priority: Priority) -> &mut Self {
         // safety: only have one of these, doesn't modify slotmap
         unsafe { self.object().set_priority(priority) };
 
         self
+    }
+
+    /// Returns the priority of the object  
+    /// Use [set_priority](Self::set_priority) to set the value
+    #[must_use]
+    pub fn priority(&self) -> Priority {
+        unsafe { self.object_shared().priority() }
     }
 
     /// Changes the sprite mode to be hidden, can be changed to Normal or Affine
@@ -429,7 +453,9 @@ impl Object<'_> {
         self
     }
 
-    /// Sets the x position of the object.
+    /// Sets the x position of the object.  
+    /// Use [x](Self::x) to get the value  
+    /// Use [set_position](Self::set_position) to set both `x` and `y`
     pub fn set_x(&mut self, x: u16) -> &mut Self {
         // safety: only have one of these, doesn't modify slotmap
         unsafe { self.object().set_x(x) };
@@ -437,7 +463,16 @@ impl Object<'_> {
         self
     }
 
-    /// Sets the y position of the object.
+    /// Returns the x position of the object  
+    /// Use [set_x](Self::set_x) to set the value
+    #[must_use]
+    pub fn x(&self) -> u16 {
+        unsafe { self.object_shared().x() }
+    }
+
+    /// Sets the y position of the object.  
+    /// Use [y](Self::y) to get the value  
+    /// Use [set_position](Self::set_position) to set both `x` and `y`
     pub fn set_y(&mut self, y: u16) -> &mut Self {
         // safety: only have one of these, doesn't modify slotmap
         unsafe { self.object().set_y(y) };
@@ -445,12 +480,27 @@ impl Object<'_> {
         self
     }
 
-    /// Sets the position of the object.
+    /// Returns the y position of the object  
+    /// Use [set_y](Self::set_y) to set the value
+    #[must_use]
+    pub fn y(&self) -> u16 {
+        unsafe { self.object_shared().y() }
+    }
+
+    /// Sets the position of the object.  
+    /// Use [position](Self::position) to get the value
     pub fn set_position(&mut self, position: Vector2D<i32>) -> &mut Self {
         // safety: only have one of these, doesn't modify slotmap
         unsafe { self.object().set_position(position) };
 
         self
+    }
+
+    /// Returns the position of the object  
+    /// Use [set_position](Self::set_position) to set the value
+    #[must_use]
+    pub fn position(&self) -> Vector2D<i32> {
+        unsafe { self.object_shared().position() }
     }
 
     /// Sets the affine matrix. This only has an affect in Affine mode.

--- a/agb/src/display/object/unmanaged/attributes.rs
+++ b/agb/src/display/object/unmanaged/attributes.rs
@@ -81,10 +81,18 @@ impl Attributes {
         self
     }
 
+    pub fn hflip(self) -> bool {
+        self.a1s.horizontal_flip()
+    }
+
     pub fn set_vflip(&mut self, flip: bool) -> &mut Self {
         self.a1s.set_vertical_flip(flip);
 
         self
+    }
+
+    pub fn vflip(self) -> bool {
+        self.a1s.vertical_flip()
     }
 
     pub fn set_x(&mut self, x: u16) -> &mut Self {
@@ -94,10 +102,18 @@ impl Attributes {
         self
     }
 
+    pub fn x(self) -> u16 {
+        u16::from(self.a1a.x())
+    }
+
     pub fn set_priority(&mut self, priority: Priority) -> &mut Self {
         self.a2.set_priority(priority);
 
         self
+    }
+
+    pub fn priority(self) -> Priority {
+        self.a2.priority()
     }
 
     pub fn hide(&mut self) -> &mut Self {
@@ -110,6 +126,10 @@ impl Attributes {
         self.a0.set_y(y as u8);
 
         self
+    }
+
+    pub fn y(self) -> u16 {
+        u16::from(self.a0.y())
     }
 
     pub fn set_palette(&mut self, palette_id: u16) -> &mut Self {

--- a/agb/src/display/object/unmanaged/object.rs
+++ b/agb/src/display/object/unmanaged/object.rs
@@ -257,29 +257,53 @@ impl ObjectUnmanaged {
         self
     }
 
-    /// Sets the horizontal flip, note that this only has a visible affect in Normal mode.
+    /// Sets the horizontal flip, note that this only has a visible affect in Normal mode.  
+    /// Use [hflip](Self::hflip) to get the value
     pub fn set_hflip(&mut self, flip: bool) -> &mut Self {
         self.attributes.set_hflip(flip);
 
         self
     }
 
-    /// Sets the vertical flip, note that this only has a visible affect in Normal mode.
+    /// Returns the horizontal flip  
+    /// Use [set_hflip](Self::set_hflip) to set the value
+    #[must_use]
+    pub fn hflip(&self) -> bool {
+        self.attributes.hflip()
+    }
+
+    /// Sets the vertical flip, note that this only has a visible affect in Normal mode.  
+    /// Use [vflip](Self::vflip) to get the value
     pub fn set_vflip(&mut self, flip: bool) -> &mut Self {
         self.attributes.set_vflip(flip);
 
         self
     }
 
-    /// Sets the priority of the object relative to the backgrounds priority.
+    /// Returns the vertical flip  
+    /// Use [set_vflip](Self::set_vflip) to set the value
+    #[must_use]
+    pub fn vflip(&self) -> bool {
+        self.attributes.vflip()
+    }
+
+    /// Sets the priority of the object relative to the backgrounds priority.  
+    /// Use [priority](Self::priority) to get the value
     pub fn set_priority(&mut self, priority: Priority) -> &mut Self {
         self.attributes.set_priority(priority);
 
         self
     }
 
-    /// Changes the sprite mode to be hidden, can be changed to Normal or Affine
-    /// modes using [`show`][ObjectUnmanaged::show] and
+    /// Returns the priority of the object  
+    /// Use [set_priority](Self::set_priority) to set the value
+    #[must_use]
+    pub fn priority(&self) -> Priority {
+        self.attributes.priority()
+    }
+
+    /// Changes the sprite mode to be hidden, can be changed to Normal or Affine  
+    /// modes using [`show`][ObjectUnmanaged::show] and  
     /// [`show_affine`][ObjectUnmanaged::show_affine] respectively.
     pub fn hide(&mut self) -> &mut Self {
         self.attributes.hide();
@@ -287,26 +311,52 @@ impl ObjectUnmanaged {
         self
     }
 
-    /// Sets the x position of the object.
+    /// Sets the x position of the object.  
+    /// Use [x](Self::x) to get the value  
+    /// Use [set_position](Self::set_position) to set both `x` and `y`
     pub fn set_x(&mut self, x: u16) -> &mut Self {
         self.attributes.set_x(x);
 
         self
     }
 
-    /// Sets the y position of the object.
+    /// Returns the x position of the object  
+    /// Use [set_x](Self::set_x) to set the value
+    #[must_use]
+    pub fn x(&self) -> u16 {
+        self.attributes.x()
+    }
+
+    /// Sets the y position of the object.  
+    /// Use [y](Self::y) to get the value  
+    /// Use [set_position](Self::set_position) to set both `x` and `y`
     pub fn set_y(&mut self, y: u16) -> &mut Self {
         self.attributes.set_y(y);
 
         self
     }
 
-    /// Sets the position of the object.
+    /// Returns the y position of the object  
+    /// Use [set_y](Self::set_y) to set the value
+    #[must_use]
+    pub fn y(&self) -> u16 {
+        self.attributes.y()
+    }
+
+    /// Sets the position of the object.  
+    /// Use [position](Self::position) to get the value
     pub fn set_position(&mut self, position: Vector2D<i32>) -> &mut Self {
         self.set_y(position.y.rem_euclid(1 << 9) as u16);
         self.set_x(position.x.rem_euclid(1 << 9) as u16);
 
         self
+    }
+
+    /// Returns the position of the object  
+    /// Use [set_position](Self::set_position) to set the value
+    #[must_use]
+    pub fn position(&self) -> Vector2D<i32> {
+        Vector2D::new(self.x() as i32, self.y() as i32)
     }
 
     /// Sets the affine matrix. This only has an affect in Affine mode.


### PR DESCRIPTION
This exposes expose the `hflip`, `vflip`, `priority` and `position` object attribute to remove the need for storing them in separate variables.
I think it might also be worth to update the pong tutorial and maybe some of the examples to highlight this.

- [x] Changelog updated / no changelog update needed
