### PR TITLE
Don't need both no_mangle and export_name

### DIFF
--- a/agb/src/interrupt.rs
+++ b/agb/src/interrupt.rs
@@ -140,7 +140,6 @@ static INTERRUPT_TABLE: SyncUnsafeCell<[InterruptRoot; 14]> = SyncUnsafeCell::ne
     InterruptRoot::new(Interrupt::Gamepak),
 ]);
 
-#[no_mangle]
 #[export_name = "__RUST_INTERRUPT_HANDLER"]
 extern "C" fn interrupt_handler(interrupt: u16) -> u16 {
     for (i, root) in unsafe { &mut *INTERRUPT_TABLE.get() }.iter().enumerate() {


### PR DESCRIPTION
Fix for clippy lints

- [x] no changelog update needed
