### PR TITLE
don't ever inline adding tile to vram

### DIFF
--- a/agb/src/display/tiled/vram_manager.rs
+++ b/agb/src/display/tiled/vram_manager.rs
@@ -391,6 +391,7 @@ impl VRamManagerInner {
         self.remove_tile(tile_index);
     }
 
+    #[inline(never)]
     pub(crate) fn add_tile(&mut self, tile_set: &TileSet<'_>, tile: u16) -> TileIndex {
         let reference = self
             .tile_set_to_vram


### PR DESCRIPTION
It's a big function that *shouldn't* (maybe) benefit from inlining too much as it depends a fair amount on global state and doesn't do any big processing with the given parameters