### PR TITLE
Fully fix dynamic tile

### DIFF
--- a/agb-image-converter/src/rust_generator.rs
+++ b/agb-image-converter/src/rust_generator.rs
@@ -109,7 +109,7 @@ pub(crate) fn generate_code(
         let index = data.new_index as u16;
 
         quote! {
-            #crate_prefix::display::tiled::TileSetting::new(#index, #hflipped, #vflipped, #palette_assignment)
+            #crate_prefix::display::tiled::TileSetting::new(#index, #crate_prefix::display::tiled::TileEffect::new(#hflipped, #vflipped, #palette_assignment))
         }
     });
 

--- a/agb/examples/dynamic_tiles.rs
+++ b/agb/examples/dynamic_tiles.rs
@@ -4,7 +4,10 @@
 use agb::display::{
     Priority,
     palette16::Palette16,
-    tiled::{DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+    tiled::{
+        DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileEffect, TileFormat,
+        VRAM_MANAGER,
+    },
 };
 
 #[agb::entry]
@@ -38,11 +41,7 @@ fn main(mut gba: agb::Gba) -> ! {
                 *bit = value;
             }
 
-            bg.set_tile(
-                (x as u16, y as u16),
-                &dynamic_tile.tile_set(),
-                dynamic_tile.tile_setting(),
-            );
+            bg.set_tile_dynamic((x as u16, y as u16), &dynamic_tile, TileEffect::default());
         }
     }
 

--- a/agb/examples/mixer_32768.rs
+++ b/agb/examples/mixer_32768.rs
@@ -7,7 +7,8 @@ use agb::{
         Font, Priority,
         palette16::Palette16,
         tiled::{
-            DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER,
+            DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileEffect, TileFormat,
+            VRAM_MANAGER,
         },
     },
     include_font, include_wav,
@@ -107,11 +108,7 @@ fn init_background(bg: &mut RegularBackgroundTiles) {
 
     for y in 0..20u16 {
         for x in 0..30u16 {
-            bg.set_tile(
-                (x, y),
-                &background_tile.tile_set(),
-                background_tile.tile_setting(),
-            );
+            bg.set_tile_dynamic((x, y), &background_tile, TileEffect::default());
         }
     }
 }

--- a/agb/examples/stereo_sound.rs
+++ b/agb/examples/stereo_sound.rs
@@ -7,7 +7,8 @@ use agb::{
         Font, Priority,
         palette16::Palette16,
         tiled::{
-            DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER,
+            DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileEffect, TileFormat,
+            VRAM_MANAGER,
         },
     },
     include_font, include_wav,
@@ -97,11 +98,7 @@ fn init_background(bg: &mut RegularBackgroundTiles) {
 
     for y in 0..20u16 {
         for x in 0..30u16 {
-            bg.set_tile(
-                (x, y),
-                &background_tile.tile_set(),
-                background_tile.tile_setting(),
-            );
+            bg.set_tile_dynamic((x, y), &background_tile, TileEffect::default());
         }
     }
 }

--- a/agb/examples/text_render.rs
+++ b/agb/examples/text_render.rs
@@ -6,7 +6,8 @@ use agb::{
         Font, Priority,
         palette16::Palette16,
         tiled::{
-            DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER,
+            DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileEffect, TileFormat,
+            VRAM_MANAGER,
         },
     },
     include_font,
