### PR TITLE
The link register points to the next instruction, not the current one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Affine background center position didn't work outside of the upper left quadrant of the gba's screen.
+- Fixed backtrace pointing to the wrong line of code (being out by one).
 
 ## [0.20.2] - 2024/05/25
 

--- a/agb/src/backtrace.rs
+++ b/agb/src/backtrace.rs
@@ -77,7 +77,10 @@ pub(crate) fn unwind_exception() -> Frames {
             break;
         }
 
-        frames.push(lr);
+        // need to subtract 2 here since the link register points to the _next_ instruction
+        // to execute, not the one that is being branched from which is the one we care about
+        // in the stack trace.
+        frames.push(lr - 2);
 
         frame_pointer = sp;
     }

--- a/agb/src/entrypoint.s
+++ b/agb/src/entrypoint.s
@@ -80,8 +80,12 @@ CommonInit:
     ldr r0, =0
     mov r1, r0
 
+    @ ensure the frame pointer is zero so that stack traces are guaranteed to terminate
+    mov r7, r0
+
     @ load main and branch
     ldr r2, =main
+    mov lr, pc
     bx  r2
 
     @ loop if we end up here


### PR DESCRIPTION
agb-debug was producing some bad backtraces which was being caused by the fact that we were producing slightly incorrect values which made bigger examples of backtraces completely useless.

I could fix this in agb-debug, but I feel like the correct place to do this is just fixing agb.

- [x] Changelog updated
