### PR TITLE
Fix the xmrs version since we've had failures twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed build error due to breaking change in `xmrs`.
+
 ## [0.21.1] - 2024/10/02
 
 ### Added

--- a/tracker/agb-xm-core/Cargo.toml
+++ b/tracker/agb-xm-core/Cargo.toml
@@ -16,4 +16,4 @@ syn = "2"
 agb_tracker_interop = { version = "0.21.1", path = "../agb-tracker-interop", default-features = false }
 agb_fixnum = { version = "0.21.1", path = "../../agb-fixnum" }
 
-xmrs = { version = "0.8.0", features = ["std", "import"] }
+xmrs = { version = "=0.8.1", features = ["std", "import"] }

--- a/tracker/agb-xm/Cargo.toml
+++ b/tracker/agb-xm/Cargo.toml
@@ -19,4 +19,4 @@ proc-macro2 = "1"
 quote = "1"
 syn = "2"
 
-xmrs = "0.8"
+xmrs = "=0.8.1"

--- a/tracker/desktop-player/Cargo.toml
+++ b/tracker/desktop-player/Cargo.toml
@@ -13,6 +13,6 @@ agb_tracker = { version = "0.21.1", path = "../agb-tracker", default-features = 
 agb_fixnum = { version = "0.21.1", path = "../../agb-fixnum" }
 
 anyhow = "1"
-xmrs = "0.8"
+xmrs = "=0.8.1"
 
 cpal = "0.15"


### PR DESCRIPTION
Will need to release 0.21.2 after this is merged since current no lockfile builds are failing.

- [x] change log updated
