### PR TITLE
Inline the docs for agb-hashmap

### DIFF
--- a/agb-hashmap/src/lib.rs
+++ b/agb-hashmap/src/lib.rs
@@ -1,3 +1,7 @@
+//! A hash map implementation optimised for the Game Boy Advance.
+//!
+//! The main structs are [`HashMap`] and [`HashSet`].
+//!
 //! A lot of the documentation for this module was copied straight out of the rust
 //! standard library. The implementation however is not.
 #![no_std]

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -303,7 +303,7 @@ mod memory_mapped;
 pub(crate) mod mgba;
 #[doc(inline)]
 pub use agb_fixnum as fixnum;
-/// Contains an implementation of a hashmap which suits the Game Boy Advance's hardware.
+#[doc(inline)]
 pub use agb_hashmap as hash_map;
 #[cfg(feature = "backtrace")]
 mod panics_render;


### PR DESCRIPTION
They looked a bit weird in the documentation. This is much neater

- [x] no changelog update needed
