### PR TITLE
Remove gba display

### DIFF
--- a/agb/examples/affine_background.rs
+++ b/agb/examples/affine_background.rs
@@ -17,7 +17,7 @@ include_background_gfx!(affine_tiles, "3f3f74", water_tiles => 256 "examples/wat
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     let tileset = &affine_tiles::water_tiles.tiles;
 

--- a/agb/examples/animated_background.rs
+++ b/agb/examples/animated_background.rs
@@ -13,7 +13,7 @@ include_background_gfx!(water_tiles, water_tiles => "examples/water_tiles.png");
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
     let vblank = agb::interrupt::VBlank::get();
 
     let tileset = &water_tiles::water_tiles.tiles;

--- a/agb/examples/chicken.rs
+++ b/agb/examples/chicken.rs
@@ -55,7 +55,7 @@ fn tile_is_collidable(tile: Vector2D<i32>) -> bool {
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
     let mut input = agb::input::ButtonController::new();
 
     VRAM_MANAGER.set_background_palette(0, &MAP_PALETTE);

--- a/agb/examples/dma_effect_background_colour.rs
+++ b/agb/examples/dma_effect_background_colour.rs
@@ -12,7 +12,7 @@ use agb::display::{
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     let mut map = RegularBackgroundTiles::new(
         agb::display::Priority::P0,

--- a/agb/examples/dma_effect_background_scroll.rs
+++ b/agb/examples/dma_effect_background_scroll.rs
@@ -12,7 +12,7 @@ use agb::display::{
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     let mut map = RegularBackgroundTiles::new(
         agb::display::Priority::P0,

--- a/agb/examples/dma_effect_circular_window.rs
+++ b/agb/examples/dma_effect_circular_window.rs
@@ -21,7 +21,7 @@ fn entry(mut gba: agb::Gba) -> ! {
 }
 
 fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     let mut map = RegularBackgroundTiles::new(
         agb::display::Priority::P0,

--- a/agb/examples/dynamic_tiles.rs
+++ b/agb/examples/dynamic_tiles.rs
@@ -11,7 +11,7 @@ use agb::display::{
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     VRAM_MANAGER.set_background_palettes(&[Palette16::new([
         0xff00, 0x0ff0, 0x00ff, 0xf00f, 0xf0f0, 0x0f0f, 0xaaaa, 0x5555, 0x0000, 0x0000, 0x0000,

--- a/agb/examples/infinite_scrolled_map.rs
+++ b/agb/examples/infinite_scrolled_map.rs
@@ -15,7 +15,7 @@ include_background_gfx!(big_map, "2ce8f4", big_map => deduplicate "examples/big_
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     let mut input = ButtonController::new();
 

--- a/agb/examples/mixer_32768.rs
+++ b/agb/examples/mixer_32768.rs
@@ -26,7 +26,7 @@ static FONT: Font = include_font!("examples/font/ark-pixel-10px-proportional-ja.
 
 #[agb::entry]
 fn main(mut gba: Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
     let mut bg = RegularBackgroundTiles::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,

--- a/agb/examples/object_text_render.rs
+++ b/agb/examples/object_text_render.rs
@@ -52,7 +52,7 @@ fn main(mut gba: agb::Gba) -> ! {
         256 * (end.wrapping_sub(start) as u32)
     );
 
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     static PALETTE: Palette16 = const {
         let mut palette = [0x0; 16];

--- a/agb/examples/save.rs
+++ b/agb/examples/save.rs
@@ -64,7 +64,7 @@ impl Save {
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
     let mut save = Save::new(&mut gba.save).expect("able to read save data");
     let mut button = ButtonController::new();
 

--- a/agb/examples/stereo_sound.rs
+++ b/agb/examples/stereo_sound.rs
@@ -26,7 +26,7 @@ static FONT: Font = include_font!("examples/font/ark-pixel-10px-proportional-ja.
 
 #[agb::entry]
 fn main(mut gba: Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
     let mut bg = RegularBackgroundTiles::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,

--- a/agb/examples/test_logo.rs
+++ b/agb/examples/test_logo.rs
@@ -11,7 +11,7 @@ use agb::{
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     let mut map = RegularBackgroundTiles::new(
         agb::display::Priority::P0,

--- a/agb/examples/text_render.rs
+++ b/agb/examples/text_render.rs
@@ -17,7 +17,7 @@ static FONT: Font = include_font!("examples/font/ark-pixel-10px-proportional-ja.
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     VRAM_MANAGER.set_background_palette(
         0,

--- a/agb/examples/windows.rs
+++ b/agb/examples/windows.rs
@@ -14,7 +14,7 @@ fn entry(mut gba: agb::Gba) -> ! {
 }
 
 fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     let mut map = RegularBackgroundTiles::new(
         agb::display::Priority::P0,

--- a/agb/src/display/example_logo.rs
+++ b/agb/src/display/example_logo.rs
@@ -26,7 +26,7 @@ mod tests {
 
     #[test_case]
     fn logo_display(gba: &mut crate::Gba) {
-        let mut gfx = gba.display.graphics.get();
+        let mut gfx = gba.graphics.get();
 
         let mut map = RegularBackgroundTiles::new(
             Priority::P0,

--- a/agb/src/display/font/sprite.rs
+++ b/agb/src/display/font/sprite.rs
@@ -50,7 +50,7 @@ mod tests {
 
     #[test_case]
     fn check_font_rendering_simple(gba: &mut crate::Gba) {
-        let mut gfx = gba.display.graphics.get();
+        let mut gfx = gba.graphics.get();
 
         static PALETTE: Palette16 = const {
             let mut palette = [0x0; 16];
@@ -88,7 +88,7 @@ mod tests {
 
     #[test_case]
     fn check_japanese_rendering(gba: &mut crate::Gba) {
-        let mut gfx = gba.display.graphics.get();
+        let mut gfx = gba.graphics.get();
 
         static PALETTE: Palette16 = const {
             let mut palette = [0x0; 16];

--- a/agb/src/display/font/tiled.rs
+++ b/agb/src/display/font/tiled.rs
@@ -97,7 +97,7 @@ mod test {
 
     #[test_case]
     fn background_text_render_english(gba: &mut Gba) {
-        let mut gfx = gba.display.graphics.get();
+        let mut gfx = gba.graphics.get();
 
         static PALETTE: Palette16 = const {
             let mut palette = [0x0; 16];
@@ -141,7 +141,7 @@ mod test {
 
     #[test_case]
     fn background_text_render_japanese(gba: &mut Gba) {
-        let mut gfx = gba.display.graphics.get();
+        let mut gfx = gba.graphics.get();
 
         static PALETTE: Palette16 = const {
             let mut palette = [0x0; 16];

--- a/agb/src/display/mod.rs
+++ b/agb/src/display/mod.rs
@@ -44,12 +44,6 @@ pub const WIDTH: i32 = 240;
 pub const HEIGHT: i32 = 160;
 
 #[non_exhaustive]
-/// Manages distribution of display modes, obtained from the gba struct
-pub struct Display {
-    pub graphics: GraphicsDist,
-}
-
-#[non_exhaustive]
 pub struct GraphicsDist;
 
 impl GraphicsDist {
@@ -105,14 +99,6 @@ impl GraphicsFrame<'_> {
 
     pub fn windows(&mut self) -> &mut Windows {
         &mut self.windows
-    }
-}
-
-impl Display {
-    pub(crate) const unsafe fn new() -> Self {
-        Display {
-            graphics: GraphicsDist,
-        }
     }
 }
 

--- a/agb/src/display/object/unmanaged/object.rs
+++ b/agb/src/display/object/unmanaged/object.rs
@@ -425,7 +425,7 @@ mod tests {
             "../examples/the-purple-night/gfx/boss.aseprite"
         );
 
-        let mut gfx = gba.display.graphics.get();
+        let mut gfx = gba.graphics.get();
 
         {
             let mut frame = gfx.frame();

--- a/agb/src/display/tiled/regular_background/test.rs
+++ b/agb/src/display/tiled/regular_background/test.rs
@@ -10,7 +10,7 @@ fn test_commit_in_basic_case(gba: &mut Gba) {
     let vblank = VBlank::get();
     vblank.wait_for_vblank();
 
-    let mut graphics = gba.display.graphics.get();
+    let mut graphics = gba.graphics.get();
     VRAM_MANAGER.set_background_palettes(agb_logo::PALETTES);
 
     let mut bg_data = RegularBackgroundTiles::new(
@@ -39,7 +39,7 @@ fn test_commit_when_background_tiles_are_modified_after_show(gba: &mut Gba) {
     let vblank = VBlank::get();
     vblank.wait_for_vblank();
 
-    let mut graphics = gba.display.graphics.get();
+    let mut graphics = gba.graphics.get();
     VRAM_MANAGER.set_background_palettes(agb_logo::PALETTES);
 
     let mut bg_data = RegularBackgroundTiles::new(
@@ -76,7 +76,7 @@ fn test_commit_when_background_tiles_are_dropped_after_show(gba: &mut Gba) {
     let vblank = VBlank::get();
     vblank.wait_for_vblank();
 
-    let mut graphics = gba.display.graphics.get();
+    let mut graphics = gba.graphics.get();
     VRAM_MANAGER.set_background_palettes(agb_logo::PALETTES);
 
     let mut bg_data = RegularBackgroundTiles::new(
@@ -109,7 +109,7 @@ fn test_commit_when_background_tiles_rendered_twice(gba: &mut Gba) {
     let vblank = VBlank::get();
     vblank.wait_for_vblank();
 
-    let mut graphics = gba.display.graphics.get();
+    let mut graphics = gba.graphics.get();
     VRAM_MANAGER.set_background_palettes(agb_logo::PALETTES);
 
     let mut bg_data = RegularBackgroundTiles::new(

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -278,7 +278,7 @@ fn avoid_double_panic(info: &core::panic::PanicInfo) {
 #[non_exhaustive]
 pub struct Gba {
     /// Manages access to the Game Boy Advance's display hardware
-    pub display: display::Display,
+    pub graphics: display::GraphicsDist,
     /// Manages access to the Game Boy Advance's direct sound mixer for playing raw wav files.
     pub mixer: sound::mixer::MixerController,
     /// Manages access to the Game Boy Advance cartridge's save chip.
@@ -308,7 +308,7 @@ impl Gba {
 
     const unsafe fn single_new() -> Self {
         Self {
-            display: unsafe { display::Display::new() },
+            graphics: display::GraphicsDist,
             mixer: sound::mixer::MixerController::new(),
             save: save::SaveManager::new(),
             timers: timer::TimerController::new(),

--- a/agb/src/no_game.rs
+++ b/agb/src/no_game.rs
@@ -139,7 +139,7 @@ fn generate_sprites() -> Box<[SpriteVram]> {
 }
 
 pub fn no_game(mut gba: crate::Gba) -> ! {
-    let mut gfx: crate::display::Graphics<'_> = gba.display.graphics.get();
+    let mut gfx: crate::display::Graphics<'_> = gba.graphics.get();
 
     let squares = generate_sprites();
 

--- a/book/games/pong/src/main.rs
+++ b/book/games/pong/src/main.rs
@@ -78,7 +78,7 @@ impl Paddle {
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
     // Get the graphics manager
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     let mut button_controller = ButtonController::new();
 

--- a/book/src/pong/03_sprites.md
+++ b/book/src/pong/03_sprites.md
@@ -60,7 +60,7 @@ Using the `Gba` struct we get the [`Oam` struct](https://docs.rs/agb/latest/agb/
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
     // Get the graphics manager, responsible for all the graphics
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     // Create an object with the ball sprite
     let mut ball = Object::new(sprites::BALL.sprite(0));

--- a/examples/amplitude/src/lib.rs
+++ b/examples/amplitude/src/lib.rs
@@ -364,7 +364,7 @@ struct FinalisedSettings {
 }
 
 pub fn main(mut gba: agb::Gba) -> ! {
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
     let sprite_cache = SpriteCache::new();
 
     VRAM_MANAGER.set_background_palettes(&[Palette16::new([u16::MAX; 16])]);

--- a/examples/combo/src/lib.rs
+++ b/examples/combo/src/lib.rs
@@ -52,7 +52,7 @@ include_background_gfx!(
 fn get_game(gba: &mut agb::Gba) -> Game {
     let mut input = agb::input::ButtonController::new();
 
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
 
     VRAM_MANAGER.set_background_palettes(games::PALETTES);
 

--- a/examples/hyperspace-roll/src/lib.rs
+++ b/examples/hyperspace-roll/src/lib.rs
@@ -99,7 +99,7 @@ pub fn main(mut gba: agb::Gba) -> ! {
         save::save_high_score(&mut gba.save, 0).expect("Could not reset high score");
     }
 
-    let gfx = gba.display.graphics.get();
+    let gfx = gba.graphics.get();
 
     let basic_die = Die {
         faces: [

--- a/examples/the-dungeon-puzzlers-lament/src/lib.rs
+++ b/examples/the-dungeon-puzzlers-lament/src/lib.rs
@@ -55,7 +55,7 @@ impl<'gba> Agb<'gba> {
 pub fn entry(mut gba: agb::Gba) -> ! {
     let _ = save::init_save(&mut gba);
 
-    let gfx = gba.display.graphics.get();
+    let gfx = gba.graphics.get();
     let mut ui_bg = RegularBackgroundTiles::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,

--- a/examples/the-hat-chooses-the-wizard/src/lib.rs
+++ b/examples/the-hat-chooses-the-wizard/src/lib.rs
@@ -746,7 +746,7 @@ impl<'a> PlayingLevel<'a> {
 }
 
 pub fn main(mut agb: agb::Gba) -> ! {
-    let mut gfx = agb.display.graphics.get();
+    let mut gfx = agb.graphics.get();
     VRAM_MANAGER.set_background_palettes(tile_sheet::PALETTES);
 
     let tileset = &tile_sheet::background.tiles;

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -2075,7 +2075,7 @@ fn game_with_level(gba: &mut agb::Gba) {
 
     let mut start_at_boss = false;
 
-    let mut gfx = gba.display.graphics.get();
+    let mut gfx = gba.graphics.get();
     VRAM_MANAGER.set_background_palettes(background::PALETTES);
 
     loop {


### PR DESCRIPTION
change `gba.display.graphics.get()` -> `gba.graphics.get()`

- [x] no changelog update needed - part of the mega update
