### PR TITLE
Rustdoc comments for infinite scrolled map

### DIFF
--- a/agb/examples/infinite_scrolled_map.rs
+++ b/agb/examples/infinite_scrolled_map.rs
@@ -37,7 +37,7 @@ fn main(mut gba: agb::Gba) -> ! {
 
         current_pos += input.vector();
 
-        infinite_scrolled.set_pos(current_pos, |p| {
+        infinite_scrolled.set_scroll_pos(current_pos, |p| {
             (
                 &big_map::big_map.tiles,
                 big_map::big_map.tile_settings

--- a/examples/combo/src/lib.rs
+++ b/examples/combo/src/lib.rs
@@ -80,7 +80,7 @@ fn get_game(gba: &mut agb::Gba) -> Game {
 
         position.x += (Num::new(game_idx * 30 * 8) - position.x) / 8;
 
-        bg.set_pos(position.floor(), |pos| {
+        bg.set_scroll_pos(position.floor(), |pos| {
             let y = pos.y.rem_euclid(20);
             let x = pos.x.rem_euclid(30);
 

--- a/examples/the-hat-chooses-the-wizard/src/lib.rs
+++ b/examples/the-hat-chooses-the-wizard/src/lib.rs
@@ -271,26 +271,30 @@ impl Map<'_> {
     pub fn commit_position(&mut self) {
         let tileset = &tile_sheet::background.tiles;
 
-        self.background.set_pos(self.position.floor(), |pos| {
-            (
-                tileset,
-                tile_sheet::background.tile_settings[*self
-                    .level
-                    .background
-                    .get((pos.y * self.level.dimensions.x as i32 + pos.x) as usize)
-                    .unwrap_or(&0) as usize],
-            )
-        });
-        self.foreground.set_pos(self.position.floor(), |pos| {
-            (
-                tileset,
-                tile_sheet::background.tile_settings[*self
-                    .level
-                    .foreground
-                    .get((pos.y * self.level.dimensions.x as i32 + pos.x) as usize)
-                    .unwrap_or(&0) as usize],
-            )
-        });
+        self.background
+            .set_scroll_pos(self.position.floor(), |pos| {
+                (
+                    tileset,
+                    tile_sheet::background.tile_settings[*self
+                        .level
+                        .background
+                        .get((pos.y * self.level.dimensions.x as i32 + pos.x) as usize)
+                        .unwrap_or(&0)
+                        as usize],
+                )
+            });
+        self.foreground
+            .set_scroll_pos(self.position.floor(), |pos| {
+                (
+                    tileset,
+                    tile_sheet::background.tile_settings[*self
+                        .level
+                        .foreground
+                        .get((pos.y * self.level.dimensions.x as i32 + pos.x) as usize)
+                        .unwrap_or(&0)
+                        as usize],
+                )
+            });
     }
 
     fn show(&self, frame: &mut GraphicsFrame) {

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -21,7 +21,7 @@ use agb::{
             VRAM_MANAGER,
         },
     },
-    fixnum::{FixedNum, Rect, Vector2D, num},
+    fixnum::{FixedNum, Rect, Vector2D, num, vec2},
     input::{Button, ButtonController, Tri},
     rng,
     sound::mixer::Frequency,
@@ -1884,34 +1884,43 @@ impl Game {
         self.player.show(frame, this_frame_offset);
         self.boss.show(frame, this_frame_offset);
 
-        let background_offset = (this_frame_offset.floor().x, 8).into();
+        let background_offset = vec2(this_frame_offset.floor().x, 8);
 
         let tileset = &background::background.tiles;
 
-        self.level.background.set_pos(background_offset, |pos| {
-            (
-                tileset,
-                background::background.tile_settings[*tilemap::BACKGROUND_MAP
-                    .get((pos.x + tilemap::WIDTH * pos.y) as usize)
-                    .unwrap_or(&0) as usize],
-            )
-        });
-        self.level.foreground.set_pos(background_offset, |pos| {
-            (
-                tileset,
-                background::background.tile_settings[*tilemap::FOREGROUND_MAP
-                    .get((pos.x + tilemap::WIDTH * pos.y) as usize)
-                    .unwrap_or(&0) as usize],
-            )
-        });
-        self.level.clouds.set_pos(background_offset / 4, |pos| {
-            (
-                tileset,
-                background::background.tile_settings[*tilemap::CLOUD_MAP
-                    .get((pos.x + tilemap::WIDTH * pos.y) as usize)
-                    .unwrap_or(&0) as usize],
-            )
-        });
+        self.level
+            .background
+            .set_scroll_pos(background_offset, |pos| {
+                (
+                    tileset,
+                    background::background.tile_settings[*tilemap::BACKGROUND_MAP
+                        .get((pos.x + tilemap::WIDTH * pos.y) as usize)
+                        .unwrap_or(&0)
+                        as usize],
+                )
+            });
+        self.level
+            .foreground
+            .set_scroll_pos(background_offset, |pos| {
+                (
+                    tileset,
+                    background::background.tile_settings[*tilemap::FOREGROUND_MAP
+                        .get((pos.x + tilemap::WIDTH * pos.y) as usize)
+                        .unwrap_or(&0)
+                        as usize],
+                )
+            });
+        self.level
+            .clouds
+            .set_scroll_pos(background_offset / 4, |pos| {
+                (
+                    tileset,
+                    background::background.tile_settings[*tilemap::CLOUD_MAP
+                        .get((pos.x + tilemap::WIDTH * pos.y) as usize)
+                        .unwrap_or(&0)
+                        as usize],
+                )
+            });
 
         for i in remove {
             self.enemies.remove(i);


### PR DESCRIPTION
Also renames `set_pos` to `set_scroll_pos`

- [x] no changelog update needed - more methods added, part of the mega update
