### PR TITLE
Remove `set_background_palette_raw`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed the dmg audio module. It will return in future but with a better thought out API which will work together with the existing mixer
+- Removed `VRamManager.set_background_palette_raw` since it is actually unsafe and didn't work as intended for smaller palettes in release mode
 
 ## [0.21.3] - 2025/02/01
 

--- a/agb/examples/chicken.rs
+++ b/agb/examples/chicken.rs
@@ -4,6 +4,7 @@
 use agb::{
     display::{
         object::{Object, Sprite},
+        palette16::Palette16,
         tiled::{
             RegularBackgroundSize, RegularBackgroundTiles, TileFormat, TileSet, TileSetting,
             VRAM_MANAGER,
@@ -59,7 +60,7 @@ fn main(mut gba: agb::Gba) -> ! {
     let vblank = agb::interrupt::VBlank::get();
     let mut input = agb::input::ButtonController::new();
 
-    VRAM_MANAGER.set_background_palette_raw(&MAP_PALETTE);
+    VRAM_MANAGER.set_background_palette(0, &MAP_PALETTE);
     let tileset = TileSet::new(&MAP_TILES, TileFormat::FourBpp);
 
     let mut background = RegularBackgroundTiles::new(
@@ -351,4 +352,5 @@ static MAP_MAP: [u16; 1024] = [
     0x0000, 0x0000, 0x0000, 0x0000,
 ];
 
-static MAP_PALETTE: [u16; 2] = [0x0000, 0x6A2F];
+static MAP_PALETTE: Palette16 =
+    Palette16::new([0x0000, 0x6A2F, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);

--- a/agb/examples/mixer_32768.rs
+++ b/agb/examples/mixer_32768.rs
@@ -3,6 +3,7 @@
 
 use agb::{
     display::{
+        palette16::Palette16,
         tiled::{
             DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER,
         },
@@ -99,10 +100,13 @@ fn main(mut gba: Gba) -> ! {
 fn init_background(bg: &mut RegularBackgroundTiles) {
     let background_tile = DynamicTile::new().fill_with(0);
 
-    VRAM_MANAGER.set_background_palette_raw(&[
-        0x0000, 0x0ff0, 0x00ff, 0xf00f, 0xf0f0, 0x0f0f, 0xaaaa, 0x5555, 0x0000, 0x0000, 0x0000,
-        0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-    ]);
+    VRAM_MANAGER.set_background_palette(
+        0,
+        &Palette16::new([
+            0x0000, 0x0ff0, 0x00ff, 0xf00f, 0xf0f0, 0x0f0f, 0xaaaa, 0x5555, 0x0000, 0x0000, 0x0000,
+            0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        ]),
+    );
 
     for y in 0..20u16 {
         for x in 0..30u16 {

--- a/agb/examples/save.rs
+++ b/agb/examples/save.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use agb::{
-    display::{object::Object, tiled::VRAM_MANAGER, HEIGHT, WIDTH},
+    display::{object::Object, palette16::Palette16, tiled::VRAM_MANAGER, HEIGHT, WIDTH},
     include_aseprite,
     input::ButtonController,
     save::{Error, SaveManager},
@@ -70,7 +70,10 @@ fn main(mut gba: agb::Gba) -> ! {
     let mut save = Save::new(&mut gba.save).expect("able to read save data");
     let mut button = ButtonController::new();
 
-    VRAM_MANAGER.set_background_palette_raw(&[0xFFFF]);
+    VRAM_MANAGER.set_background_palette(
+        0,
+        &Palette16::new([0xffff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    );
 
     loop {
         let mut frame = gfx.frame();

--- a/agb/examples/stereo_sound.rs
+++ b/agb/examples/stereo_sound.rs
@@ -3,6 +3,7 @@
 
 use agb::{
     display::{
+        palette16::Palette16,
         tiled::{
             DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER,
         },
@@ -87,10 +88,13 @@ fn main(mut gba: Gba) -> ! {
 fn init_background(bg: &mut RegularBackgroundTiles) {
     let background_tile = DynamicTile::new().fill_with(0);
 
-    VRAM_MANAGER.set_background_palette_raw(&[
-        0x0000, 0x0ff0, 0x00ff, 0xf00f, 0xf0f0, 0x0f0f, 0xaaaa, 0x5555, 0x0000, 0x0000, 0x0000,
-        0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-    ]);
+    VRAM_MANAGER.set_background_palette(
+        0,
+        &Palette16::new([
+            0x0000, 0x0ff0, 0x00ff, 0xf00f, 0xf0f0, 0x0f0f, 0xaaaa, 0x5555, 0x0000, 0x0000, 0x0000,
+            0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        ]),
+    );
 
     for y in 0..20u16 {
         for x in 0..30u16 {

--- a/agb/examples/text_render.rs
+++ b/agb/examples/text_render.rs
@@ -3,6 +3,7 @@
 
 use agb::{
     display::{
+        palette16::Palette16,
         tiled::{
             DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER,
         },
@@ -20,10 +21,13 @@ fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.display.graphics.get();
     let vblank = agb::interrupt::VBlank::get();
 
-    VRAM_MANAGER.set_background_palette_raw(&[
-        0x0000, 0x0ff0, 0x00ff, 0xf00f, 0xf0f0, 0x0f0f, 0xaaaa, 0x5555, 0x0000, 0x0000, 0x0000,
-        0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-    ]);
+    VRAM_MANAGER.set_background_palette(
+        0,
+        &Palette16::new([
+            0x0000, 0x0ff0, 0x00ff, 0xf00f, 0xf0f0, 0x0f0f, 0xaaaa, 0x5555, 0x0000, 0x0000, 0x0000,
+            0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+        ]),
+    );
 
     let background_tile = DynamicTile::new().fill_with(0);
 

--- a/agb/src/display/font.rs
+++ b/agb/src/display/font.rs
@@ -271,7 +271,11 @@ impl<'a, 'b> TextRenderer<'b> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::display::tiled::{RegularBackgroundTiles, TileFormat, VRAM_MANAGER};
+    use crate::display::{
+        palette16::Palette16,
+        tiled::{RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+    };
+
     static FONT: Font = crate::include_font!("examples/font/yoster.ttf", 12);
 
     #[test_case]
@@ -284,10 +288,13 @@ mod tests {
             TileFormat::FourBpp,
         );
 
-        VRAM_MANAGER.set_background_palette_raw(&[
-            0x0000, 0x0ff0, 0x00ff, 0xf00f, 0xf0f0, 0x0f0f, 0xaaaa, 0x5555, 0x0000, 0x0000, 0x0000,
-            0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
-        ]);
+        VRAM_MANAGER.set_background_palette(
+            0,
+            &Palette16::new([
+                0x0000, 0x0ff0, 0x00ff, 0xf00f, 0xf0f0, 0x0f0f, 0xaaaa, 0x5555, 0x0000, 0x0000,
+                0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000,
+            ]),
+        );
 
         let background_tile = VRAM_MANAGER.new_dynamic_tile().fill_with(0);
 

--- a/agb/src/display/tiled/vram_manager.rs
+++ b/agb/src/display/tiled/vram_manager.rs
@@ -255,10 +255,6 @@ impl VRamManager {
         self.with(VRamManagerInner::gc);
     }
 
-    pub fn set_background_palette_raw(&self, palette: &[u16]) {
-        self.with(|inner| inner.set_background_palette_raw(palette));
-    }
-
     pub fn set_background_palette(&self, pal_index: u8, palette: &palette16::Palette16) {
         self.with(|inner| inner.set_background_palette(pal_index, palette));
     }
@@ -522,15 +518,6 @@ impl VRamManagerInner {
                     tmp4 = out(reg) _,
                 ),
             }
-        }
-    }
-
-    /// Copies raw palettes to the background palette without any checks.
-    pub fn set_background_palette_raw(&mut self, palette: &[u16]) {
-        unsafe {
-            PALETTE_BACKGROUND
-                .as_ptr()
-                .copy_from_nonoverlapping(palette.as_ptr(), palette.len());
         }
     }
 


### PR DESCRIPTION
It's technically unsafe, but rather than mark it as such, I've just removed it since it's hard to use correctly and can be better used by calling `set_background_palette` instead.

- [x] Changelog updated
