### PR TITLE
Fix dma when passing more than 160 values

### DIFF
--- a/agb/src/dma.rs
+++ b/agb/src/dma.rs
@@ -65,7 +65,7 @@ where
 
         let mut copied_values = Box::into_pin(Box::new([const { MaybeUninit::uninit() }; 161]));
         copied_values[..160].copy_from_slice(unsafe {
-            core::mem::transmute::<&[Item], &[MaybeUninit<Item>]>(values)
+            core::mem::transmute::<&[Item], &[MaybeUninit<Item>]>(&values[..160])
         });
 
         copied_values[160].write(values[0]);

--- a/justfile
+++ b/justfile
@@ -137,7 +137,7 @@ build-site-examples: build-release
         just gbafix "$CARGO_TARGET_DIR/thumbv4t-none-eabi/release/examples/$EXAMPLE" --output="$CARGO_TARGET_DIR/thumbv4t-none-eabi/release/examples/$EXAMPLE.gba"
         cp "agb/examples/$EXAMPLE_NAME" "website/agb/src/roms/examples/$EXAMPLE_NAME"
         gzip -9 -c $CARGO_TARGET_DIR/thumbv4t-none-eabi/release/examples/$EXAMPLE.gba > website/agb/src/roms/examples/$EXAMPLE.gba.gz
-        just generate-screenshot --rom="$CARGO_TARGET_DIR/thumbv4t-none-eabi/release/examples/$EXAMPLE.gba" --frames=10 --output=website/agb/src/roms/examples/$EXAMPLE.png
+        just generate-screenshot --rom="$CARGO_TARGET_DIR/thumbv4t-none-eabi/release/examples/$EXAMPLE.gba" --frames=100 --output=website/agb/src/roms/examples/$EXAMPLE.png
         EXAMPLE_IMAGE_IMPORTS="$EXAMPLE_IMAGE_IMPORTS import $EXAMPLE from './$EXAMPLE.png';"
         EXAMPLE_DEFINITIONS="$EXAMPLE_DEFINITIONS {url: new URL('./$EXAMPLE.gba.gz', import.meta.url), example_name: '$EXAMPLE', screenshot: $EXAMPLE},"
     done


### PR DESCRIPTION
The new method required exactly 160 values which isn't actually what we want. We want at least 160 values.

Also update the screenshot generation to generate a screenshot on frame 100 rather than 10 because we have a few examples which require more setup time (mainly the new dma ones)

- [x] no changelog update needed
