### PR TITLE
Blend in graphics frame

### DIFF
--- a/agb/examples/windows.rs
+++ b/agb/examples/windows.rs
@@ -1,10 +1,9 @@
 #![no_std]
 #![no_main]
 
-use agb::display::blend::Layer;
 use agb::display::tiled::{RegularBackgroundTiles, TileFormat};
 use agb::display::{example_logo, tiled::RegularBackgroundSize, window::WinIn};
-use agb::display::{HEIGHT, WIDTH};
+use agb::display::{BlendLayer, HEIGHT, WIDTH};
 use agb::fixnum::{num, Num, Rect, Vector2D};
 use agb::interrupt::VBlank;
 
@@ -59,9 +58,11 @@ fn main(mut gba: agb::Gba) -> ! {
         let blend = frame.blend();
         blend
             .alpha()
-            .set_layer_alpha(Layer::Top, blend_amount.try_change_base().unwrap());
-        blend.layer(Layer::Top).enable_background(background_id);
-        blend.layer(Layer::Bottom).enable_backdrop();
+            .set_layer_alpha(BlendLayer::Top, blend_amount.try_change_base().unwrap());
+        blend
+            .layer(BlendLayer::Top)
+            .enable_background(background_id);
+        blend.layer(BlendLayer::Bottom).enable_backdrop();
 
         vblank.wait_for_vblank();
 

--- a/agb/examples/windows.rs
+++ b/agb/examples/windows.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-use agb::display::blend::{BlendMode, Layer};
+use agb::display::blend::Layer;
 use agb::display::tiled::{RegularBackgroundTiles, TileFormat};
 use agb::display::{example_logo, tiled::RegularBackgroundSize, window::WinIn};
 use agb::display::{HEIGHT, WIDTH};
@@ -56,16 +56,16 @@ fn main(mut gba: agb::Gba) -> ! {
         let mut frame = gfx.frame();
         let background_id = map.show(&mut frame);
 
+        let blend = frame.blend();
+        blend
+            .alpha()
+            .set_layer_alpha(Layer::Top, blend_amount.try_change_base().unwrap());
+        blend.layer(Layer::Top).enable_background(background_id);
+        blend.layer(Layer::Bottom).enable_backdrop();
+
         vblank.wait_for_vblank();
 
         let mut window = gba.display.window.get();
-        let mut blend = gba.display.blend.get();
-
-        blend
-            .set_background_enable(Layer::Top, background_id, true)
-            .set_backdrop_enable(Layer::Bottom, true)
-            .set_blend_mode(BlendMode::Normal)
-            .set_blend_weight(Layer::Top, blend_amount.try_change_base().unwrap());
 
         window
             .win_in(WinIn::Win0)
@@ -81,6 +81,5 @@ fn main(mut gba: agb::Gba) -> ! {
 
         frame.commit();
         window.commit();
-        blend.commit();
     }
 }

--- a/agb/src/display/blend.rs
+++ b/agb/src/display/blend.rs
@@ -1,5 +1,3 @@
-use core::marker::PhantomData;
-
 mod registers;
 
 use registers::{BlendControlAlpha, BlendControlBrightness, BlendControlRegister};
@@ -21,50 +19,44 @@ pub enum Layer {
     Bottom = 1,
 }
 
-pub struct Blend<'frame> {
-    _phantom: PhantomData<&'frame ()>,
-
+pub struct Blend {
     blend_control: registers::BlendControlRegister,
     alpha: registers::BlendControlAlpha,
     brightness: registers::BlendControlBrightness,
 }
 
-impl<'frame> Blend<'frame> {
+impl Blend {
     pub(crate) fn new() -> Self {
         Self {
-            _phantom: PhantomData,
-
             blend_control: Default::default(),
             alpha: Default::default(),
             brightness: Default::default(),
         }
     }
 
-    pub fn layer<'blend>(&'blend mut self, layer: Layer) -> BlendLayer<'blend, 'frame> {
+    pub fn layer<'blend>(&'blend mut self, layer: Layer) -> BlendLayer<'blend> {
         BlendLayer { blend: self, layer }
     }
 
-    pub fn alpha<'blend>(&'blend mut self) -> BlendAlphaEffect<'blend, 'frame> {
+    pub fn alpha<'blend>(&'blend mut self) -> BlendAlphaEffect<'blend> {
         self.blend_control
             .set_colour_effect(registers::Effect::Alpha);
         BlendAlphaEffect { blend: self }
     }
 
