### PR TITLE
Shorten the first paragraphs

### DIFF
--- a/agb/src/agb_alloc/mod.rs
+++ b/agb/src/agb_alloc/mod.rs
@@ -61,9 +61,10 @@ macro_rules! impl_zst_allocator {
 
 pub(crate) use impl_zst_allocator;
 
-/// This is the allocator for the External Working Ram. This is currently
-/// equivalent to the Global Allocator (where things are allocated if no allocator is provided). This implements the allocator trait, so
-/// is meant to be used in specifying where certain structures should be
+/// This is the allocator for the External Working Ram.
+///
+/// This is currently equivalent to the Global Allocator (where things are allocated if no allocator is provided).
+/// This implements the allocator trait, so is meant to be used in specifying where certain structures should be
 /// allocated.
 ///
 /// ```rust,no_run

--- a/agb/src/display/object/affine.rs
+++ b/agb/src/display/object/affine.rs
@@ -14,10 +14,12 @@ struct AffineMatrixData {
 #[derive(Debug, Clone)]
 pub(crate) struct AffineMatrixVram(Rc<AffineMatrixData>);
 
-/// An affine matrix that can be used on objects. It is just in time copied to
-/// vram, so you can have as many as you like of these but you can only use up
-/// to 16 in one frame. They are reference counted (Cloning is cheap) and
-/// immutable, if you want to change a matrix you must make a new one and set it
+/// An affine matrix that can be used on objects.
+///
+/// It is just in time copied to vram, so you can have as many as you like
+/// of these but you can only use up to 16 in one frame. They are reference
+/// counted (Cloning is cheap) and immutable, if you want to change a matrix
+/// you must make a new one and set it
 /// on all your objects.
 #[derive(Debug, Clone)]
 pub struct AffineMatrixInstance {

--- a/agb/src/display/object/sprites/sprite.rs
+++ b/agb/src/display/object/sprites/sprite.rs
@@ -74,8 +74,9 @@ macro_rules! align_bytes {
     }};
 }
 
-/// Includes sprites found in the referenced aseprite files. Can include
-/// multiple at once and optimises palettes of all included in the single call
+/// Includes sprites found in the referenced aseprite files.
+///
+/// Can include multiple at once and optimises palettes of all included in the single call
 /// together. See [Size] for supported sizes. Returns a reference to [Graphics].
 ///
 /// ```rust,no_run

--- a/agb/src/display/window.rs
+++ b/agb/src/display/window.rs
@@ -6,9 +6,11 @@ use crate::{dma, fixnum::Rect, memory_mapped::MemoryMapped};
 
 use super::{tiled::BackgroundID, DISPLAY_CONTROL, HEIGHT, WIDTH};
 
-/// The windows feature of the Game Boy Advance can selectively display
-/// backgrounds or objects on the screen and can selectively enable and disable
-/// effects. This gives out references and holds changes before they can be committed.
+/// Access to the windows feature of the Game Boy Advance.
+///
+/// The windows feature can selectively display backgrounds or objects on the screen
+/// and can selectively enable and disable effects. This gives out references and
+/// holds changes before they can be committed.
 pub struct Windows<'gba> {
     wins: [MovableWindow; 2],
     out: Window,

--- a/agb/src/interrupt.rs
+++ b/agb/src/interrupt.rs
@@ -342,6 +342,8 @@ impl VBlank {
 }
 
 #[must_use]
+/// A basic profiler you can use to find hot functions in your code.
+///
 /// The behaviour of this function is undefined in the sense that it will output
 /// some information in some way that can be interpreted in a way to give some
 /// profiling information. What it outputs, how it outputs it, and how to

--- a/agb/src/sound/mixer/mod.rs
+++ b/agb/src/sound/mixer/mod.rs
@@ -125,9 +125,11 @@ enum SoundPriority {
     Low,
 }
 
-/// The supported frequencies within AGB. These are chosen to work well with
-/// the hardware. Note that the higher the frequency, the better the quality of
-/// the sound but the more CPU time sound mixing will take.
+/// The supported frequencies within AGB.
+///
+/// These are chosen to work well with/ the hardware. Note that the higher
+/// the frequency, the better the quality of the sound but the more CPU time
+///  sound mixing will take.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Frequency {


### PR DESCRIPTION
Clippy was complaining that our first paragraphs were too long

- [x] no changelog update needed
