### PR TITLE
Fix cargo warning about profiles in the non root package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,7 @@ exclude = [
 
     "template",
 ]
+
+[profile.release.package.backtrace]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/website/backtrace/Cargo.toml
+++ b/website/backtrace/Cargo.toml
@@ -13,7 +13,7 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 wasm-bindgen = "0.2"
-agb-debug = { path="../../agb-debug" }
+agb-debug = { path = "../../agb-debug" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -24,9 +24,7 @@ console_error_panic_hook = { version = "0.1", optional = true }
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 
-[profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"
-
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(wasm_bindgen_unstable_test_coverage)',
+] }


### PR DESCRIPTION
We were getting 
```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root
```

as a warning in the build. Set it correctly in the workspace toml file

- [x] no changelog update needed
