### PR TITLE
Const fn num macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Introduced `agb::display::{Rgb15, Rgb}` to represent colours and allow for basic interpolation and conversion.
+- You can now pass any constant expression to the `num!` macro.
 
 ### Changed
 

--- a/agb-fixnum/Cargo.toml
+++ b/agb-fixnum/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["no-std", "no-std::no-alloc"]
 serde = ["dep:serde"]
 
 [dependencies]
-const_soft_float = { version = "0.1.4", features = ["no_std"] }
+const_soft_float = { version = "0.1", features = ["no_std"] }
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1", features = [
     "derive",

--- a/agb-fixnum/Cargo.toml
+++ b/agb-fixnum/Cargo.toml
@@ -11,6 +11,8 @@ categories = ["no-std", "no-std::no-alloc"]
 serde = ["dep:serde"]
 
 [dependencies]
-agb_macros = { version = "0.21.3", path = "../agb-macros" }
+const_soft_float = { version = "0.1.4", features = ["no_std"] }
 num-traits = { version = "0.2", default-features = false }
-serde = { version = "1", features = ["derive"], default-features = false, optional = true }
+serde = { version = "1", features = [
+    "derive",
+], default-features = false, optional = true }

--- a/agb-fixnum/src/lib.rs
+++ b/agb-fixnum/src/lib.rs
@@ -23,10 +23,11 @@ pub mod __private {
 /// # use agb_fixnum::{Num, num};
 /// let n: Num<i32, 8> = num!(0.75);
 /// assert_eq!(n, Num::new(3) / 4, "0.75 == 3/4");
+/// assert_eq!(n, num!(3. / 4.));
 /// ```
 #[macro_export]
 macro_rules! num {
-    ($value:literal) => {
+    ($value:expr) => {
         $crate::Num::new_from_parts(
             const {
                 use $crate::__private::const_soft_float::soft_f64::SoftF64;

--- a/agb-macros/src/lib.rs
+++ b/agb-macros/src/lib.rs
@@ -125,19 +125,6 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
     .into()
 }
 
-#[proc_macro]
-pub fn num(input: TokenStream) -> TokenStream {
-    let f = syn::parse_macro_input!(input as syn::LitFloat);
-    let v: f64 = f.base10_parse().expect("The number should be parsable");
-
-    let integer = v.trunc();
-    let fractional = v.fract() * (1_u64 << 30) as f64;
-
-    let integer = integer as i32;
-    let fractional = fractional as i32;
-    quote!((#integer, #fractional)).into()
-}
-
 fn hashed_ident<T: Hash>(f: &T) -> Ident {
     let hash = calculate_hash(f);
     Ident::new(&format!("_agb_main_func_{hash}"), Span::call_site())


### PR DESCRIPTION
Now that you can use floats in const contexts, we can mess around with floats inside `num!` and be able to put constant expressions in there rather than just float literals.

- [x] Changelog updated
