### PR TITLE
Group JS updates to reduce PR spam a little

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,25 @@
 {
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "ignorePresets": [
     ":prHourlyLimit2"
   ],
-  "dependencyDashboardAutoclose": true
+  "dependencyDashboardAutoclose": true,
+  "packageRules": [
+    {
+      "groupName": "Javascript packages (non-major)",
+      "groupSlug": "js-update",
+      "schedule": [
+        "on tuesday"
+      ],
+      "matchManagers": [
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]
+    }
+  ]
 }

--- a/justfile
+++ b/justfile
@@ -31,6 +31,9 @@ check-docs:
     (cd tracker/agb-tracker && cargo doc --target=thumbv4t-none-eabi --no-deps)
     cargo doc --no-deps
 
+validate-renovate:
+    npx --yes --package renovate -- renovate-config-validator
+
 _build_docs crate:
     (cd "{{crate}}" && cargo doc --no-deps)
 


### PR DESCRIPTION
Make renovate only update js dependencies once per week and to group them all in one PR.

Apparently with this branch name, renovate will validate the config for me which is fancy

- [x]  no changelog update needed
