### PR TITLE
Add a set_next method on OamIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   your rustflags field. This can also be disabled by removing the `backtrace` feature.
 - Initial unicode support for font rendering.
 - Kerning support for font rendering.
+- Added `set_next` method to `OamIterator` to avoid repeated boilerplate when dealing with unmanaged objects.
 
 ### Fixed
 

--- a/agb/src/display/object/unmanaged/object.rs
+++ b/agb/src/display/object/unmanaged/object.rs
@@ -75,7 +75,7 @@ impl<'oam> OamIterator<'oam> {
     /// Sets the next oam slot with the provided `object`.
     ///
     /// Is equivalent to the following:
-    /// ```rust
+    /// ```no_run
     /// # #![no_main]
     /// # #![no_std]
     /// # use agb::display::object::{OamIterator, ObjectUnmanaged};

--- a/agb/src/display/object/unmanaged/object.rs
+++ b/agb/src/display/object/unmanaged/object.rs
@@ -71,6 +71,27 @@ pub struct OamIterator<'oam> {
     frame_data: &'oam UnsafeCell<OamFrameModifyables>,
 }
 
+impl<'oam> OamIterator<'oam> {
+    /// Sets the next oam slot with the provided `object`.
+    ///
+    /// Is equivalent to the following:
+    /// ```rust
+    /// # #![no_main]
+    /// # #![no_std]
+    /// # use agb::display::object::{OamIterator, ObjectUnmanaged};
+    /// # fn set_next_example(oam_iterator: &mut OamIterator, object: &ObjectUnmanaged) {
+    /// if let Some(slot) = oam_iterator.next() {
+    ///     slot.set(object);
+    /// }
+    /// # }
+    /// ```
+    pub fn set_next(&mut self, object: &ObjectUnmanaged) {
+        if let Some(slot) = self.next() {
+            slot.set(object);
+        }
+    }
+}
+
 /// A slot in Oam that you can write to. Note that you must call [OamSlot::set]
 /// or else it is a bug and will panic when dropped.
 ///


### PR DESCRIPTION
It was annoying me how often I had to write this

- [x] Changelog updated
