### PR TITLE
It doesn't appear to be an error to have an invalid instrument index

### DIFF
--- a/tracker/agb-xm-core/src/lib.rs
+++ b/tracker/agb-xm-core/src/lib.rs
@@ -112,8 +112,10 @@ pub fn parse_module(module: &Module) -> agb_tracker_interop::Track {
                 } else {
                     let instrument_index = (slot.instrument - 1) as usize;
 
-                    if let InstrumentType::Default(ref instrument) =
-                        module.instrument[instrument_index].instr_type
+                    if let Some(InstrumentType::Default(ref instrument)) = module
+                        .instrument
+                        .get(instrument_index)
+                        .map(|instrument| &instrument.instr_type)
                     {
                         let sample_slot = *instrument
                             .sample_for_note


### PR DESCRIPTION
I've seen an xm file that plays fine in milkytracker and other places, but has instrument indexes which are too high. They are just treated as non-existent :)

- [x] no changelog update needed
