### PR TITLE
Add a method to stop the tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for vibrato in `agb-tracker`'s XM format
+- Method to stop the tracker
 
 ### Changed
 
@@ -17,9 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unless you've been using `default-features = false` in which case we recommend removing that from your `Cargo.toml`.
 
 ### Fixed
+
 - There are no longer gaps between tiles in affine graphics modes.
 
 ### Added
+
 - Added option to export imported background graphics from `include_background_gfx` as pub.
 
 ## [0.20.5] - 2024/06/18

--- a/tracker/agb-tracker/src/lib.rs
+++ b/tracker/agb-tracker/src/lib.rs
@@ -286,6 +286,21 @@ impl<'track, TChannelId> TrackerInner<'track, TChannelId> {
         self.realise(mixer);
     }
 
+    /// Stops all channels.
+    ///
+    /// It is expected that you don't call step after this. But doing so will continue from
+    /// where you left off. However, notes which were playing won't resume.
+    pub fn stop<M: Mixer<ChannelId = TChannelId>>(&mut self, mixer: &mut M) {
+        for channel_id in &mut self.mixer_channels {
+            if let Some(channel) = channel_id
+                .take()
+                .and_then(|channel_id| mixer.channel(&channel_id))
+            {
+                channel.stop();
+            }
+        }
+    }
+
     fn realise<M: Mixer<ChannelId = TChannelId>>(&mut self, mixer: &mut M) {
         for (i, (mixer_channel, tracker_channel)) in self
             .mixer_channels


### PR DESCRIPTION
I've done some horrible hacks for this in our jam games. Better to have a first-party solution to stopping channels in the tracker.

- [x] Changelog updated 