### PR TITLE
Add windows instructions

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -5,7 +5,7 @@
 - [Running an example](./setup/getting_started.md)
   - [Environment setup](./setup/setup.md)
     - [Linux setup](./setup/linux.md)
-    - [Windows setup]()
+    - [Windows setup](./setup/windows.md)
     - [Mac OS setup](./setup/mac.md)
   - [Building the template](./setup/building.md)
 - [Learn agb part I - pong](./pong/01_introduction.md)

--- a/book/src/pong/03_sprites.md
+++ b/book/src/pong/03_sprites.md
@@ -63,9 +63,9 @@ Using the `Gba` struct we get the [`ObjectController` struct](https://docs.rs/ag
 
 ```rust
 #[agb::entry]
-fn main(gba: mut agb::Gba) -> ! {
+fn main(mut gba: agb::Gba) -> ! {
     // Get the object manager
-    let object = gba.display.object.get();
+    let object = gba.display.object.get_managed();
 
     // Create an object with the ball sprite
     let mut ball = object.object_sprite(BALL.sprite(0));

--- a/book/src/setup/building.md
+++ b/book/src/setup/building.md
@@ -35,13 +35,13 @@ To do this, we'll use the tool `agb-gbafix`.
 Run the following command to convert the binary file to a GBA ROM:
 
 ```sh
-agb-gbafix target/thumbv4t-none-eabi/release/template -o template.gba
+agb-gbafix target/thumbv4t-none-eabi/release/agb_template -o agb_template.gba
 ```
 
 or
 
 ```sh
-agb-gbafix target/thumbv4t-none-eabi/release/template.elf -o template.gba
+agb-gbafix target/thumbv4t-none-eabi/release/agb_template.elf -o agb_template.gba
 ```
 
 This command will add the correct GBA header to the template.gba file and it will be playable on real hardware or an emulator.

--- a/book/src/setup/windows.md
+++ b/book/src/setup/windows.md
@@ -1,0 +1,37 @@
+# Windows setup
+
+This guide has been tested on Windows 11 using PowerShell with elevated rights _(dont use cmd)_.
+
+# 1. Install a recent version of rust
+
+To use agb, you'll need to use nightly rust since it requires a few nightly features.
+Firstly, ensure that you have **rustup** installed which you can do by following the instructions on the [rust website](https://www.rust-lang.org/tools/install)
+
+If you have installed rustup, you can update it with `rustup update`.  
+If the `rustup`-command fails, you'll most probably add the cargo/bin folder to the Path-environment variable.
+
+
+# 2. git
+
+The source code for the game is hosted on github, so you will need to install git.
+
+You'd need to follow this official github git [guide](https://github.com/git-guides/install-git).
+
+# 3. mGBA
+
+We recommend using the mGBA emulator which you can download for Mac [here](https://mgba.io/downloads.html).
+
+After installing, you can add the binary to your Path-environment variable and create an alias for the agb run command to use.
+
+Creating link for mgba-qt:
+```PS
+New-Item -itemtype hardlink -path "C:\Program Files\mGBA\mgba-qt.exe" -value "C:\Program Files\mGBA\mGBA.exe"
+```
+
+# 4. gbafix
+
+In order to be able to play games made with agb on real hardware or on some emulators, you will need to install 'agb-gbafix'.
+Agb's implementation can be installed very easily using `cargo install agb-gbafix`.
+
+That is all you need to get started!
+You can now move on to 'building the game'.

--- a/book/src/setup/windows.md
+++ b/book/src/setup/windows.md
@@ -19,7 +19,7 @@ You'd need to follow this official github git [guide](https://github.com/git-gui
 
 # 3. mGBA
 
-We recommend using the mGBA emulator which you can download for Mac [here](https://mgba.io/downloads.html).
+We recommend using the mGBA emulator which you can download from [here](https://mgba.io/downloads.html).
 
 After installing, you can add the binary to your Path-environment variable and create an alias for the agb run command to use.
 


### PR DESCRIPTION
Closes #691

* Added Windows instruction for the setup
* fixed the path to the example, adjusted to the cargo-project name
* fixed broken code in the example

Original PR contains an extra merge commit we don't want, so this avoids that.

- [x] no changelog update needed