-    pub fn brighten<'blend>(&'blend mut self) -> BlendFadeEffect<'blend, 'frame> {
+    pub fn brighten<'blend>(&'blend mut self) -> BlendFadeEffect<'blend> {
         self.blend_control
             .set_colour_effect(registers::Effect::Increase);
         BlendFadeEffect { blend: self }
     }
 
-    pub fn darken<'blend>(&'blend mut self) -> BlendFadeEffect<'blend, 'frame> {
+    pub fn darken<'blend>(&'blend mut self) -> BlendFadeEffect<'blend> {
         self.blend_control
             .set_colour_effect(registers::Effect::Decrease);
         BlendFadeEffect { blend: self }
     }
 
-    pub fn object_transparency<'blend>(
-        &'blend mut self,
-    ) -> BlendObjectTransparency<'blend, 'frame> {
+    pub fn object_transparency<'blend>(&'blend mut self) -> BlendObjectTransparency<'blend> {
         self.blend_control
             .set_colour_effect(registers::Effect::None);
         BlendObjectTransparency { blend: self }
@@ -124,12 +116,12 @@ impl<'frame> Blend<'frame> {
     }
 }
 
-pub struct BlendLayer<'blend, 'frame> {
-    blend: &'blend mut Blend<'frame>,
+pub struct BlendLayer<'blend> {
+    blend: &'blend mut Blend,
     layer: Layer,
 }
 
-impl BlendLayer<'_, '_> {
+impl BlendLayer<'_> {
     /// Enables a background for blending on this layer
     pub fn enable_background(&mut self, background: BackgroundId) -> &mut Self {
         self.blend.set_background_enable(self.layer, background);
@@ -147,11 +139,11 @@ impl BlendLayer<'_, '_> {
     }
 }
 
-pub struct BlendAlphaEffect<'blend, 'frame> {
-    blend: &'blend mut Blend<'frame>,
+pub struct BlendAlphaEffect<'blend> {
+    blend: &'blend mut Blend,
 }
 
-impl BlendAlphaEffect<'_, '_> {
+impl BlendAlphaEffect<'_> {
     pub fn set_layer_alpha(&mut self, layer: Layer, value: Num<u8, 4>) -> &mut Self {
         assert!(value <= 1.into(), "Layer alpha must be <= 1");
         self.blend.set_layer_alpha(layer, value);
@@ -159,11 +151,11 @@ impl BlendAlphaEffect<'_, '_> {
     }
 }
 
-pub struct BlendFadeEffect<'blend, 'frame> {
-    blend: &'blend mut Blend<'frame>,
+pub struct BlendFadeEffect<'blend> {
+    blend: &'blend mut Blend,
 }
 
-impl BlendFadeEffect<'_, '_> {
+impl BlendFadeEffect<'_> {
     pub fn set_fade(&mut self, value: Num<u8, 4>) -> &mut Self {
         assert!(value <= 1.into(), "Layer fade must be <= 1");
         self.blend.set_fade(value);
@@ -177,11 +169,11 @@ impl BlendFadeEffect<'_, '_> {
     }
 }
 
-pub struct BlendObjectTransparency<'blend, 'frame> {
-    blend: &'blend mut Blend<'frame>,
+pub struct BlendObjectTransparency<'blend> {
+    blend: &'blend mut Blend,
 }
 
-impl BlendObjectTransparency<'_, '_> {
+impl BlendObjectTransparency<'_> {
     pub fn set_alpha(&mut self, value: Num<u8, 4>) -> &mut Self {
         assert!(value <= 1.into(), "Object alpha must be <= 1");
         self.blend.set_layer_alpha(Layer::Top, value);

--- a/agb/src/display/blend.rs
+++ b/agb/src/display/blend.rs
@@ -34,29 +34,29 @@ impl Blend {
         }
     }
 
-    pub fn layer<'blend>(&'blend mut self, layer: Layer) -> BlendLayer<'blend> {
+    pub fn layer(&mut self, layer: Layer) -> BlendLayer<'_> {
         BlendLayer { blend: self, layer }
     }
 
-    pub fn alpha<'blend>(&'blend mut self) -> BlendAlphaEffect<'blend> {
+    pub fn alpha(&mut self) -> BlendAlphaEffect<'_> {
         self.blend_control
             .set_colour_effect(registers::Effect::Alpha);
         BlendAlphaEffect { blend: self }
     }
 
