### PR TITLE
Fix build issue due to atomic u128s

### DIFF
--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -24,8 +24,8 @@ agb_fixnum = { version = "0.21.0", path = "../agb-fixnum" }
 agb_hashmap = { version = "0.21.0", path = "../agb-hashmap", features = ["allocator_api"] }
 bilge = "0.2"
 qrcodegen-no-heap = { version = "1.8", optional = true }
-portable-atomic = { version = "1.6.0", default-features = false, features = ["unsafe-assume-single-core"] }
-once_cell = { version = "1.19.0", default-features = false, features = ["critical-section"] }
+portable-atomic = { version = "1.6.0", default-features = false, features = ["unsafe-assume-single-core", "fallback"] }
+once_cell = { version = "1.20.1", default-features = false, features = ["critical-section"] }
 critical-section = { version = "1.1.2", features = ["restore-state-u16"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Add fallback feature for portable-atomic.

This is needed since without it, we don't get anything that the platform doesn't natively support, which is only up to 32 bits.

We newly need to change this because once_cell no longer imports with default features.

Fixes:
```
error[E0432]: unresolved import `portable_atomic::AtomicU128`
 --> src/rng.rs:1:23
  |
1 | use portable_atomic::{AtomicU128, Ordering};
  |                       ^^^^^^^^^^
  |                       |
  |                       no `AtomicU128` in the root
  |                       help: a similar name exists in the module: `AtomicU8`
```

- [x] no changelog update needed
