### PR TITLE
Better affine tile allocation

### DIFF
--- a/agb/src/display/tiled/affine_background.rs
+++ b/agb/src/display/tiled/affine_background.rs
@@ -137,7 +137,7 @@ impl AffineBackgroundTiles {
         let old_tile = self.tiles.get(pos);
 
         let new_tile = if tile_index != TRANSPARENT_TILE_INDEX {
-            let new_tile_idx = VRAM_MANAGER.add_tile(tileset, tile_index);
+            let new_tile_idx = VRAM_MANAGER.add_tile(tileset, tile_index, true);
             if new_tile_idx.raw_index() > u8::MAX as u16 {
                 VRAM_MANAGER.remove_tile(new_tile_idx);
                 0

--- a/agb/src/display/tiled/regular_background.rs
+++ b/agb/src/display/tiled/regular_background.rs
@@ -290,7 +290,7 @@ impl RegularBackgroundTiles {
         let tile_index = tile_setting.tile_id();
 
         let new_tile = if tile_index != TRANSPARENT_TILE_INDEX {
-            let new_tile_idx = VRAM_MANAGER.add_tile(tileset, tile_index);
+            let new_tile_idx = VRAM_MANAGER.add_tile(tileset, tile_index, false);
             Tile::new(new_tile_idx, tile_setting)
         } else {
             Tile::default()

--- a/agb/src/display/tiled/vram_manager/tile_allocator.rs
+++ b/agb/src/display/tiled/vram_manager/tile_allocator.rs
@@ -1,0 +1,61 @@
+use core::{alloc::Layout, ptr::NonNull};
+
+use crate::{
+    agb_alloc::{block_allocator::BlockAllocator, bump_allocator::StartEnd},
+    display::tiled::{CHARBLOCK_SIZE, VRAM_START},
+};
+
+use super::TileFormat;
+
+const fn layout_of(format: TileFormat) -> Layout {
+    unsafe { Layout::from_size_align_unchecked(format.tile_size(), format.tile_size()) }
+}
+
+const AFFINE_ALLOC_END: usize = VRAM_START + 256 * 8 * 8 / 2;
+
+static AFFINE_TILE_ALLOCATOR: BlockAllocator = unsafe {
+    BlockAllocator::new(StartEnd {
+        start: || VRAM_START + 8 * 8,
+        end: || AFFINE_ALLOC_END,
+    })
+};
+
+static TILE_ALLOCATOR: BlockAllocator = unsafe {
+    BlockAllocator::new(StartEnd {
+        start: || AFFINE_ALLOC_END,
+        end: || VRAM_START + CHARBLOCK_SIZE * 2,
+    })
+};
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct TileAllocator;
+
+impl TileAllocator {
+    pub unsafe fn alloc_for_regular(self, tile_format: TileFormat) -> NonNull<u32> {
+        let layout = layout_of(tile_format);
+
+        unsafe {
+            match TILE_ALLOCATOR.alloc(layout) {
+                Some(ptr) => ptr,
+                None => AFFINE_TILE_ALLOCATOR
+                    .alloc(layout)
+                    .expect("Ran out of video RAM for tiles"),
+            }
+        }
+        .cast()
+    }
+
+    pub unsafe fn dealloc(self, ptr: NonNull<u32>, tile_format: TileFormat) {
+        let layout = layout_of(tile_format);
+
+        let allocator = if ptr.addr().get() < AFFINE_ALLOC_END {
+            &AFFINE_TILE_ALLOCATOR
+        } else {
+            &TILE_ALLOCATOR
+        };
+
+        unsafe {
+            allocator.dealloc(ptr.cast().as_ptr(), layout);
+        }
+    }
+}

--- a/agb/src/display/tiled/vram_manager/tile_allocator.rs
+++ b/agb/src/display/tiled/vram_manager/tile_allocator.rs
@@ -45,6 +45,17 @@ impl TileAllocator {
         .cast()
     }
 
+    pub unsafe fn alloc_for_affine(self) -> NonNull<u32> {
+        let layout = layout_of(TileFormat::EightBpp);
+
+        unsafe {
+            AFFINE_TILE_ALLOCATOR
+                .alloc(layout)
+                .expect("Ran out of video RAM for tiles")
+        }
+        .cast()
+    }
+
     pub unsafe fn dealloc(self, ptr: NonNull<u32>, tile_format: TileFormat) {
         let layout = layout_of(tile_format);
 


### PR DESCRIPTION
Affine backgrounds require their tiles to be within the first 256 tiles. This is a pain, and currently only happens by accident in agb.

This PR addresses this issue by allocating all regular tiles to _after_ the first 256 tiles, and then to the first 256 tiles if that runs out of space. It leaves affine tiles to go in the first 256 tiles.

- [x] no changelog update needed - part of the mega update
