### PR TITLE
Update agbabi as-of 2025-02-05

### DIFF
--- a/agb/src/agbabi/memcpy.s
+++ b/agb/src/agbabi/memcpy.s
@@ -1,54 +1,63 @@
-/*
-===============================================================================
- ABI:
-    __aeabi_memcpy, __aeabi_memcpy4, __aeabi_memcpy8
- Standard:
-    memcpy
- Support:
-    __agbabi_memcpy2, __agbabi_memcpy1
- Copyright (C) 2021-2022 agbabi contributors
- For conditions of distribution and use, see copyright notice in LICENSE.md
-===============================================================================
-*/
+@===============================================================================
+@
+@ ABI:
+@    __aeabi_memcpy, __aeabi_memcpy4, __aeabi_memcpy8
+@ Standard:
+@    memcpy
+@ Support:
+@    __agbabi_memcpy2, __agbabi_memcpy1
+@
+@ Copyright (C) 2021-2023 agbabi contributors
+@ For conditions of distribution and use, see copyright notice in LICENSE.md
+@
+@===============================================================================
+
+.syntax unified
 
     .arm
+    .align 2
 
     .section .iwram.__aeabi_memcpy, "ax", %progbits
-    .align 2
+
     .global __agbabi_memcpy
+    .type __agbabi_memcpy, %function
 __agbabi_memcpy:
+
     .global __aeabi_memcpy
+    .type __aeabi_memcpy, %function
 __aeabi_memcpy:
-    // >6-bytes is roughly the threshold when byte-by-byte copy is slower
+    @ >6-bytes is roughly the threshold when byte-by-byte copy is slower
     cmp     r2, #6
     ble     __agbabi_memcpy1
 
     align_switch r0, r1, r3, __agbabi_memcpy1, .Lcopy_halves
 
-    // Check if r0 (or r1) needs word aligning
+    @ Check if r0 (or r1) needs word aligning
     rsbs    r3, r0, #4
     joaobapt_test r3
 
-    // Copy byte head to align
+    @ Copy byte head to align
     ldrbmi  r3, [r1], #1
     strbmi  r3, [r0], #1
     submi   r2, r2, #1
-    // r0, r1 are now half aligned
+    @ r0, r1 are now half aligned
 
-    // Copy half head to align
+    @ Copy half head to align
     ldrhcs  r3, [r1], #2
     strhcs  r3, [r0], #2
     subcs   r2, r2, #2
-    // r0, r1 are now word aligned
+    @ r0, r1 are now word aligned
 
     .global __aeabi_memcpy8
+    .type __aeabi_memcpy8, %function
 __aeabi_memcpy8:
     .global __aeabi_memcpy4
+    .type __aeabi_memcpy4, %function
 __aeabi_memcpy4:
     cmp     r2, #32
     blt     .Lcopy_words
 
-    // Word aligned, 32-byte copy
+    @ Word aligned, 32-byte copy
     push    {{r4-r10}}
 .Lloop_32:
     subs    r2, r2, #32
@@ -58,7 +67,7 @@ __aeabi_memcpy4:
     pop     {{r4-r10}}
     bxeq    lr
 
-    // < 32 bytes remaining to be copied
+    @ < 32 bytes remaining to be copied
     add     r2, r2, #32
 
 .Lcopy_words:
@@ -71,26 +80,27 @@ __aeabi_memcpy4:
     bgt     .Lloop_4
     bxeq    lr
 
-    // Copy byte & half tail
-    // This test still works when r2 is negative
+    @ Copy byte & half tail
+    @ This test still works when r2 is negative
     joaobapt_test r2
-    // Copy half
+    @ Copy half
     ldrhcs  r3, [r1], #2
     strhcs  r3, [r0], #2
-    // Copy byte
+    @ Copy byte
     ldrbmi  r3, [r1]
     strbmi  r3, [r0]
     bx      lr
 
 .Lcopy_halves:
-    // Copy byte head to align
+    @ Copy byte head to align
     tst     r0, #1
     ldrbne  r3, [r1], #1
     strbne  r3, [r0], #1
     subne   r2, r2, #1
-    // r0, r1 are now half aligned
+    @ r0, r1 are now half aligned
 
     .global __agbabi_memcpy2
+    .type __agbabi_memcpy2, %function
 __agbabi_memcpy2:
     subs    r2, r2, #2
     ldrhge  r3, [r1], #2
@@ -98,13 +108,15 @@ __agbabi_memcpy2:
     bgt     __agbabi_memcpy2
     bxeq    lr
 
-    // Copy byte tail
-    adds    r2, r2, #1
-    ldrbeq  r3, [r1]
-    strbeq  r3, [r0]
+    @ Copy byte tail
+    adds    r2, r2, #2
+    ldrbne  r3, [r1]
+    strbne  r3, [r0]
     bx      lr
 
