### PR TITLE
Delete the docs from agb-image-converter so it doesn't appear twice in agb

### DIFF
--- a/agb-image-converter/src/lib.rs
+++ b/agb-image-converter/src/lib.rs
@@ -176,15 +176,6 @@ impl config::Config for IncludeBackgroundGfxInput {
     }
 }
 
-/// Including from the out directory is supported through the `$OUT_DIR` token.
-///
-/// ```rust,ignore
-/// # #![no_std]
-/// # #![no_main]
-/// # use agb::include_background_gfx;
-/// include_background_gfx!(mod generated_background, "000000", DATA => "$OUT_DIR/generated_background.aseprite");
-/// ```
-///
 #[proc_macro]
 pub fn include_background_gfx(input: TokenStream) -> TokenStream {
     let config = Box::new(parse_macro_input!(input as IncludeBackgroundGfxInput));


### PR DESCRIPTION

- [x] no changelog update needed
