### PR TITLE
Make backtraces optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a new crash screen which provides a mechanism for seeing a full stack trace of your program when it panics.
   This requires a change to your `.cargo/config.toml`. You must add the rust flag `"-Cforce-frame-pointers=yes"` to
-  your rustflags field.
+  your rustflags field. This can also be disabled by removing the `backtrace` feature.
 - Initial unicode support for font rendering.
 - Kerning support for font rendering.
 
@@ -52,7 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `.show()` and `.hide()` with `.set_visible()`in `RegularMap`, `AffineMap` and `InfiniteScrolledMap`.
 - Added `.into_inner()` to `InfiniteScrolledMap` to get the map back once you are done using it in the `InfiniteScrolledMap`.
 - Added `.hflip()`, `.vflip()`, `.priority()`, `.position()` to `ObjectUnmanaged` and `Object`.
-- An abstraction over hblank DMA to allow for cool effects like gradients and circular windows. See the dma_effect* examples.
+- An abstraction over hblank DMA to allow for cool effects like gradients and circular windows. See the dma_effect\* examples.
 - Expermental and incomplete support for MIDI files with agb-tracker.
 - Fixnum now implements [`num::Num`](https://docs.rs/num/0.4/num/trait.Num.html) from the [`num`](https://crates.io/crates/num) crate.
 - `Default` implementations for `RandomNumberGenerator`, `InitOnce` and `RawMutex`.

--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -8,7 +8,8 @@ license = "MPL-2.0"
 repository = "https://github.com/agbrs/agb"
 
 [features]
-default = ["testing"]
+default = ["backtrace", "testing"]
+backtrace = ["testing", "dep:qrcodegen-no-heap"]
 testing = []
 multiboot = []
 
@@ -20,7 +21,7 @@ agb_macros = { version = "0.19.1", path = "../agb-macros" }
 agb_fixnum = { version = "0.19.1", path = "../agb-fixnum" }
 agb_hashmap = { version = "0.19.1", path = "../agb-hashmap" }
 bilge = "0.2"
-qrcodegen-no-heap = "1.8"
+qrcodegen-no-heap = { version = "1.8", optional = true }
 portable-atomic = { version = "1.6.0", default-features = false, features = ["unsafe-assume-single-core"] }
 once_cell = { version = "1.19.0", default-features = false, features = ["critical-section"] }
 critical-section = { version = "1.1.2", features = ["restore-state-u16"] }

--- a/justfile
+++ b/justfile
@@ -4,18 +4,22 @@ CLIPPY_ARGUMENTS := "-Dwarnings -Dclippy::all -Aclippy::empty-loop"
 build: build-roms
 
 build-debug:
-    just _build-debug agb
-    just _build-debug tracker/agb-tracker
+    (cd agb && cargo build --no-default-features)
+    (cd agb && cargo build --no-default-features --features=testing)
+    (cd agb && cargo build --examples --tests)
+
+    (cd tracker/agb-tracker && cargo build --examples --tests)
+
 build-release:
-    just _build-release agb
-    just _build-release tracker/agb-tracker
+    (cd agb && cargo build --examples --tests --release)
+
 clippy:
     just _all-crates _clippy
 
 test:
     just _test-debug agb
-    just _test-multiboot
     just _test-debug tracker/agb-tracker
+    just _test-multiboot
     just _test-debug-arm agb
 
 test-release:
@@ -147,17 +151,11 @@ _all-crates target:
         just "{{target}}" "$PROJECT_DIR" || exit $?; \
     done
 
-_build-debug crate:
-    (cd "{{crate}}" && cargo build --examples --tests)
-_build-release crate:
-    (cd "{{crate}}" && cargo build --release --examples --tests)
 _test-release crate:
-    just _build-release {{crate}}
     (cd "{{crate}}" && cargo test --release)
 _test-release-arm crate:
     (cd "{{crate}}" && cargo test --release --target=armv4t-none-eabi)
 _test-debug crate:
-    just _build-debug {{crate}}
     (cd "{{crate}}" && cargo test)
 _test-debug-arm crate:
     (cd "{{crate}}" && cargo test --target=armv4t-none-eabi)


### PR DESCRIPTION
You probably don't want backtraces if you're doing multiboot and in a few other cases.

Also #646 broke the build if you didn't use the `testing` feature, so I've updated the `justfile` so that a CI run checks that agb builds correctly both without the `testing` feature and without the `backtrace` feature. The `backtrace` feature implies the testing feature to make things a bit simpler.

- [x] Changelog updated
