### PR TITLE
Make set_background_palette public

### DIFF
--- a/agb/src/display/tiled/vram_manager.rs
+++ b/agb/src/display/tiled/vram_manager.rs
@@ -419,7 +419,8 @@ impl VRamManager {
         }
     }
 
-    fn set_background_palette(&mut self, pal_index: u8, palette: &palette16::Palette16) {
+    pub fn set_background_palette(&mut self, pal_index: u8, palette: &palette16::Palette16) {
+        assert!(pal_index < 16);
         for (colour_index, &colour) in palette.colours.iter().enumerate() {
             PALETTE_BACKGROUND.set(colour_index + 16 * pal_index as usize, colour);
         }


### PR DESCRIPTION
This makes set_background_palette public so that one can set a specific background palette, not only write the entire bank at once with set_background_palettes.

- [ ] Changelog updated / no changelog update needed