+    .section .iwram.__agbabi_memcpy1, "ax", %progbits
     .global __agbabi_memcpy1
+    .type __agbabi_memcpy1, %function
 __agbabi_memcpy1:
     subs    r2, r2, #1
     ldrbge  r3, [r1], #1
@@ -113,8 +125,8 @@ __agbabi_memcpy1:
     bx      lr
 
     .section .iwram.memcpy, "ax", %progbits
-    .align 2
     .global memcpy
+    .type memcpy, %function
 memcpy:
     push    {{r0, lr}}
     bl      __aeabi_memcpy

--- a/agb/src/agbabi/memset.s
+++ b/agb/src/agbabi/memset.s
@@ -1,116 +1,129 @@
-/*
-===============================================================================
+@===============================================================================
+@
+@ ABI:
+@    __aeabi_memclr, __aeabi_memclr4, __aeabi_memclr8,
+@    __aeabi_memset, __aeabi_memset4, __aeabi_memset8
+@ Standard:
+@    memset
+@ Support:
+@    __agbabi_wordset4, __agbabi_lwordset4, __agbabi_memset1
+@
+@ Copyright (C) 2021-2023 agbabi contributors
+@ For conditions of distribution and use, see copyright notice in LICENSE.md
+@
+@===============================================================================
 
- ABI:
-    __aeabi_memset, __aeabi_memset4, __aeabi_memset8,
-    __aeabi_memclr, __aeabi_memclr4, __aeabi_memclr8
- Standard:
-    memset
- Support:
-    __agbabi_wordset4
-
- Copyright (C) 2021-2022 agbabi contributors
- For conditions of distribution and use, see copyright notice in LICENSE.md
-
-===============================================================================
-*/
+.syntax unified
 
     .arm
-
-    .section .iwram.__aeabi_memset, "ax", %progbits
     .align 2
+
+    .section .iwram.__aeabi_memclr, "ax", %progbits
     .global __aeabi_memclr
+    .type __aeabi_memclr, %function
 __aeabi_memclr:
     mov     r2, #0
-    b       .LskipShifts
-
-    .global __agbabi_memset
-__agbabi_memset:
-    .global __aeabi_memset
-__aeabi_memset:
-    mov     r2, r2, lsl #24
-    orr     r2, r2, r2, lsr #8
-    orr     r2, r2, r2, lsr #16
-    // Fallthrough
-
-.LskipShifts:
-    // Handle <= 2 byte set byte-by-byte
-    cmp     r1, #2
-    bgt     .LskipShortHead
-    // JoaoBapt carry & sign bit test
-    movs    r1, r1, lsl #31
-    // Set byte and half
-    strbmi  r2, [r0], #1
-    strbcs  r2, [r0], #1
-    strbcs  r2, [r0]
-    bx      lr
-
-.LskipShortHead:
-    rsb     r3, r0, #4
-    // JoaoBapt carry & sign bit test
-    movs    r3, r3, lsl #31
-    // Set half and byte head
-    strbmi  r2, [r0], #1
-    submi   r1, r1, #1
-    strhcs  r2, [r0], #2
-    subcs   r1, r1, #2
-    b       __agbabi_wordset4
+    b       __aeabi_memset
 
     .global __aeabi_memclr8
+    .type __aeabi_memclr8, %function
 __aeabi_memclr8:
     .global __aeabi_memclr4
+    .type __aeabi_memclr4, %function
 __aeabi_memclr4:
     mov     r2, #0
     b       __agbabi_wordset4
 
+    .section .iwram.__aeabi_memset, "ax", %progbits
+    .global __agbabi_memset
+    .type __agbabi_memset, %function
+__agbabi_memset:
+
+    .global __aeabi_memset
+    .type __aeabi_memset, %function
+__aeabi_memset:
+    @ < 8 bytes probably won't be aligned: go byte-by-byte
+    cmp     r1, #8
+    blt     __agbabi_memset1
+
+    @ Copy head to align to next word
+    rsb     r3, r0, #4
+    joaobapt_test r3
+    strbmi  r2, [r0], #1
+    submi   r1, r1, #1
+    strbcs  r2, [r0], #1
+    strbcs  r2, [r0], #1
+    subcs   r1, r1, #2
+
     .global __aeabi_memset8
+    .type __aeabi_memset8, %function
 __aeabi_memset8:
     .global __aeabi_memset4
+    .type __aeabi_memset4, %function
 __aeabi_memset4:
-    mov     r2, r2, lsl #24
+    lsl     r2, r2, #24
     orr     r2, r2, r2, lsr #8
     orr     r2, r2, r2, lsr #16
