### PR TITLE
Rustdoc comments for regular backgrounds

### DIFF
--- a/agb/examples/dma_effect_circular_window.rs
+++ b/agb/examples/dma_effect_circular_window.rs
@@ -5,9 +5,8 @@ extern crate alloc;
 
 use agb::{
     display::{
-        HEIGHT, WIDTH, example_logo,
+        HEIGHT, WIDTH, WinIn, example_logo,
         tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat},
-        window::WinIn,
     },
     dma::HBlankDmaDefinition,
     fixnum::{Num, Rect, Vector2D},

--- a/agb/examples/windows.rs
+++ b/agb/examples/windows.rs
@@ -3,7 +3,7 @@
 
 use agb::display::tiled::{RegularBackgroundTiles, TileFormat};
 use agb::display::{BlendLayer, HEIGHT, WIDTH};
-use agb::display::{example_logo, tiled::RegularBackgroundSize, window::WinIn};
+use agb::display::{WinIn, example_logo, tiled::RegularBackgroundSize};
 use agb::fixnum::{Num, Rect, Vector2D, num};
 
 type FNum = Num<i32, 8>;

--- a/agb/src/display/mod.rs
+++ b/agb/src/display/mod.rs
@@ -5,10 +5,7 @@ use bilge::prelude::*;
 
 use tiled::{BackgroundFrame, DisplayControlRegister, TiledBackground};
 
-use self::{
-    object::{Oam, OamFrame, initilise_oam},
-    window::Windows,
-};
+use object::{Oam, OamFrame, initilise_oam};
 
 pub use colours::{Rgb, Rgb15};
 pub use palette16::{Palette16, include_palette};
@@ -27,7 +24,7 @@ pub mod tiled;
 
 pub mod affine;
 mod blend;
-pub mod window;
+mod window;
 
 pub mod font;
 
@@ -39,6 +36,8 @@ const VCOUNT: MemoryMapped<u16> = unsafe { MemoryMapped::new(0x0400_0006) };
 pub use blend::{
     Blend, BlendAlphaEffect, BlendFadeEffect, BlendObjectTransparency, Layer as BlendLayer,
 };
+
+pub use window::{MovableWindow, WinIn, Window, Windows};
 
 /// Width of the Gameboy advance screen in pixels
 pub const WIDTH: i32 = 240;

--- a/agb/src/display/tiled.rs
+++ b/agb/src/display/tiled.rs
@@ -15,7 +15,9 @@ use alloc::rc::Rc;
 pub use infinite_scrolled_map::{InfiniteScrolledMap, PartialUpdateStatus};
 use regular_background::RegularBackgroundScreenblock;
 pub use regular_background::{RegularBackgroundSize, RegularBackgroundTiles};
-pub use vram_manager::{DynamicTile, TileFormat, TileIndex, TileSet, VRAM_MANAGER};
+pub use vram_manager::{DynamicTile, TileFormat, TileSet, VRAM_MANAGER};
+
+pub(crate) use vram_manager::TileIndex;
 
 pub(crate) use registers::*;
 

--- a/agb/src/display/tiled/regular_background.rs
+++ b/agb/src/display/tiled/regular_background.rs
@@ -27,7 +27,7 @@ mod tiles;
 /// size you can while minimising the number of times you have to redraw tiles.
 ///
 /// If you want more space than can be provided here, or want to keep more video ram free, then you should use
-/// the [`InfiniteScrolledMap`](super::InfiniteScrolledMap) which will dynamically load tile data for any size
+/// the [`InfiniteScrolle   p`](super::InfiniteScrolledMap) which will dynamically load tile data for any size
 /// as you scroll around.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u16)]
@@ -285,6 +285,8 @@ impl RegularBackgroundTiles {
     /// Note that after this call, any modifications made to the background will _not_ show this frame. Effectively
     /// calling `show()` takes a snapshot of the current state of the background, so you can even modify
     /// the background and `show()` it again and both will show in the frame.
+    ///
+    /// The returned [`BackgroundId`] can be passed to a [`Blend`](crate::display::Blend) or [`Window`](crate::display::Window).
     ///
     /// # Panics
     ///

--- a/agb/src/display/tiled/regular_background.rs
+++ b/agb/src/display/tiled/regular_background.rs
@@ -313,6 +313,17 @@ impl RegularBackgroundTiles {
         self.screenblock.size()
     }
 
+    /// Gets the [`Priority`] of this background.
+    #[must_use]
+    pub fn priority(&self) -> Priority {
+        self.priority
+    }
+
+    /// Sets the [`Priority`] of this background. This won't take effect until the next call to [`show()`](RegularBackgroundTiles::show())
+    pub fn set_priority(&mut self, priority: Priority) {
+        self.priority = priority;
+    }
+
     fn bg_ctrl_value(&self) -> BackgroundControlRegister {
         let mut background_control_register = BackgroundControlRegister::default();
 

--- a/agb/src/display/tiled/vram_manager.rs
+++ b/agb/src/display/tiled/vram_manager.rs
@@ -79,7 +79,7 @@ impl<'a> TileSet<'a> {
 /// Tile indices are used to reference specific 8x8 pixel blocks of data stored in the GBA's
 /// Video RAM (VRAM).
 #[derive(Debug, Clone, Copy)]
-pub enum TileIndex {
+pub(crate) enum TileIndex {
     /// 4 bits per pixel, allowing for 16 colours per tile
     FourBpp(u16),
     /// 8 bits per pixel, allowing for 256 colours per tile


### PR DESCRIPTION
Added rustdoc comments for regular backgrounds. Could probably do with some more examples, but that can come later.

- [x] no changelog update needed