-    pub fn brighten<'blend>(&'blend mut self) -> BlendFadeEffect<'blend> {
+    pub fn brighten(&mut self) -> BlendFadeEffect<'_> {
         self.blend_control
             .set_colour_effect(registers::Effect::Increase);
         BlendFadeEffect { blend: self }
     }
 
-    pub fn darken<'blend>(&'blend mut self) -> BlendFadeEffect<'blend> {
+    pub fn darken(&mut self) -> BlendFadeEffect<'_> {
         self.blend_control
             .set_colour_effect(registers::Effect::Decrease);
         BlendFadeEffect { blend: self }
     }
 
-    pub fn object_transparency<'blend>(&'blend mut self) -> BlendObjectTransparency<'blend> {
+    pub fn object_transparency(&mut self) -> BlendObjectTransparency<'_> {
         self.blend_control
             .set_colour_effect(registers::Effect::None);
         BlendObjectTransparency { blend: self }

--- a/agb/src/display/blend.rs
+++ b/agb/src/display/blend.rs
@@ -1,25 +1,16 @@
-//! This controls the blending modes on the GBA.
-//!
-//! For now a description of how blending can be used is found on [the tonc page
-//! for graphic
-//! effects](https://www.coranac.com/tonc/text/gfx.htm#ssec-bld-gba). See the
-//! [Blend] struct for all the functions to manage blend effects. You acquire
-//! the Blend struct through the [Display][super::Display] struct.
-//! ```no_run
-//! # #![no_main]
-//! # #![no_std]
-//! # fn blend(mut gba: agb::Gba) {
-//! let mut blend = gba.display.blend.get();
-//! // ...
-//! # }
-//! ```
-//! where `gba` is a mutable [Gba][crate::Gba] struct.
-
 use core::marker::PhantomData;
 
-use crate::{fixnum::Num, memory_mapped::set_bits};
+mod registers;
+
+use registers::{BlendControlAlpha, BlendControlBrightness, BlendControlRegister};
 
 use super::tiled::BackgroundId;
+use crate::{fixnum::Num, memory_mapped::MemoryMapped};
+
+const BLEND_CONTROL: MemoryMapped<BlendControlRegister> = unsafe { MemoryMapped::new(0x0400_0050) };
+const BLEND_ALPHA: MemoryMapped<BlendControlAlpha> = unsafe { MemoryMapped::new(0x0400_0052) };
+const BLEND_BRIGHTNESS: MemoryMapped<BlendControlBrightness> =
+    unsafe { MemoryMapped::new(0x0400_0054) };
 
 /// The layers, top layer will be blended into the bottom layer
 #[derive(Clone, Copy, Debug)]
@@ -30,185 +21,170 @@ pub enum Layer {
     Bottom = 1,
 }
 
-/// The different blend modes available on the GBA
-#[derive(Clone, Copy, Debug)]
-pub enum BlendMode {
-    // No blending
-    Off = 0,
-    // Additive blending, use the [Blend::set_blend_weight] function to use this
-    Normal = 0b01,
-    // Brighten, use the [Blend::set_fade] to use this
-    FadeToWhite = 0b10,
-    // Darken, use the [Blend::set_fade] to use this
-    FadeToBlack = 0b11,
+pub struct Blend<'frame> {
+    _phantom: PhantomData<&'frame ()>,
+
+    blend_control: registers::BlendControlRegister,
+    alpha: registers::BlendControlAlpha,
+    brightness: registers::BlendControlBrightness,
 }
 
