### PR TITLE
Upgrade xmrs which gives us s3m and mod file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for s3m and mod format files to `agb-tracker`.
+
 ## [0.21.0] - 2024/09/24
 
 ### Added

--- a/tracker/agb-tracker/src/lib.rs
+++ b/tracker/agb-tracker/src/lib.rs
@@ -79,6 +79,14 @@ use agb_fixnum::Num;
 #[cfg(feature = "xm")]
 pub use agb_xm::include_xm;
 
+/// Import an S3M file. Only available if you have the `xm` feature enabled (enabled by default).
+#[cfg(feature = "xm")]
+pub use agb_xm::include_s3m;
+
+/// Import a MOD file. Only available if you have the `xm` feature enabled (enabled by default).
+#[cfg(feature = "xm")]
+pub use agb_xm::include_mod;
+
 /// Import a midi file. Only available if you have the `midi` feature enabled (enabled by default).
 /// This is currently experimental, and many types of MIDI file or MIDI features are not supported.
 ///

--- a/tracker/agb-xm-core/Cargo.toml
+++ b/tracker/agb-xm-core/Cargo.toml
@@ -16,4 +16,4 @@ syn = "2"
 agb_tracker_interop = { version = "0.21.0", path = "../agb-tracker-interop", default-features = false }
 agb_fixnum = { version = "0.21.0", path = "../../agb-fixnum" }
 
-xmrs = { version = "0.7.0", features = ["std"] }
+xmrs = { version = "0.7.2", features = ["std"] }

--- a/tracker/agb-xm-core/Cargo.toml
+++ b/tracker/agb-xm-core/Cargo.toml
@@ -16,4 +16,4 @@ syn = "2"
 agb_tracker_interop = { version = "0.21.0", path = "../agb-tracker-interop", default-features = false }
 agb_fixnum = { version = "0.21.0", path = "../../agb-fixnum" }
 
-xmrs = { version = "0.6.1", features = ["std"] }
+xmrs = { version = "0.7.0", features = ["std"] }

--- a/tracker/agb-xm/Cargo.toml
+++ b/tracker/agb-xm/Cargo.toml
@@ -19,4 +19,4 @@ proc-macro2 = "1"
 quote = "1"
 syn = "2"
 
-xmrs = "0.6"
+xmrs = "0.7"

--- a/tracker/agb-xm/src/lib.rs
+++ b/tracker/agb-xm/src/lib.rs
@@ -5,12 +5,27 @@ use proc_macro::TokenStream;
 use proc_macro_error::{abort, proc_macro_error};
 use quote::quote;
 use syn::LitStr;
-use xmrs::{module::Module, xm::xmmodule::XmModule};
+use xmrs::{
+    amiga::amiga_module::AmigaModule, module::Module, s3m::s3m_module::S3mModule,
+    xm::xmmodule::XmModule,
+};
 
 #[proc_macro_error]
 #[proc_macro]
 pub fn include_xm(args: TokenStream) -> TokenStream {
-    agb_xm_core(args, parse_xm)
+    agb_xm_core(args, |content| Ok(XmModule::load(content)?.to_module()))
+}
+
+#[proc_macro_error]
+#[proc_macro]
+pub fn include_s3m(args: TokenStream) -> TokenStream {
+    agb_xm_core(args, |content| Ok(S3mModule::load(content)?.to_module()))
+}
+
+#[proc_macro_error]
+#[proc_macro]
+pub fn include_mod(args: TokenStream) -> TokenStream {
+    agb_xm_core(args, |content| Ok(AmigaModule::load(content)?.to_module()))
 }
 
 fn agb_xm_core(
@@ -49,8 +64,4 @@ fn agb_xm_core(
         }
     }
     .into()
-}
-
-fn parse_xm(file_content: &[u8]) -> Result<Module, Box<dyn Error>> {
-    Ok(XmModule::load(file_content)?.to_module())
 }

--- a/tracker/desktop-player/Cargo.toml
+++ b/tracker/desktop-player/Cargo.toml
@@ -12,6 +12,7 @@ agb_xm_core = { version = "0.21.0", path = "../agb-xm-core" }
 agb_tracker = { version = "0.21.0", path = "../agb-tracker", default-features = false }
 agb_fixnum = { version = "0.21.0", path = "../../agb-fixnum" }
 
+anyhow = "1"
 xmrs = "0.7"
 
 cpal = "0.15"

--- a/tracker/desktop-player/Cargo.toml
+++ b/tracker/desktop-player/Cargo.toml
@@ -12,6 +12,6 @@ agb_xm_core = { version = "0.21.0", path = "../agb-xm-core" }
 agb_tracker = { version = "0.21.0", path = "../agb-tracker", default-features = false }
 agb_fixnum = { version = "0.21.0", path = "../../agb-fixnum" }
 
-xmrs = "0.6"
+xmrs = "0.7"
 
 cpal = "0.15"


### PR DESCRIPTION
Closes #742

Turns out XMRS will do the conversion for us, which means we can 'just support' s3m and mod file formats for free which is nice.

- [x] Changelog updated / no changelog update needed
