### PR TITLE
Hopefully improve performance of add_tile

### DIFF
--- a/agb/src/display/tiled/affine_background.rs
+++ b/agb/src/display/tiled/affine_background.rs
@@ -131,9 +131,6 @@ impl AffineBackgroundTiles {
 
     fn set_tile_at_pos(&mut self, pos: usize, tileset: &TileSet<'_>, tile_index: u16) {
         let old_tile = self.tiles.get(pos);
-        if old_tile != 0 {
-            VRAM_MANAGER.remove_tile(TileIndex::EightBpp(old_tile as u16));
-        }
 
         let new_tile = if tile_index != TRANSPARENT_TILE_INDEX {
             let new_tile_idx = VRAM_MANAGER.add_tile(tileset, tile_index);
@@ -146,6 +143,10 @@ impl AffineBackgroundTiles {
         } else {
             0
         };
+
+        if old_tile != 0 {
+            VRAM_MANAGER.remove_tile(TileIndex::EightBpp(old_tile as u16));
+        }
 
         if old_tile == new_tile {
             return;

--- a/agb/src/display/tiled/regular_background.rs
+++ b/agb/src/display/tiled/regular_background.rs
@@ -254,9 +254,6 @@ impl RegularBackgroundTiles {
 
     fn set_tile_at_pos(&mut self, pos: usize, tileset: &TileSet<'_>, tile_setting: TileSetting) {
         let old_tile = self.tiles.get(pos);
-        if old_tile != Tile::default() {
-            VRAM_MANAGER.remove_tile(old_tile.tile_index(self.tiles.colours()));
-        }
 
         let tile_index = tile_setting.index();
 
@@ -266,6 +263,10 @@ impl RegularBackgroundTiles {
         } else {
             Tile::default()
         };
+
+        if old_tile != Tile::default() {
+            VRAM_MANAGER.remove_tile(old_tile.tile_index(self.tiles.colours()));
+        }
 
         if old_tile == new_tile {
             // no need to mark as dirty if nothing changes


### PR DESCRIPTION
Removing first could take the reference count to 0, and add it to the GC
queue to be processed at GC time. However, if we're then adding the same
tile back on, it doesn't get removed from the GC queue.

By adding the new tile on, and then removing the old one, if it's the
same tile, we just increase the reference count to 2 and then back down
to 1.

Setting a tile to itself is a reasonably common operation, and it isn't
that uncommon for tiles to be unique across the screen too, so hopefully
this'll improve performance and either way is probably the cause of the
incredibly bad performance of the old tile rendering before the more
recent refactor (in addition to the other horribly inefficient code that
was there).

- [x] no changelog update needed
