### PR TITLE
Fix the incorrect copying of map tiles issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `.abs()` on `Vector2D` and `Rect`
+
+### Fixed
+
+- `InfiniteScrolledMap` can now scroll more than 1 tile in a single frame without corrupting.
+
 ## [0.19.0] - 2024/03/06
 
 ### Added
+
 - Added `.priority()`, `.set_priority()` and `.is_visible()` to `RegularMap`, `AffineMap` and `InfiniteScrolledMap`.
 - Replaced `.show()` and `.hide()` with `.set_visible()`in `RegularMap`, `AffineMap` and `InfiniteScrolledMap`.
 - Added `.into_inner()` to `InfiniteScrolledMap` to get the map back once you are done using it in the `InfiniteScrolledMap`.
@@ -20,21 +29,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Default` implementations for `RandomNumberGenerator`, `InitOnce` and `RawMutex`.
 
 ### Changed
+
 - A few functions which previously accepted a `Vector<u16>` now accept an `impl Into<Vector2D<u16>>` instead.
 
 ## [0.18.1] - 2024/02/06
 
 ### Added
+
 - You can now use include_aseprite and include_background_gfx to include files from the out directory using the `$OUT_DIR` token.
 - Added `.pause()` and `.resume()` methods to `SoundChannels` to let you pause and resume from where you left off.
 
 ## [0.18.0] - 2023/10/31
 
 ### Added
+
 - There is now a multiboot feature which you can use to easily make multiboot ROMs.
 - Can now set palette on a TileSetting struct.
 
 ### Changed
+
 - You no longer need the gba.ld or gba_mb.ld files in your repository. You should delete these when upgrading.
 
 ### Fixed

--- a/agb-fixnum/src/lib.rs
+++ b/agb-fixnum/src/lib.rs
@@ -759,6 +759,16 @@ impl<T: Number> SubAssign<Self> for Vector2D<T> {
     }
 }
 
+impl<T: FixedWidthSignedInteger> Vector2D<T> {
+    /// Calculates the absolute value of the x and y components.
+    pub fn abs(self) -> Self {
+        Self {
+            x: self.x.fixed_abs(),
+            y: self.y.fixed_abs(),
+        }
+    }
+}
+
 impl<I: FixedWidthUnsignedInteger, const N: usize> Vector2D<Num<I, N>> {
     #[must_use]
     /// Truncates the x and y coordinate, see [Num::trunc]
@@ -1070,6 +1080,20 @@ impl<T: FixedWidthUnsignedInteger> Rect<T> {
 
             Some((ret_x, y))
         })
+    }
+}
+
+impl<T: FixedWidthSignedInteger> Rect<T> {
+    /// Makes a rectangle that represents the equivalent location in space but with a positive size
+    pub fn abs(self) -> Self {
+        Self {
+            position: (
+                self.position.x + self.size.x.min(0.into()),
+                self.position.y + self.size.y.min(0.into()),
+            )
+                .into(),
+            size: self.size.abs(),
+        }
     }
 }
 

--- a/agb/src/display/tiled/infinite_scrolled_map.rs
+++ b/agb/src/display/tiled/infinite_scrolled_map.rs
@@ -306,15 +306,18 @@ impl<'a> InfiniteScrolledMap<'a> {
 
         self.current_pos = new_pos;
 
+        let old_tile_x = div_floor(old_pos.x, 8);
+        let old_tile_y = div_floor(old_pos.y, 8);
+
         let new_tile_x = div_floor(new_pos.x, 8);
         let new_tile_y = div_floor(new_pos.y, 8);
 
-        let difference_tile_x = div_ceil(difference.x, 8);
-        let difference_tile_y = div_ceil(difference.y, 8);
+        let difference_tile_x = new_tile_x - old_tile_x;
+        let difference_tile_y = new_tile_y - old_tile_y;
 
         let size = self.map.size();
 
-        let vertical_rect_to_update: Rect<i32> = if div_floor(old_pos.x, 8) != new_tile_x {
+        let vertical_rect_to_update: Rect<i32> = if difference_tile_x != 0 {
             // need to update the x line
             // calculate which direction we need to update
             let direction = difference.x.signum();
@@ -332,13 +335,14 @@ impl<'a> InfiniteScrolledMap<'a> {
 
             Rect::new(
                 (line_to_update, new_tile_y - 1).into(),
-                (difference_tile_x, y_tiles_to_update).into(),
+                (-difference_tile_x, y_tiles_to_update).into(),
             )
+            .abs()
         } else {
             Rect::new((0i32, 0).into(), (0i32, 0).into())
         };
 
-        let horizontal_rect_to_update: Rect<i32> = if div_floor(old_pos.y, 8) != new_tile_y {
+        let horizontal_rect_to_update: Rect<i32> = if difference_tile_y != 0 {
             // need to update the y line
             // calculate which direction we need to update
             let direction = difference.y.signum();
@@ -356,8 +360,9 @@ impl<'a> InfiniteScrolledMap<'a> {
 
             Rect::new(
                 (new_tile_x - 1, line_to_update).into(),
-                (x_tiles_to_update, difference_tile_y).into(),
+                (x_tiles_to_update, -difference_tile_y).into(),
             )
+            .abs()
         } else {
             Rect::new((0i32, 0).into(), (0i32, 0).into())
         };


### PR DESCRIPTION
* A very old issue that meant you couldn't move more than one tile per frame.
* This fixes the logic so we can move maps quickly.

- [x] Changelog updated
