### PR TITLE
Add template to workspace exclude

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,6 @@ exclude = [
     "examples/the-purple-night",
 
     "book/games/pong",
+
+    "template",
 ]


### PR DESCRIPTION
Avoids a warning in rust-analyzer and is the correct thing to do

- [x] no changelog update needed