-/// Manages the blending, won't cause anything to change unless [Blend::commit]
-/// is called.
-pub struct Blend<'gba> {
-    targets: u16,
-    blend_weights: u16,
-    fade_weight: u16,
-    phantom: PhantomData<&'gba ()>,
+impl<'frame> Blend<'frame> {
+    pub(crate) fn new() -> Self {
+        Self {
+            _phantom: PhantomData,
+
+            blend_control: Default::default(),
+            alpha: Default::default(),
+            brightness: Default::default(),
+        }
+    }
+
+    pub fn layer<'blend>(&'blend mut self, layer: Layer) -> BlendLayer<'blend, 'frame> {
+        BlendLayer { blend: self, layer }
+    }
+
+    pub fn alpha<'blend>(&'blend mut self) -> BlendAlphaEffect<'blend, 'frame> {
+        self.blend_control
+            .set_colour_effect(registers::Effect::Alpha);
+        BlendAlphaEffect { blend: self }
+    }
+
+    pub fn brighten<'blend>(&'blend mut self) -> BlendFadeEffect<'blend, 'frame> {
+        self.blend_control
+            .set_colour_effect(registers::Effect::Increase);
+        BlendFadeEffect { blend: self }
+    }
+
+    pub fn darken<'blend>(&'blend mut self) -> BlendFadeEffect<'blend, 'frame> {
+        self.blend_control
+            .set_colour_effect(registers::Effect::Decrease);
+        BlendFadeEffect { blend: self }
+    }
+
+    pub fn object_transparency<'blend>(
+        &'blend mut self,
+    ) -> BlendObjectTransparency<'blend, 'frame> {
+        self.blend_control
+            .set_colour_effect(registers::Effect::None);
+        BlendObjectTransparency { blend: self }
+    }
+
+    fn set_background_enable(&mut self, layer: Layer, background_id: BackgroundId) {
+        self.with_target(layer, |mut target| {
+            target.enable_background(background_id);
+            target
+        });
+    }
+
+    fn set_object_enable(&mut self, layer: Layer) {
+        self.with_target(layer, |mut target| {
+            target.enable_object();
+            target
+        });
+    }
+
+    fn set_backdrop_enable(&mut self, layer: Layer) {
+        self.with_target(layer, |mut target| {
+            target.enable_backdrop();
+            target
+        });
+    }
+
+    fn with_target(
+        &mut self,
+        layer: Layer,
+        f: impl FnOnce(registers::BlendTarget) -> registers::BlendTarget,
+    ) {
+        match layer {
+            Layer::Top => self
+                .blend_control
+                .set_first_target(f(self.blend_control.first_target())),
+            Layer::Bottom => self
+                .blend_control
+                .set_second_target(f(self.blend_control.second_target())),
+        }
+    }
+
+    fn set_layer_alpha(&mut self, layer: Layer, value: Num<u8, 4>) {
+        match layer {
+            Layer::Top => self.alpha.set_first_blend(value),
+            Layer::Bottom => self.alpha.set_second_blend(value),
+        }
+    }
+
+    fn set_fade(&mut self, value: Num<u8, 4>) {
+        self.brightness.set(value);
+    }
+
+    pub(crate) fn commit(self) {
+        BLEND_CONTROL.set(self.blend_control);
+        BLEND_ALPHA.set(self.alpha);
+        BLEND_BRIGHTNESS.set(self.brightness);
+    }
 }
 