-    // Fallthrough
 
     .global __agbabi_wordset4
+    .type __agbabi_wordset4, %function
 __agbabi_wordset4:
-    // Set 8 words
-    movs    r12, r1, lsr #5
-    beq     .Lskip32
-    lsl     r3, r12, #5
-    sub     r1, r1, r3
-    push    {{r4-r9}}
     mov     r3, r2
+
+    .global __agbabi_lwordset4
+    .type __agbabi_lwordset4, %function
+__agbabi_lwordset4:
+    @ 16 words is roughly the threshold when lwordset is slower
+    cmp     r1, #64
+    blt     .Lset_2_words
+
+    @ 8 word set
+    push    {{r4-r9}}
     mov     r4, r2
-    mov     r5, r2
+    mov     r5, r3
     mov     r6, r2
-    mov     r7, r2
+    mov     r7, r3
     mov     r8, r2
-    mov     r9, r2
-.LsetWords8:
-    stmia   r0!, {{r2-r9}}
-    subs    r12, r12, #1
-    bne     .LsetWords8
+    mov     r9, r3
+
+.Lset_8_words:
+    subs    r1, r1, #32
+    stmiage r0!, {{r2-r9}}
+    bgt     .Lset_8_words
     pop     {{r4-r9}}
-.Lskip32:
+    bxeq    lr
 
-    // Set words
-    movs    r12, r1, lsr #2
-.LsetWords:
-    subs    r12, r12, #1
-    strhs   r2, [r0], #4
-    bhs     .LsetWords
+    @ Fixup remaining
+    add     r1, r1, #32
+.Lset_2_words:
+    subs    r1, r1, #8
+    stmiage r0!, {{r2-r3}}
+    bgt     .Lset_2_words
+    bxeq    lr
 
-    // Set half and byte tail
-    // JoaoBapt carry & sign bit test
-    movs    r3, r1, lsl #31
+    @ Test for remaining word
+    adds    r1, r1, #4
+    strge   r2, [r0], #4
+    bxeq    lr
+
+    @ Set tail
+    joaobapt_test r1
     strhcs  r2, [r0], #2
-    strbmi  r2, [r0]
+    strbmi  r2, [r0], #1
+    bx      lr
+
+    .section .iwram.__agbabi_memset1, "ax", %progbits
+    .global __agbabi_memset1
+    .type __agbabi_memset1, %function
+__agbabi_memset1:
+    subs    r1, r1, #1
+    strbge  r2, [r0], #1
+    bgt     __agbabi_memset1
     bx      lr
 
     .section .iwram.memset, "ax", %progbits
-    .align 2
     .global memset
+    .type memset, %function
 memset:
     mov     r3, r1
     mov     r1, r2


### PR DESCRIPTION
There are very minor performance improvements from this:

Before:
```
agb::agbabi::test::memcpy::test_all_of_memcpy...[ok: 53510906 c ≈ 3.19 s]
agb::agbabi::test::memcpy::test_all_of_memcpy4...[ok: 39371480 c ≈ 2.35 s]
agb::agbabi::test::memcpy::test_all_of_memcpy4_non_word_length...[ok: 45755219 c ≈ 2.73 s]
agb::agbabi::test::memcpy::test_memcpy4_with_different_sizes...[ok: 244971 c ≈ 0.01 s]
agb::agbabi::test::memset::test_memset4_with_different_sizes_and_offsets...[ok: 3326916 c ≈ 0.2 s]
agb::agbabi::test::memset::test_memset4_with_non_word_size_sizes_and_offsets...[ok: 10717390 c ≈ 0.64 s]
agb::agbabi::test::memset::test_memset_with_different_sizes_and_offsets...[ok: 2525106 c ≈ 0.15 s]
```

After:
```
agb::agbabi::test::memcpy::test_all_of_memcpy...[ok: 53494903 c ≈ 3.19 s]
agb::agbabi::test::memcpy::test_all_of_memcpy4...[ok: 39371450 c ≈ 2.35 s]
agb::agbabi::test::memcpy::test_all_of_memcpy4_non_word_length...[ok: 45755189 c ≈ 2.73 s]
agb::agbabi::test::memcpy::test_memcpy4_with_different_sizes...[ok: 243639 c ≈ 0.01 s]
agb::agbabi::test::memset::test_memset4_with_different_sizes_and_offsets...[ok: 3317581 c ≈ 0.2 s]
agb::agbabi::test::memset::test_memset4_with_non_word_size_sizes_and_offsets...[ok: 10699685 c ≈ 0.64 s]
agb::agbabi::test::memset::test_memset_with_different_sizes_and_offsets...[ok: 2512914 c ≈ 0.15 s]
```

- [x] No changelog update needed
