### PR TITLE
Add an into_inner() function on infinite scrolled map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `.priority()`, `.set_priority()` and `.is_visible()` to `RegularMap`, `AffineMap` and `InfiniteScrolledMap`.
 - Replaced `.show()` and `.hide()` with `.set_visible()`in `RegularMap`, `AffineMap` and `InfiniteScrolledMap`.
+- Added `.into_inner()` to `InfiniteScrolledMap` to get the map back once you are done using it in the `InfiniteScrolledMap`.
 - Added `.hflip()`, `.vflip()`, `.priority()`, `.position()` to `ObjectUnmanaged` and `Object`.
 - An abstraction over hblank DMA to allow for cool effects like gradients and circular windows. See the dma_effect* examples.
 - Expermental and incomplete support for MIDI files with agb-tracker.

--- a/agb/src/display/tiled/infinite_scrolled_map.rs
+++ b/agb/src/display/tiled/infinite_scrolled_map.rs
@@ -431,6 +431,7 @@ impl<'a> InfiniteScrolledMap<'a> {
         self.map.background()
     }
 
+    /// Returns the underlying map back. The map will not be cleared.
     #[must_use]
     pub fn into_inner(self) -> MapLoan<'a, RegularMap> {
         self.map

--- a/agb/src/display/tiled/infinite_scrolled_map.rs
+++ b/agb/src/display/tiled/infinite_scrolled_map.rs
@@ -430,6 +430,11 @@ impl<'a> InfiniteScrolledMap<'a> {
     pub const fn background(&self) -> BackgroundID {
         self.map.background()
     }
+
+    #[must_use]
+    pub fn into_inner(self) -> MapLoan<'a, RegularMap> {
+        self.map
+    }
 }
 
 fn div_floor(x: i32, y: i32) -> i32 {


### PR DESCRIPTION
Adds a useful into_inner function which we need at the moment.

Will add a changelog and documentation later

- [x] Changelog updated
