### PR TITLE
'Document' mgba module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `round` methods for `Num` and `Vector2D` that rounds towards the nearest integer.
 - Added `clamp_point` and corner methods to `Rect`.
 - Added `width` and `height` to `TileData` to track the original size of your backgrounds.
+- Added an `eprintln!()` macro which prints at error level for mgba
 
 ### Changed
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the dmg audio module. It will return in future but with a better thought out API which will work together with the existing mixer
 - Removed `VRamManager.set_background_palette_raw` since it is actually unsafe and didn't work as intended for smaller palettes in release mode
 - Removed the `syscall` module and put the useful `halt` method in `agb::halt()`.
+- Removed the `mgba` module since you should do all printing via the `println!()` macro.
 
 ## [0.21.3] - 2025/02/01
 

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -288,13 +288,15 @@ pub mod input;
 pub mod interrupt;
 mod memory_mapped;
 /// Implements logging to the mgba emulator.
-pub mod mgba;
+pub(crate) mod mgba;
 #[doc(inline)]
 pub use agb_fixnum as fixnum;
 /// Contains an implementation of a hashmap which suits the Game Boy Advance's hardware.
 pub use agb_hashmap as hash_map;
 #[cfg(feature = "backtrace")]
 mod panics_render;
+#[doc(hidden)]
+pub mod print;
 pub(crate) mod refcount;
 /// Simple random number generator
 pub mod rng;

--- a/agb/src/mgba.rs
+++ b/agb/src/mgba.rs
@@ -79,14 +79,3 @@ impl core::fmt::Write for MgbaWriter {
         Ok(())
     }
 }
-
-#[macro_export]
-macro_rules! println {
-    ($( $x:expr ),*) => {
-        {
-            if let Some(mut mgba) = $crate::mgba::Mgba::new() {
-                let _ = mgba.print(format_args!($($x,)*), $crate::mgba::DebugLevel::Info);
-            }
-        }
-    };
-}

--- a/agb/src/print.rs
+++ b/agb/src/print.rs
@@ -1,0 +1,62 @@
+use core::fmt::Arguments;
+
+use crate::mgba::{DebugLevel, Mgba};
+
+#[doc(hidden)]
+pub fn println(args: Arguments) {
+    if let Some(mut mgba) = Mgba::new() {
+        let _ = mgba.print(args, DebugLevel::Info);
+    }
+}
+
+#[doc(hidden)]
+pub fn eprintln(args: Arguments) {
+    if let Some(mut mgba) = Mgba::new() {
+        let _ = mgba.print(args, DebugLevel::Error);
+    }
+}
+
+/// Works like [`std::println`](https://doc.rust-lang.org/stable/std/macro.println.html)
+///
+/// Prints to the standard output when running under the mgba emulator.
+/// This is mainly useful for debugging, and is reasonably slow.
+///
+/// ```rust
+/// ##![no_std]
+/// ##![no_main]
+/// # core::include!("doctest_runner.rs");
+///
+/// # fn test(_: agb::Gba) {
+/// agb::println!("Hello, World!");
+///
+/// let variable = 5;
+/// agb::println!("format {variable} argument");
+/// # }
+/// ```
+#[macro_export]
+macro_rules! println {
+    ($( $x:expr ),*) => {
+        $crate::print::println(format_args!($($x,)*))
+    };
+}
+
+/// Works like [`std::println`](https://doc.rust-lang.org/stable/std/macro.println.html)
+///
+/// Prints to the standard output when running under the mgba emulator but with the error level internally
+/// This is mainly intended for debugging, and is reasonably slow.
+///
+/// ```rust
+/// ##![no_std]
+/// ##![no_main]
+/// # core::include!("doctest_runner.rs");
+///
+/// # fn test(_: agb::Gba) {
+/// agb::eprintln!("error: Could not load save file");
+/// # }
+/// ```
+#[macro_export]
+macro_rules! eprintln {
+    ($( $x:expr ),*) => {
+        $crate::print::eprintln(format_args!($($x,)*))
+    };
+}


### PR DESCRIPTION
I removed it (and replaced it with recommendation to use the `println!` macro and the new `eprintln!` macro)

- [x] Changelog updated