### PR TITLE
Stop allowing an empty loop

### DIFF
--- a/agb/examples/output.rs
+++ b/agb/examples/output.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use agb::syscall;
 use portable_atomic::{AtomicU32, Ordering};
 
 static COUNT: AtomicU32 = AtomicU32::new(0);
@@ -14,5 +15,7 @@ fn main(_gba: agb::Gba) -> ! {
             COUNT.store(cur_count + 1, Ordering::SeqCst);
         })
     };
-    loop {}
+    loop {
+        syscall::halt();
+    }
 }

--- a/agb/tests/test_multiboot.rs
+++ b/agb/tests/test_multiboot.rs
@@ -25,5 +25,7 @@ fn multiboot_test(_gba: &mut agb::Gba) {
 
 #[agb::entry]
 fn entry(_gba: agb::Gba) -> ! {
-    loop {}
+    loop {
+        agb::syscall::halt();
+    }
 }

--- a/agb/tests/test_save_eeprom_512b.rs
+++ b/agb/tests/test_save_eeprom_512b.rs
@@ -12,5 +12,7 @@ fn save_setup(gba: &mut agb::Gba) {
 
 #[agb::entry]
 fn entry(_gba: agb::Gba) -> ! {
-    loop {}
+    loop {
+        agb::syscall::halt();
+    }
 }

--- a/agb/tests/test_save_eeprom_8k.rs
+++ b/agb/tests/test_save_eeprom_8k.rs
@@ -12,5 +12,7 @@ fn save_setup(gba: &mut agb::Gba) {
 
 #[agb::entry]
 fn entry(_gba: agb::Gba) -> ! {
-    loop {}
+    loop {
+        agb::syscall::halt();
+    }
 }

--- a/agb/tests/test_save_flash_128k.rs
+++ b/agb/tests/test_save_flash_128k.rs
@@ -12,5 +12,7 @@ fn save_setup(gba: &mut agb::Gba) {
 
 #[agb::entry]
 fn entry(_gba: agb::Gba) -> ! {
-    loop {}
+    loop {
+        agb::syscall::halt();
+    }
 }

--- a/agb/tests/test_save_flash_64k.rs
+++ b/agb/tests/test_save_flash_64k.rs
@@ -12,5 +12,7 @@ fn save_setup(gba: &mut agb::Gba) {
 
 #[agb::entry]
 fn entry(_gba: agb::Gba) -> ! {
-    loop {}
+    loop {
+        agb::syscall::halt();
+    }
 }

--- a/agb/tests/test_save_sram.rs
+++ b/agb/tests/test_save_sram.rs
@@ -12,5 +12,7 @@ fn save_setup(gba: &mut agb::Gba) {
 
 #[agb::entry]
 fn entry(_gba: agb::Gba) -> ! {
-    loop {}
+    loop {
+        agb::syscall::halt();
+    }
 }

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 export CARGO_TARGET_DIR := env_var_or_default('CARGO_TARGET_DIR', justfile_directory() + "/target")
-CLIPPY_ARGUMENTS := "-Dwarnings -Dclippy::all -Aclippy::empty-loop"
+CLIPPY_ARGUMENTS := "-Dwarnings -Dclippy::all"
 
 podman_command := "podman"
 

--- a/tracker/agb-tracker/src/lib.rs
+++ b/tracker/agb-tracker/src/lib.rs
@@ -667,7 +667,9 @@ impl TrackerChannel {
 #[cfg(all(test, feature = "agb"))]
 #[agb::entry]
 fn main(gba: agb::Gba) -> ! {
-    loop {}
+    loop {
+        agb::syscall::halt();
+    }
 }
 
 #[cfg(feature = "agb")]


### PR DESCRIPTION
We previously allowed an empty loop (`loop {}`) to make a function never return. This is a clippy warning, and probably for good reason.

I've swapped them all with `loop { syscall::halt() }` which is the more correct thing to do in an infinite loop :).

- [x] no changelog update needed
