### PR TITLE
Fix tilemap gaps in affine graphic modes #733

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Kludge fix for tilemap gaps in affine graphics modes.
+
 ## [0.20.5] - 2024/06/18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Kludge fix for tilemap gaps in affine graphics modes.
+- There are no longer gaps between tiles in affine graphics modes.
 
 ## [0.20.5] - 2024/06/18
 

--- a/agb/src/display/tiled/map.rs
+++ b/agb/src/display/tiled/map.rs
@@ -30,7 +30,6 @@ trait TiledMapPrivate: TiledMapTypes {
 
     fn background_id(&self) -> usize;
     fn screenblock(&self) -> usize;
-    fn priority(&self) -> Priority;
     fn map_size(&self) -> Self::Size;
 
     fn update_bg_registers(&self);
@@ -217,9 +216,6 @@ impl TiledMapPrivate for RegularMap {
     fn screenblock(&self) -> usize {
         self.screenblock as usize
     }
-    fn priority(&self) -> Priority {
-        self.priority
-    }
     fn map_size(&self) -> Self::Size {
         self.size
     }
@@ -400,9 +396,6 @@ impl TiledMapPrivate for AffineMap {
     }
     fn screenblock(&self) -> usize {
         self.screenblock as usize
-    }
-    fn priority(&self) -> Priority {
-        self.priority
     }
     fn map_size(&self) -> Self::Size {
         self.size

--- a/agb/src/display/tiled/map.rs
+++ b/agb/src/display/tiled/map.rs
@@ -15,7 +15,6 @@ use super::{
 };
 
 use alloc::{vec, vec::Vec};
-use crate::display::tiled::TileFormat::FourBpp;
 
 pub trait TiledMapTypes: private::Sealed {
     type Size: BackgroundSize + Copy;
@@ -90,8 +89,8 @@ impl TiledMap for AffineMap
         let screenblock_memory = self.screenblock_memory() as *mut u8;
 
         if *self.tiles_dirty() {
+            let tiledata: Vec<u8> = self.tiles_mut().iter().map(|a| a.tile_index(TileFormat::EightBpp).raw_index() as u8).collect();
             unsafe {
-                let tiledata: Vec<u8> = self.tiles_mut().iter().map(|a| a.tile_index(FourBpp).raw_index() as u8).collect();
                 screenblock_memory.copy_from(
                     tiledata.as_ptr(),
                     self.map_size().num_tiles(),

--- a/agb/src/display/tiled/map.rs
+++ b/agb/src/display/tiled/map.rs
@@ -52,8 +52,7 @@ pub trait TiledMap: TiledMapTypes {
     fn size(&self) -> Self::Size;
 }
 
-impl TiledMap for AffineMap
-{
+impl TiledMap for AffineMap {
     fn clear(&mut self, vram: &mut VRamManager) {
         let colours = self.colours();
 
@@ -88,12 +87,13 @@ impl TiledMap for AffineMap
         let screenblock_memory = self.screenblock_memory() as *mut u8;
 
         if *self.tiles_dirty() {
-            let tiledata: Vec<u8> = self.tiles_mut().iter().map(|a| a.tile_index(TileFormat::EightBpp).raw_index() as u8).collect();
+            let tiledata: Vec<u8> = self
+                .tiles_mut()
+                .iter()
+                .map(|a| a.tile_index(TileFormat::EightBpp).raw_index() as u8)
+                .collect();
             unsafe {
-                screenblock_memory.copy_from(
-                    tiledata.as_ptr(),
-                    self.map_size().num_tiles(),
-                );
+                screenblock_memory.copy_from(tiledata.as_ptr(), self.map_size().num_tiles());
             }
         }
 
@@ -116,8 +116,7 @@ impl TiledMap for AffineMap
         self.map_size()
     }
 }
-impl TiledMap for RegularMap
-{
+impl TiledMap for RegularMap {
     fn clear(&mut self, vram: &mut VRamManager) {
         let colours = self.colours();
 


### PR DESCRIPTION
- [x] Changelog updated
Fixes issue #733 where affine tilemaps have a gap.