### PR TITLE
Move Palette16 to the display module

### DIFF
--- a/agb-image-converter/src/rust_generator.rs
+++ b/agb-image-converter/src/rust_generator.rs
@@ -24,14 +24,14 @@ pub(crate) fn generate_palette_code(
             .take(16);
 
         quote! {
-            #crate_prefix::display::palette16::Palette16::new([
+            #crate_prefix::display::Palette16::new([
                 #(#colours),*
             ])
         }
     });
 
     quote! {
-        pub static PALETTES: &[#crate_prefix::display::palette16::Palette16] = &[#(#palettes),*];
+        pub static PALETTES: &[#crate_prefix::display::Palette16] = &[#(#palettes),*];
     }
 }
 

--- a/agb/examples/chicken.rs
+++ b/agb/examples/chicken.rs
@@ -3,9 +3,8 @@
 
 use agb::{
     display::{
-        GraphicsFrame, HEIGHT, WIDTH,
+        GraphicsFrame, HEIGHT, Palette16, WIDTH,
         object::{Object, Sprite},
-        palette16::Palette16,
         tiled::{
             RegularBackgroundSize, RegularBackgroundTiles, TileFormat, TileSet, TileSetting,
             VRAM_MANAGER,

--- a/agb/examples/dynamic_tiles.rs
+++ b/agb/examples/dynamic_tiles.rs
@@ -2,8 +2,7 @@
 #![no_main]
 
 use agb::display::{
-    Priority,
-    palette16::Palette16,
+    Palette16, Priority,
     tiled::{
         DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileEffect, TileFormat,
         VRAM_MANAGER,

--- a/agb/examples/mixer_32768.rs
+++ b/agb/examples/mixer_32768.rs
@@ -6,9 +6,8 @@ extern crate alloc;
 use agb::{
     Gba,
     display::{
-        Priority, WIDTH,
+        Palette16, Priority, WIDTH,
         font::{AlignmentKind, Font, Layout, RegularBackgroundTextRenderer},
-        palette16::Palette16,
         tiled::{
             DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileEffect, TileFormat,
             VRAM_MANAGER,

--- a/agb/examples/object_text_render.rs
+++ b/agb/examples/object_text_render.rs
@@ -3,9 +3,9 @@
 
 use agb::{
     display::{
+        Palette16,
         font::{AlignmentKind, ChangeColour, Font, Layout, SpriteTextRenderer},
         object::Size,
-        palette16::Palette16,
     },
     include_font,
 };

--- a/agb/examples/save.rs
+++ b/agb/examples/save.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use agb::{
-    display::{HEIGHT, WIDTH, object::Object, palette16::Palette16, tiled::VRAM_MANAGER},
+    display::{HEIGHT, Palette16, WIDTH, object::Object, tiled::VRAM_MANAGER},
     include_aseprite,
     input::ButtonController,
     save::{Error, SaveManager},

--- a/agb/examples/stereo_sound.rs
+++ b/agb/examples/stereo_sound.rs
@@ -6,9 +6,8 @@ extern crate alloc;
 use agb::{
     Gba,
     display::{
-        Priority, WIDTH,
+        Palette16, Priority, WIDTH,
         font::{AlignmentKind, Font, Layout, RegularBackgroundTextRenderer},
-        palette16::Palette16,
         tiled::{
             DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileEffect, TileFormat,
             VRAM_MANAGER,

--- a/agb/examples/text_render.rs
+++ b/agb/examples/text_render.rs
@@ -3,9 +3,8 @@
 
 use agb::{
     display::{
-        Priority,
+        Palette16, Priority,
         font::{AlignmentKind, Font, Layout, RegularBackgroundTextRenderer},
-        palette16::Palette16,
         tiled::{
             DynamicTile, RegularBackgroundSize, RegularBackgroundTiles, TileEffect, TileFormat,
             VRAM_MANAGER,

--- a/agb/src/display/mod.rs
+++ b/agb/src/display/mod.rs
@@ -9,13 +9,15 @@ use self::{
     window::Windows,
 };
 
+pub use palette16::{Palette16, include_palette};
+
 /// Graphics mode 3. Bitmap mode that provides a 16-bit colour framebuffer.
 pub(crate) mod bitmap3;
 /// Test logo of agb.
 pub mod example_logo;
 pub mod object;
 /// Palette type.
-pub mod palette16;
+mod palette16;
 /// Data produced by agb-image-converter
 pub mod tile_data;
 /// Graphics mode 0. Four regular backgrounds.

--- a/agb/src/display/object/sprites/sprite.rs
+++ b/agb/src/display/object/sprites/sprite.rs
@@ -183,7 +183,7 @@ macro_rules! include_aseprite {
         $v mod $module {
             #[allow(unused_imports)]
             use $crate::display::object::{Size, Sprite, Tag};
-            use $crate::display::palette16::Palette16;
+            use $crate::display::Palette16;
             use $crate::align_bytes;
 
             $crate::include_aseprite_inner!($($aseprite_path),*);
@@ -212,7 +212,7 @@ macro_rules! include_aseprite_256 {
         $v mod $module {
             #[allow(unused_imports)]
             use $crate::display::object::{Size, Sprite, Tag, PaletteMulti};
-            use $crate::display::palette16::Palette16;
+            use $crate::display::Palette16;
             use $crate::align_bytes;
 
             $crate::include_aseprite_256_inner!($($aseprite_path),*);

--- a/agb/src/no_game.rs
+++ b/agb/src/no_game.rs
@@ -4,8 +4,8 @@ use agb_fixnum::{Num, Vector2D, num};
 use alloc::vec::Vec;
 use alloc::{boxed::Box, vec};
 
+use crate::display::Palette16;
 use crate::display::object::{DynamicSprite, PaletteVramSingle, Size, SpriteVram};
-use crate::display::palette16::Palette16;
 use crate::{
     display::{HEIGHT, WIDTH, object::Object},
     include_palette,

--- a/examples/amplitude/src/lib.rs
+++ b/examples/amplitude/src/lib.rs
@@ -11,10 +11,9 @@ use core::ops::Range;
 
 use agb::{
     display::{
-        self, GraphicsFrame,
+        self, GraphicsFrame, Palette16,
         affine::AffineMatrix,
         object::{AffineMatrixInstance, AffineMode, Object, ObjectAffine, SpriteVram, Tag},
-        palette16::Palette16,
         tiled::VRAM_MANAGER,
     },
     fixnum::{Num, Vector2D, num},

--- a/examples/the-dungeon-puzzlers-lament/src/game.rs
+++ b/examples/the-dungeon-puzzlers-lament/src/game.rs
@@ -1,9 +1,8 @@
 use agb::{
     display::{
-        GraphicsFrame, HEIGHT, Priority, WIDTH,
+        GraphicsFrame, HEIGHT, Palette16, Priority, WIDTH,
         font::{AlignmentKind, Layout, SpriteTextRenderer},
         object::{Object, PaletteVramSingle, Size, SpriteVram},
-        palette16::Palette16,
         tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat},
     },
     fixnum::Vector2D,


### PR DESCRIPTION
It seems a bit silly to have a special module for `Palette16`, so I've pulled it into the `display` module.

- [x] no changelog update needed - mega update
