### PR TITLE
only have a panic handler when using the either of the default testing or backtrace features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional serde support for agb-hashmap via the `serde` feature flag
 - Added `set_background_palette` to be able to set a single background palette.
 
+### Changed
+
+- Using neither of the testing and backtrace features will mean there is no panic handler.
+
 ### Fixed
 
 - Fixed build error due to breaking change in `xmrs`.

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -225,6 +225,11 @@ fn panic_implementation(info: &core::panic::PanicInfo) -> ! {
     crate::panics_render::render_backtrace(&frames, info);
 
     #[cfg(not(feature = "backtrace"))]
+    if let Some(mut mgba) = mgba::Mgba::new() {
+        let _ = mgba.print(format_args!("{info}"), mgba::DebugLevel::Fatal);
+    }
+
+    #[cfg(not(feature = "backtrace"))]
     loop {
         syscall::halt();
     }

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -208,18 +208,26 @@ pub mod external {
 
 pub use {agb_alloc::ExternalAllocator, agb_alloc::InternalAllocator};
 
-#[cfg(not(any(test, feature = "testing")))]
+#[cfg(any(test, feature = "testing", feature = "backtrace"))]
 #[panic_handler]
-#[allow(unused_must_use)]
 fn panic_implementation(info: &core::panic::PanicInfo) -> ! {
     avoid_double_panic(info);
 
+    #[cfg(feature = "backtrace")]
+    let frames = backtrace::unwind_exception();
+
+    #[cfg(feature = "testing")]
     if let Some(mut mgba) = mgba::Mgba::new() {
-        let _ = mgba.print(format_args!("{info}"), mgba::DebugLevel::Fatal);
+        let _ = mgba.print(format_args!("[failed]"), mgba::DebugLevel::Error);
     }
 
-    #[allow(clippy::empty_loop)]
-    loop {}
+    #[cfg(feature = "backtrace")]
+    crate::panics_render::render_backtrace(&frames, info);
+
+    #[cfg(not(feature = "backtrace"))]
+    loop {
+        syscall::halt();
+    }
 }
 
 // If we panic during the panic handler, then there isn't much we can do any more. So this code
@@ -353,26 +361,6 @@ pub mod test_runner {
 
             mgba.print(format_args!("[ok]"), mgba::DebugLevel::Info)
                 .unwrap();
-        }
-    }
-
-    #[panic_handler]
-    fn panic_implementation(info: &core::panic::PanicInfo) -> ! {
-        avoid_double_panic(info);
-
-        #[cfg(feature = "backtrace")]
-        let frames = backtrace::unwind_exception();
-
-        if let Some(mut mgba) = mgba::Mgba::new() {
-            let _ = mgba.print(format_args!("[failed]"), mgba::DebugLevel::Error);
-        }
-
-        #[cfg(feature = "backtrace")]
-        crate::panics_render::render_backtrace(&frames, info);
-
-        #[cfg(not(feature = "backtrace"))]
-        loop {
-            syscall::halt();
         }
     }
 


### PR DESCRIPTION
Fixes #818

- [ ] Changelog updated / no changelog update needed
