### PR TITLE
[agb] Added function to change the text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `dot` and `cross` product methods for `Vector2D`.
+- Added `set_foreground_colour` and `set_background_colour` methods for `TextRenderer`.
 
 ### Fixed
 

--- a/agb/src/display/font.rs
+++ b/agb/src/display/font.rs
@@ -154,6 +154,16 @@ impl<'a, 'b> TextWriter<'a, 'b> {
     pub fn commit(self) {
         self.text_renderer.commit(self.bg, self.vram_manager);
     }
+
+    pub fn set_foreground_colour(&mut self, colour: u8) -> &mut Self {
+        self.foreground_colour = colour;
+        self
+    }
+
+    pub fn set_background_colour(&mut self, colour: u8) -> &mut Self {
+        self.background_colour = colour;
+        self
+    }
 }
 
 fn div_ceil(quotient: i32, divisor: i32) -> i32 {


### PR DESCRIPTION
Currently you need to create a new writer everytime you want to change the color of the text.   
I implemented these 2 functions to make it more straight forward and to recycle the writer instead of creating a new one for each color.  

`set_foreground_colour` and `set_background_colour` can be used like this:

```Rust
    gba_write!(&mut writer, "Lorem ipsum dolor sit amet,").unwrap();
    writer.set_foreground_colour(2);
    gba_write!(&mut writer, "consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt.").unwrap();
    writer.set_foreground_colour(3);
    gba_write!(&mut writer, "ut labore et dolore magna aliquyam erat, sed diam voluptua.").unwrap();
    writer.set_foreground_colour(5);
    gba_write!(&mut writer, "At vero eos et accusam et justo duo dolores et ea rebum.").unwrap();
    writer.set_foreground_colour(6).set_background_colour(1);
    gba_write!(&mut writer, "Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.").unwrap();
```


- [x] Changelog updated 

