### PR TITLE
Allowing imported graphics to be exposed as pub mod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - There are no longer gaps between tiles in affine graphics modes.
 
+### Added
+- Added option to export imported background graphics from `include_background_gfx` as pub.
+
 ## [0.20.5] - 2024/06/18
 
 ### Fixed

--- a/agb-image-converter/src/lib.rs
+++ b/agb-image-converter/src/lib.rs
@@ -197,7 +197,7 @@ pub fn include_background_gfx(input: TokenStream) -> TokenStream {
     let root = std::env::var("CARGO_MANIFEST_DIR").expect("Failed to get cargo manifest dir");
 
     let module_name = config.module_name.clone();
-    let as_pub = config.as_pub.clone();
+    let as_pub = config.as_pub;
     include_gfx_from_config(config, as_pub, module_name, Path::new(&root))
 }
 

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -106,6 +106,15 @@
 /// # use agb::include_background_gfx;
 /// include_background_gfx!(generated_background, "000000", DATA => "$OUT_DIR/generated_background.aseprite");
 /// ```
+///
+/// You can also make the exported background a public module which will allow other modules access them. The following
+/// will declare `water_tiles` as a `pub mod` rather than a `mod`.
+///
+/// ```rust,no_run
+/// ##![no_std]
+/// ##![no_main]
+/// agb::include_background_gfx!(pub water_tiles, tiles => "examples/water_tiles.png");
+/// ```
 pub use agb_image_converter::include_background_gfx;
 
 #[doc(hidden)]


### PR DESCRIPTION

- [X] Changelog updated

This PR adds the possibility for graphics imported through `include_background_gfx!` to be used as public modules, e.g.:
```rust
/// graphics.rs
agb::include_background_gfx!(pub background, "d77bba", tiles256 => 256 "map.aseprite");

/// main.rs
#![no_std]
#![no_main]

use agb::display::Priority;
use agb::display::tiled::RegularBackgroundSize::Background64x64;
use agb::display::tiled::{TiledMap, TileFormat};

mod graphics;


#[agb::entry]
fn main(mut gba: agb::Gba) -> ! {
    let (tiled, mut vram) = gba.display.video.tiled1();
    let vblank = agb::interrupt::VBlank::get();
    let tileset = &graphics::background::tiles256.tiles;

    vram.set_background_palettes(graphics::background::PALETTES);

    let mut bg = tiled.regular(Priority::P2, Background64x64, TileFormat::EightBpp);

    for y in 0..64u16 {
        for x in 0..64u16 {
            bg.set_tile(&mut vram, (x, y), tileset, graphics::background::tiles256.tile_settings[1]);
        }
    }
    bg.set_visible(true);
    bg.commit(&mut vram);

    loop {
        vblank.wait_for_vblank();
    }
}
```