-/// When making many modifications to a layer, it is convenient to operate on
-/// that layer directly. This is created by the [Blend::layer] function and
-/// operates on that layer.
-pub struct BlendLayer<'blend, 'gba> {
-    blend: &'blend mut Blend<'gba>,
+pub struct BlendLayer<'blend, 'frame> {
+    blend: &'blend mut Blend<'frame>,
     layer: Layer,
 }
 
 impl BlendLayer<'_, '_> {
-    /// Set whether a background is enabled for blending on this layer.
-    pub fn set_background_enable(&mut self, background: BackgroundId, enable: bool) -> &mut Self {
-        self.blend
-            .set_background_enable(self.layer, background, enable);
-
+    /// Enables a background for blending on this layer
+    pub fn enable_background(&mut self, background: BackgroundId) -> &mut Self {
+        self.blend.set_background_enable(self.layer, background);
         self
     }
 
-    /// Set whether objects are enabled for blending on this layer.
-    pub fn set_object_enable(&mut self, enable: bool) -> &mut Self {
-        self.blend.set_object_enable(self.layer, enable);
-
+    pub fn enable_object(&mut self) -> &mut Self {
+        self.blend.set_object_enable(self.layer);
         self
     }
 
-    /// Set whether the backdrop contributes to the blend on this layer.
-    /// The backdrop is transparent colour, the colour rendered when nothing is
-    /// in it's place.
-    pub fn set_backdrop_enable(&mut self, enable: bool) -> &mut Self {
-        self.blend.set_backdrop_enable(self.layer, enable);
-
-        self
-    }
-
-    /// Set the weight for the blend on this layer.
-    pub fn set_blend_weight(&mut self, value: Num<u8, 4>) -> &mut Self {
-        self.blend.set_blend_weight(self.layer, value);
-
+    pub fn enable_backdrop(&mut self) -> &mut Self {
+        self.blend.set_backdrop_enable(self.layer);
         self
     }
 }
 
-const BLEND_CONTROL: *mut u16 = 0x0400_0050 as *mut _;
-const BLEND_ALPHAS: *mut u16 = 0x0400_0052 as *mut _;
+pub struct BlendAlphaEffect<'blend, 'frame> {
+    blend: &'blend mut Blend<'frame>,
+}
 
-const BLEND_FADES: *mut u16 = 0x0400_0054 as *mut _;
-
-impl<'gba> Blend<'gba> {
-    pub(crate) fn new() -> Self {
-        let blend = Self {
-            targets: 0,
-            blend_weights: 0,
-            fade_weight: 0,
-            phantom: PhantomData,
-        };
-        blend.commit();
-
-        blend
-    }
-
-    /// Reset the targets to all disabled, the targets control which layers are
-    /// enabled for blending.
-    pub fn reset_targets(&mut self) -> &mut Self {
-        self.targets = 0;
-
+impl BlendAlphaEffect<'_, '_> {
+    pub fn set_layer_alpha(&mut self, layer: Layer, value: Num<u8, 4>) -> &mut Self {
+        assert!(value <= 1.into(), "Layer alpha must be <= 1");
+        self.blend.set_layer_alpha(layer, value);
         self
     }
+}
 
-    /// Reset the blend weights
-    pub fn reset_weights(&mut self) -> &mut Self {
-        self.blend_weights = 0;
+pub struct BlendFadeEffect<'blend, 'frame> {
+    blend: &'blend mut Blend<'frame>,
+}
 
-        self
-    }
-
-    /// Reset the brighten and darken weights
-    pub fn reset_fades(&mut self) -> &mut Self {
-        self.fade_weight = 0;
-
-        self
-    }
-
-    /// Reset targets, blend weights, and fades
-    pub fn reset(&mut self) -> &mut Self {
-        self.reset_targets().reset_fades().reset_weights()
-    }
-
-    /// Creates a layer object whose functions work only on that layer,
-    /// convenient when performing multiple operations on that layer without the
-    /// need of specifying the layer every time.
-    pub fn layer(&mut self, layer: Layer) -> BlendLayer<'_, 'gba> {
-        BlendLayer { blend: self, layer }
-    }
-
-    /// Set whether a background is enabled for blending on a particular layer.
-    pub fn set_background_enable(
-        &mut self,
-        layer: Layer,
-        background: BackgroundId,
-        enable: bool,
-    ) -> &mut Self {
-        let bit_to_modify = (background.0 as usize) + (layer as usize * 8);
-        self.targets = set_bits(self.targets, enable as u16, 1, bit_to_modify);
-
-        self
-    }
-
-    /// Set whether objects are enabled for blending on a particular layer
-    pub fn set_object_enable(&mut self, layer: Layer, enable: bool) -> &mut Self {
-        let bit_to_modify = 0x4 + (layer as usize * 8);
-        self.targets = set_bits(self.targets, enable as u16, 1, bit_to_modify);
-
-        self
-    }
-
-    /// Set whether the backdrop contributes to the blend on a particular layer.
-    /// The backdrop is transparent colour, the colour rendered when nothing is
-    /// in it's place.
-    pub fn set_backdrop_enable(&mut self, layer: Layer, enable: bool) -> &mut Self {
-        let bit_to_modify = 0x5 + (layer as usize * 8);
-        self.targets = set_bits(self.targets, enable as u16, 1, bit_to_modify);
-
-        self
-    }
-
-    /// Set the weight for the blend on a particular layer.
-    pub fn set_blend_weight(&mut self, layer: Layer, value: Num<u8, 4>) -> &mut Self {
-        self.blend_weights = set_bits(
-            self.blend_weights,
-            value.to_raw() as u16,
-            5,
-            (layer as usize) * 8,
-        );
-
-        self
-    }
-
-    /// Set the fade of brighten or darken
+impl BlendFadeEffect<'_, '_> {
     pub fn set_fade(&mut self, value: Num<u8, 4>) -> &mut Self {
-        self.fade_weight = value.to_raw() as u16;
-
+        assert!(value <= 1.into(), "Layer fade must be <= 1");
+        self.blend.set_fade(value);
         self
     }
 
-    /// Set the current blend mode
-    pub fn set_blend_mode(&mut self, blend_mode: BlendMode) -> &mut Self {
-        self.targets = set_bits(self.targets, blend_mode as u16, 2, 0x6);
-
+    pub fn set_object_alpha(&mut self, value: Num<u8, 4>) -> &mut Self {
+        assert!(value <= 1.into(), "Object alpha must be <= 1");
+        self.blend.set_layer_alpha(Layer::Top, value);
         self
     }
+}
 
-    /// Commits the current state, should be called near after a call to wait
-    /// for next vblank.
-    pub fn commit(&self) {
-        unsafe {
-            BLEND_CONTROL.write_volatile(self.targets);
-            BLEND_ALPHAS.write_volatile(self.blend_weights);
-            BLEND_FADES.write_volatile(self.fade_weight);
-        }
+pub struct BlendObjectTransparency<'blend, 'frame> {
+    blend: &'blend mut Blend<'frame>,
+}
+
+impl BlendObjectTransparency<'_, '_> {
+    pub fn set_alpha(&mut self, value: Num<u8, 4>) -> &mut Self {
+        assert!(value <= 1.into(), "Object alpha must be <= 1");
+        self.blend.set_layer_alpha(Layer::Top, value);
+        self
     }
 }

--- a/agb/src/display/blend/registers.rs
+++ b/agb/src/display/blend/registers.rs
@@ -1,0 +1,77 @@
+use agb_fixnum::Num;
+use bilge::prelude::*;
+
+use crate::display::tiled::BackgroundId;
+
+#[bitsize(6)]
+#[derive(FromBits, Default, Clone, Copy)]
+pub(crate) struct BlendTarget {
+    backgrounds: u4,
+    object: bool,
+    backdrop: bool,
+}
+
+impl BlendTarget {
+    pub fn enable_background(&mut self, background_id: BackgroundId) {
+        self.set_backgrounds(self.backgrounds() | u4::new(1u8 << background_id.0));
+    }
+
+    pub fn enable_object(&mut self) {
+        self.set_object(true);
+    }
+
+    pub fn enable_backdrop(&mut self) {
+        self.set_backdrop(true);
+    }
+}
+
+#[bitsize(2)]
+#[derive(FromBits, Default, Clone, Copy)]
+pub(crate) enum Effect {
+    #[default]
+    None,
+    Alpha,
+    Increase,
+    Decrease,
+}
+
+#[bitsize(16)]
+#[derive(Default, Clone, Copy)]
+pub(crate) struct BlendControlRegister {
+    pub(crate) first_target: BlendTarget,
+    pub(crate) colour_effect: Effect,
+    pub(crate) second_target: BlendTarget,
+    _unused: u2,
+}
+
+#[bitsize(16)]
+#[derive(Default, Clone, Copy)]
+pub(crate) struct BlendControlAlpha {
+    first: u5,
+    _unused: u3,
+    second: u5,
+    _unused2: u3,
+}
+
+impl BlendControlAlpha {
+    pub(crate) fn set_first_blend(&mut self, value: Num<u8, 4>) {
+        self.set_first(u5::new(value.to_raw()));
+    }
+
+    pub(crate) fn set_second_blend(&mut self, value: Num<u8, 4>) {
+        self.set_second(u5::new(value.to_raw()));
+    }
+}
+
+#[bitsize(16)]
+#[derive(Default, Clone, Copy)]
+pub(crate) struct BlendControlBrightness {
+    brightness: u5,
+    _unused: u11,
+}
+
+impl BlendControlBrightness {
+    pub(crate) fn set(&mut self, value: Num<u8, 4>) {
+        self.set_brightness(u5::new(value.to_raw()));
+    }
+}

--- a/agb/src/display/mod.rs
+++ b/agb/src/display/mod.rs
@@ -81,17 +81,17 @@ impl<'gba> Graphics<'gba> {
 pub struct GraphicsFrame<'frame> {
     pub(crate) oam_frame: OamFrame<'frame>,
     pub(crate) bg_frame: BackgroundFrame<'frame>,
-    blend: Blend<'frame>,
+    blend: Blend,
 }
 
-impl<'frame> GraphicsFrame<'frame> {
+impl GraphicsFrame<'_> {
     pub fn commit(self) {
         self.oam_frame.commit();
         self.bg_frame.commit();
         self.blend.commit();
     }
 
-    pub fn blend(&mut self) -> &mut Blend<'frame> {
+    pub fn blend(&mut self) -> &mut Blend {
         &mut self.blend
     }
 }

--- a/agb/src/display/mod.rs
+++ b/agb/src/display/mod.rs
@@ -2,7 +2,6 @@ use crate::memory_mapped::MemoryMapped;
 
 use bilge::prelude::*;
 
-use blend::Blend;
 use tiled::{BackgroundFrame, DisplayControlRegister, TiledBackground};
 
 use self::{
@@ -23,7 +22,7 @@ pub mod tile_data;
 pub mod tiled;
 
 pub mod affine;
-pub mod blend;
+mod blend;
 pub mod window;
 
 pub mod font;
@@ -33,6 +32,10 @@ const DISPLAY_CONTROL: MemoryMapped<DisplayControlRegister> =
     unsafe { MemoryMapped::new(0x0400_0000) };
 pub(crate) const DISPLAY_STATUS: MemoryMapped<u16> = unsafe { MemoryMapped::new(0x0400_0004) };
 const VCOUNT: MemoryMapped<u16> = unsafe { MemoryMapped::new(0x0400_0006) };
+
+pub use blend::{
+    Blend, BlendAlphaEffect, BlendFadeEffect, BlendObjectTransparency, Layer as BlendLayer,
+};
 
 /// Width of the Gameboy advance screen in pixels
 pub const WIDTH: i32 = 240;

--- a/agb/src/memory_mapped.rs
+++ b/agb/src/memory_mapped.rs
@@ -40,21 +40,6 @@ where
     }
 }
 
-pub fn set_bits<T>(current_value: T, value: T, length: usize, shift: usize) -> T
-where
-    T: From<u8>
-        + Copy
-        + ops::Shl<usize, Output = T>
-        + ops::BitAnd<Output = T>
-        + ops::Sub<Output = T>
-        + ops::BitOr<Output = T>
-        + ops::Not<Output = T>,
-{
-    let one: T = 1u8.into();
-    let mask: T = (one << length) - one;
-    (current_value & !(mask << shift)) | ((value & mask) << shift)
-}
-
 pub struct MemoryMapped1DArray<T, const N: usize> {
     array: *mut [T; N],
 }


### PR DESCRIPTION
The current implementation of blend doesn't quite make sense given the new paradigms we're going for. This pushes the blend configuration into the `GraphicsFrame` which means you configure your blending as you configure your backgrounds etc, which feels better to me.

I've also fixed the API to hopefully ensure that only valid modes can be done.

- [ ] Changelog will be part of the big entry for the next version
