### PR TITLE
Mix rng in a hard to predict way

### DIFF
--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -26,6 +26,7 @@ qrcodegen-no-heap = { version = "1.8", optional = true }
 portable-atomic = { version = "1.6.0", default-features = false, features = ["unsafe-assume-single-core"] }
 once_cell = { version = "1.19.0", default-features = false, features = ["critical-section"] }
 critical-section = { version = "1.1.2", features = ["restore-state-u16"] }
+rustc-hash = { version = "1", default-features = false }
 
 [package.metadata.docs.rs]
 default-target = "thumbv4t-none-eabi"


### PR DESCRIPTION
- [ ] Changelog updated / no changelog update needed

You might look at the registers I chose and think that they're all dependent on player input, indeed everything is so why bother including anything except player input? Well, if you were to do a computer search for an optimal rng sequence now I think you'd have to run a full GBA emulator to get the timing right.