### PR TITLE
Don't use ok_or_else for a copy value

### DIFF
--- a/agb-debug/src/load_dwarf.rs
+++ b/agb-debug/src/load_dwarf.rs
@@ -27,7 +27,7 @@ pub fn load_dwarf(file_content: &[u8]) -> Result<GimliDwarf, LoadDwarfError> {
     let last_non_zero_byte = file_content
         .iter()
         .rposition(|&b| b != 0)
-        .ok_or_else(|| LoadDwarfError::GbaFileEmpty)?;
+        .ok_or(LoadDwarfError::GbaFileEmpty)?;
 
     let file_content = &file_content[..last_non_zero_byte + 1];
 


### PR DESCRIPTION
Needed to fix today's clippy linting error

- [x]  no changelog update needed
