### PR TITLE
add link to examples

### DIFF
--- a/website/agb/src/app/page.tsx
+++ b/website/agb/src/app/page.tsx
@@ -135,6 +135,7 @@ export default function Home() {
             Docs
           </ExternalLink>
           <ExternalLink href="./showcase">Showcase</ExternalLink>
+          <ExternalLink href="./examples">Examples</ExternalLink>
         </ExternalLinkBlock>
       </ContentBlock>
     </>


### PR DESCRIPTION
Adds a link from the main page to the examples now that we should be happy with them in the next version of agb.

Note that as the website releases all the time, this will apply to the live site if merged using the old examples as the content. Decide if this is okay.