### PR TITLE
Exclude tests / examples / benches from the published packages

### DIFF
--- a/agb-hashmap/Cargo.toml
+++ b/agb-hashmap/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MPL-2.0"
 description = "A simple no_std hashmap implementation intended for use in the `agb` library"
 repository = "https://github.com/agbrs/agb"
+exclude = ["/benches"]
 
 [features]
 allocator_api = []

--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -7,6 +7,7 @@ description = "Library for Game Boy Advance Development"
 license = "MPL-2.0"
 repository = "https://github.com/agbrs/agb"
 homepage = "https://agbrs.dev"
+exclude = ["/tests", "/examples"]
 
 [features]
 default = ["backtrace", "testing"]

--- a/tracker/agb-tracker/Cargo.toml
+++ b/tracker/agb-tracker/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 license = "MPL-2.0"
 description = "Library for playing tracker music. Designed for use with the agb library for the Game Boy Advance."
 repository = "https://github.com/agbrs/agb"
+exclude = ["/examples"]
 
 [features]
 default = ["xm", "midi"]


### PR DESCRIPTION
The package published to crates.io should not include tests / examples / benches. Previously we ran into issues with having a too large package from example data, but we avoided this by making the examples smaller. A better way to avoid this is to not include them at all.

- [x] no changelog update needed