@@ -39,11 +40,7 @@ fn main(mut gba: agb::Gba) -> ! {
 
     for y in 0..20u16 {
         for x in 0..30u16 {
-            bg.set_tile(
-                (x, y),
-                &background_tile.tile_set(),
-                background_tile.tile_setting(),
-            );
+            bg.set_tile_dynamic((x, y), &background_tile, TileEffect::default());
         }
     }
 

--- a/agb/src/display/font.rs
+++ b/agb/src/display/font.rs
@@ -3,7 +3,7 @@ use core::fmt::{Error, Write};
 use crate::fixnum::Vector2D;
 use crate::hash_map::HashMap;
 
-use super::tiled::{DynamicTile, RegularBackgroundTiles};
+use super::tiled::{DynamicTile, RegularBackgroundTiles, TileEffect};
 
 /// The text renderer renders a variable width fixed size
 /// bitmap font using dynamic tiles as a rendering surface.
@@ -240,10 +240,10 @@ impl<'a> TextRenderer {
     /// Commit the dynamic tiles that contain the text to the background.
     pub fn commit(&self, bg: &'a mut RegularBackgroundTiles) {
         for ((x, y), tile) in self.tiles.iter() {
-            bg.set_tile(
+            bg.set_tile_dynamic(
                 (self.tile_pos.x + *x as u16, self.tile_pos.y + *y as u16),
-                &tile.tile_set(),
-                tile.tile_setting(),
+                &tile,
+                TileEffect::default(),
             );
         }
     }
@@ -272,7 +272,7 @@ mod tests {
     use super::*;
     use crate::display::{
         palette16::Palette16,
-        tiled::{RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackgroundTiles, TileEffect, TileFormat, VRAM_MANAGER},
     };
 
     static FONT: Font = crate::include_font!("examples/font/yoster.ttf", 12);
@@ -299,11 +299,7 @@ mod tests {
 
         for y in 0..20u16 {
             for x in 0..30u16 {
-                bg.set_tile(
-                    (x, y),
-                    &background_tile.tile_set(),
-                    background_tile.tile_setting(),
-                );
+                bg.set_tile_dynamic((x, y), &background_tile, TileEffect::default());
             }
         }
 

--- a/agb/src/display/font.rs
+++ b/agb/src/display/font.rs
@@ -240,11 +240,8 @@ impl<'a> TextRenderer {
     /// Commit the dynamic tiles that contain the text to the background.
     pub fn commit(&self, bg: &'a mut RegularBackgroundTiles) {
         for ((x, y), tile) in self.tiles.iter() {
-            bg.set_tile_dynamic(
-                (self.tile_pos.x + *x as u16, self.tile_pos.y + *y as u16),
-                &tile,
-                TileEffect::default(),
-            );
+            let tile_pos = (self.tile_pos.x + *x as u16, self.tile_pos.y + *y as u16);
+            bg.set_tile_dynamic(tile_pos, tile, TileEffect::default());
         }
     }
 

--- a/agb/src/display/tiled.rs
+++ b/agb/src/display/tiled.rs
@@ -80,6 +80,24 @@ impl TileSetting {
         &mut self.tile_effect
     }
 
+    #[must_use]
+    pub const fn hflip(mut self, should_flip: bool) -> Self {
+        self.tile_effect().hflip(should_flip);
+        self
+    }
+
+    #[must_use]
+    pub const fn vflip(mut self, should_flip: bool) -> Self {
+        self.tile_effect().vflip(should_flip);
+        self
+    }
+
+    #[must_use]
+    pub const fn palette(mut self, palette_id: u8) -> Self {
+        self.tile_effect().palette(palette_id);
+        self
+    }
+
     fn index(self) -> u16 {
         self.tile_id
     }

--- a/agb/src/display/tiled.rs
+++ b/agb/src/display/tiled.rs
@@ -49,19 +49,22 @@ const TRANSPARENT_TILE_INDEX: u16 = 0xffff;
 #[repr(align(4))]
 pub struct TileSetting {
     tile_id: u16,
-    effect_bits: u16,
+    tile_effect: TileEffect,
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+#[repr(transparent)]
+pub struct TileEffect(u16);
+
 impl TileSetting {
-    pub const BLANK: Self = TileSetting::new(TRANSPARENT_TILE_INDEX, false, false, 0);
+    pub const BLANK: Self =
+        TileSetting::new(TRANSPARENT_TILE_INDEX, TileEffect::new(false, false, 0));
 
     #[must_use]
-    pub const fn new(tile_id: u16, hflip: bool, vflip: bool, palette_id: u8) -> Self {
+    pub const fn new(tile_id: u16, tile_effect: TileEffect) -> Self {
         Self {
             tile_id,
-            effect_bits: ((hflip as u16) << 10)
-                | ((vflip as u16) << 11)
-                | ((palette_id as u16) << 12),
+            tile_effect,
         }
     }
 
@@ -69,32 +72,12 @@ impl TileSetting {
     pub const fn from_raw(tile_id: u16, effect_bits: u16) -> Self {
         Self {
             tile_id,
-            effect_bits,
+            tile_effect: TileEffect(effect_bits),
         }
     }
 
-    #[must_use]
-    pub const fn hflip(self, should_flip: bool) -> Self {
-        Self {
-            effect_bits: self.effect_bits ^ ((should_flip as u16) << 10),
-            ..self
-        }
-    }
-
-    #[must_use]
-    pub const fn vflip(self, should_flip: bool) -> Self {
-        Self {
-            effect_bits: self.effect_bits ^ ((should_flip as u16) << 11),
-            ..self
-        }
-    }
-
-    #[must_use]
-    pub const fn palette(self, palette_id: u8) -> Self {
-        Self {
-            effect_bits: self.effect_bits ^ ((palette_id as u16) << 12),
-            ..self
-        }
+    pub const fn tile_effect(&mut self) -> &mut TileEffect {
+        &mut self.tile_effect
     }
 
     fn index(self) -> u16 {
@@ -102,7 +85,30 @@ impl TileSetting {
     }
 
     fn setting(self) -> u16 {
-        self.effect_bits
+        self.tile_effect.0
+    }
+}
+
+impl TileEffect {
+    #[must_use]
+    pub const fn new(hflip: bool, vflip: bool, palette_id: u8) -> Self {
+        Self(((hflip as u16) << 10) | ((vflip as u16) << 11) | ((palette_id as u16) << 12))
+    }
+
+    pub const fn hflip(&mut self, should_flip: bool) -> &mut Self {
+        self.0 ^= (should_flip as u16) << 10;
+        self
+    }
+
+    pub const fn vflip(&mut self, should_flip: bool) -> &mut Self {
+        self.0 ^= (should_flip as u16) << 11;
+        self
+    }
+
+    pub const fn palette(&mut self, palette_id: u8) -> &mut Self {
+        self.0 &= 0x0fff;
+        self.0 |= (palette_id as u16) << 12;
+        self
     }
 }
 

--- a/agb/src/display/tiled/regular_background.rs
+++ b/agb/src/display/tiled/regular_background.rs
@@ -8,8 +8,9 @@ use crate::{
 };
 
 use super::{
-    BackgroundControlRegister, BackgroundId, RegularBackgroundCommitData, RegularBackgroundData,
-    SCREENBLOCK_SIZE, TRANSPARENT_TILE_INDEX, Tile, TileFormat, TileSet, TileSetting, VRAM_MANAGER,
+    BackgroundControlRegister, BackgroundId, DynamicTile, RegularBackgroundCommitData,
+    RegularBackgroundData, SCREENBLOCK_SIZE, TRANSPARENT_TILE_INDEX, Tile, TileEffect, TileFormat,
+    TileSet, TileSetting, VRAM_MANAGER,
 };
 
 pub(crate) use screenblock::RegularBackgroundScreenblock;
@@ -124,6 +125,27 @@ impl RegularBackgroundTiles {
 
         let pos = self.screenblock.size().gba_offset(pos.into());
         self.set_tile_at_pos(pos, tileset, tile_setting);
+    }
+
+    pub fn set_tile_dynamic(
+        &mut self,
+        pos: impl Into<Vector2D<i32>>,
+        tile: &DynamicTile,
+        effect: TileEffect,
+    ) {
+        assert_eq!(
+            self.tiles.colours(),
+            TileFormat::FourBpp,
+            "Cannot set a dynamic tile on a {:?} colour background",
+            self.tiles.colours()
+        );
+
+        let pos = self.screenblock.size().gba_offset(pos.into());
+        self.set_tile_at_pos(
+            pos,
+            &tile.tile_set(),
+            TileSetting::new(tile.tile_id(), effect),
+        );
     }
 
     pub fn fill_with(&mut self, tile_data: &TileData) {

--- a/agb/src/display/tiled/vram_manager.rs
+++ b/agb/src/display/tiled/vram_manager.rs
@@ -11,7 +11,7 @@ use crate::{
     util::SyncUnsafeCell,
 };
 
-use super::{CHARBLOCK_SIZE, TileSetting, VRAM_START};
+use super::{CHARBLOCK_SIZE, VRAM_START};
 
 const PALETTE_BACKGROUND: MemoryMapped1DArray<u16, 256> =
     unsafe { MemoryMapped1DArray::new(0x0500_0000) };
@@ -182,7 +182,7 @@ impl DynamicTile {
     }
 
     #[must_use]
-    pub fn tile_set(&self) -> TileSet<'_> {
+    pub(crate) fn tile_set(&self) -> TileSet<'_> {
         let tiles = unsafe {
             slice::from_raw_parts_mut(
                 VRAM_START as *mut u8,
@@ -194,11 +194,9 @@ impl DynamicTile {
     }
 
     #[must_use]
-    pub fn tile_setting(&self) -> TileSetting {
+    pub(crate) fn tile_id(&self) -> u16 {
         let difference = self.tile_data.as_ptr() as usize - VRAM_START;
-        let tile_id = (difference / TileFormat::FourBpp.tile_size()) as u16;
-
-        TileSetting::new(tile_id, false, false, 0)
+        (difference / TileFormat::FourBpp.tile_size()) as u16
     }
 }
 


### PR DESCRIPTION
Required a new method on regular background tiles `set_tile_dynamic` sadly. But with it now you can't let the tile run out of scope while it's still visible :).

- [x] Changelog update will be part of the mega update
