### PR TITLE
Document everything in agb

### DIFF
--- a/agb/examples/dma_effect_affine_background_3d_plane.rs
+++ b/agb/examples/dma_effect_affine_background_3d_plane.rs
@@ -11,7 +11,7 @@ use agb::{
             AffineMatrixBackground, RegularBackgroundSize, RegularBackgroundTiles, VRAM_MANAGER,
         },
     },
-    dma::HBlankDmaDefinition,
+    dma::HBlankDma,
     fixnum::{Num, Vector2D, num, vec2},
     include_background_gfx,
     input::{Button, ButtonController, Tri},
@@ -120,7 +120,7 @@ fn main(mut gba: agb::Gba) -> ! {
             })
             .collect::<Vec<_>>();
 
-        HBlankDmaDefinition::new(bg_id.transform_dma(), &transforms).show(&mut frame);
+        HBlankDma::new(bg_id.transform_dma(), &transforms).show(&mut frame);
 
         help_bg.show(&mut frame);
         frame.commit();

--- a/agb/examples/dma_effect_affine_background_pipe.rs
+++ b/agb/examples/dma_effect_affine_background_pipe.rs
@@ -12,7 +12,7 @@ use agb::{
             AffineMatrixBackground, RegularBackgroundSize, RegularBackgroundTiles, VRAM_MANAGER,
         },
     },
-    dma::HBlankDmaDefinition,
+    dma::HBlankDma,
     fixnum::{Num, Vector2D, num, vec2},
     input::{ButtonController, Tri},
 };
@@ -74,7 +74,7 @@ fn main(mut gba: agb::Gba) -> ! {
                 )
             })
             .collect::<Vec<_>>();
-        HBlankDmaDefinition::new(transform_dma, &transforms).show(&mut frame);
+        HBlankDma::new(transform_dma, &transforms).show(&mut frame);
 
         help.show(&mut frame);
 

--- a/agb/examples/dma_effect_background_blob_monster.rs
+++ b/agb/examples/dma_effect_background_blob_monster.rs
@@ -16,7 +16,7 @@ use agb::{
             RegularBackgroundSize, RegularBackgroundTiles, TileEffect, TileSetting, VRAM_MANAGER,
         },
     },
-    dma::HBlankDmaDefinition,
+    dma::HBlankDma,
     fixnum::{Num, Vector2D, num, vec2},
     include_aseprite, include_background_gfx,
 };
@@ -132,7 +132,7 @@ impl BlobMonster {
             .set_priority(Priority::P0)
             .show(frame);
 
-        HBlankDmaDefinition::new(bg_id.scroll_dma(), &self.width_start_pairs()).show(frame);
+        HBlankDma::new(bg_id.scroll_dma(), &self.width_start_pairs()).show(frame);
     }
 
     fn width_start_pairs(&self) -> Vec<Vector2D<u16>> {

--- a/agb/examples/dma_effect_background_colour.rs
+++ b/agb/examples/dma_effect_background_colour.rs
@@ -8,7 +8,7 @@ use agb::{
         Rgb, Rgb15,
         tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
     },
-    dma::HBlankDmaDefinition,
+    dma::HBlankDma,
     include_background_gfx, include_colours,
     input::{Button, ButtonController},
 };
@@ -48,7 +48,7 @@ fn main(mut gba: agb::Gba) -> ! {
         let mut frame = gfx.frame();
 
         if should_do_dma {
-            HBlankDmaDefinition::new(
+            HBlankDma::new(
                 VRAM_MANAGER.background_palette_colour_dma(0, background_colour_index),
                 &SKY_GRADIENT,
             )

--- a/agb/examples/dma_effect_background_desert.rs
+++ b/agb/examples/dma_effect_background_desert.rs
@@ -10,7 +10,7 @@ use agb::{
         HEIGHT,
         tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
     },
-    dma::HBlankDmaDefinition,
+    dma::HBlankDma,
     fixnum::Num,
     include_background_gfx,
 };
@@ -40,7 +40,7 @@ fn main(mut gba: agb::Gba) -> ! {
             .map(|offset| offset as u16)
             .collect();
 
-        HBlankDmaDefinition::new(background_id.y_scroll_dma(), &offsets).show(&mut frame);
+        HBlankDma::new(background_id.y_scroll_dma(), &offsets).show(&mut frame);
 
         frame.commit();
     }

--- a/agb/examples/dma_effect_background_magic_spell.rs
+++ b/agb/examples/dma_effect_background_magic_spell.rs
@@ -10,7 +10,7 @@ use agb::{
         HEIGHT,
         tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
     },
-    dma::HBlankDmaDefinition,
+    dma::HBlankDma,
     fixnum::Num,
     include_background_gfx,
 };
@@ -40,7 +40,7 @@ fn main(mut gba: agb::Gba) -> ! {
             .map(|offset| offset as u16)
             .collect();
 
-        HBlankDmaDefinition::new(background_id.x_scroll_dma(), &offsets).show(&mut frame);
+        HBlankDma::new(background_id.x_scroll_dma(), &offsets).show(&mut frame);
 
         frame.commit();
     }

--- a/agb/examples/dma_effect_circular_window.rs
+++ b/agb/examples/dma_effect_circular_window.rs
@@ -8,7 +8,7 @@ use agb::{
         HEIGHT, WIDTH, WinIn,
         tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
     },
-    dma::HBlankDmaDefinition,
+    dma::HBlankDma,
     fixnum::{Num, Rect, Vector2D, vec2},
     include_background_gfx,
 };
@@ -76,7 +76,7 @@ fn main(mut gba: agb::Gba) -> ! {
             .set_pos(Rect::new(pos.floor(), (64, 65).into()));
 
         let dma_controllable = window.win_in(WinIn::Win0).horizontal_pos_dma();
-        HBlankDmaDefinition::new(dma_controllable, &circle_poses).show(&mut frame);
+        HBlankDma::new(dma_controllable, &circle_poses).show(&mut frame);
 
         frame.commit();
     }

--- a/agb/src/display/tiled/vram_manager.rs
+++ b/agb/src/display/tiled/vram_manager.rs
@@ -445,7 +445,7 @@ impl VRamManager {
     /// Used if you want to control a colour in the background which could change e.g. on every row of pixels.
     /// Very useful if you want a gradient of more colours than the gba can normally handle.
     ///
-    /// See [`HBlankDmaDefinition`](crate::dma::HBlankDmaDefinition) for examples for how to do this, or the
+    /// See [`HBlankDma`](crate::dma::HBlankDma) for examples for how to do this, or the
     /// [`dma_effect_background_colour`](https://agbrs.dev/examples/dma_effect_background_colour) example.
     #[must_use]
     pub fn background_palette_colour_dma(
@@ -459,7 +459,7 @@ impl VRamManager {
     /// Used if you want to control a colour in the background which could change e.g. on every row of pixels.
     /// Very useful if you want a gradient of more colours than the gba can normally handle.
     ///
-    /// See [`HBlankDmaDefinition`](crate::dma::HBlankDmaDefinition) for examples for how to do this, or the
+    /// See [`HBlankDma`](crate::dma::HBlankDma) for examples for how to do this, or the
     /// [`dma_effect_background_colour`](https://agbrs.dev/examples/dma_effect_background_colour) example.
     #[must_use]
     pub fn background_palette_colour_256_dma(

--- a/agb/src/dma.rs
+++ b/agb/src/dma.rs
@@ -35,9 +35,7 @@ impl Dma {
 
 /// A struct to describe things you can modify using DMA (normally some register within the GBA)
 ///
-/// This is generally used to perform fancy graphics tricks like screen wobble on a per-scanline basis or
-/// to be able to create a track like in mario kart. This is an advanced technique and likely not needed
-/// unless you want to do fancy graphics.
+/// This is generally used to perform fancy graphics tricks by utilising [`HBlankDma`].
 pub struct DmaControllable<Item> {
     memory_location: *mut Item,
 }
@@ -48,6 +46,12 @@ impl<Item> DmaControllable<Item> {
     }
 }
 
+/// A Dma that copies a value to a given destination each hblank.
+///
+/// This is very useful for creating advanced graphical effects that would
+/// otherwise be impossible on the GBA. For instance, circular windows as used
+/// by many commercial games relies on modifying the width of a window each on
+/// each hblank interval.
 pub struct HBlankDma<Item> {
     controllable: DmaControllable<Item>,
     values: Pin<Box<[Item; 161]>>,
@@ -57,6 +61,13 @@ impl<Item> HBlankDma<Item>
 where
     Item: Copy + Unpin + 'static,
 {
+    #[must_use]
+    /// Creates a HBlankDma that will write to the given controllable destination each hblank the values give.
+    ///
+    /// Does nothing unless [`show`][Self::show]n to the [`GraphicsFrame`].
+    ///
+    /// # Panics
+    /// If less than 160 values are given (the number of horizontal lines), this will panic.
     pub fn new(controllable: DmaControllable<Item>, values: &[Item]) -> Self {
         assert!(
             values.len() >= 160,
@@ -80,6 +91,7 @@ where
         }
     }
 
+    /// Causes the HBlankDma action to be performed during the graphics frame provided.
     pub fn show(self, frame: &mut GraphicsFrame) {
         frame.add_dma(self);
     }

--- a/agb/src/dma.rs
+++ b/agb/src/dma.rs
@@ -48,12 +48,12 @@ impl<Item> DmaControllable<Item> {
     }
 }
 
-pub struct HBlankDmaDefinition<Item> {
+pub struct HBlankDma<Item> {
     controllable: DmaControllable<Item>,
     values: Pin<Box<[Item; 161]>>,
 }
 
-impl<Item> HBlankDmaDefinition<Item>
+impl<Item> HBlankDma<Item>
 where
     Item: Copy + Unpin + 'static,
 {
@@ -85,7 +85,7 @@ where
     }
 }
 
-impl<Item> DmaFrame for HBlankDmaDefinition<Item>
+impl<Item> DmaFrame for HBlankDma<Item>
 where
     Item: Copy + 'static,
 {

--- a/agb/src/interrupt.rs
+++ b/agb/src/interrupt.rs
@@ -24,7 +24,7 @@ pub enum Interrupt {
     VBlank = 0,
     /// Triggers on the start of each horizontal blanking interval. The
     /// interrupt is most often used in agb as part of the
-    /// [`HBlankDmaDefinition`][crate::dma::HBlankDmaDefinition]
+    /// [`HBlankDma`][crate::dma::HBlankDma]
     HBlank = 1,
     /// You may specify a particular line that this gets triggered on. Can be
     /// thought of as a more flexible VBlank interrupt as it can trigger on any

--- a/agb/src/interrupt.rs
+++ b/agb/src/interrupt.rs
@@ -7,20 +7,53 @@ use portable_atomic::{AtomicBool, AtomicUsize, Ordering};
 use crate::{display::DISPLAY_STATUS, memory_mapped::MemoryMapped, util::SyncUnsafeCell};
 
 #[derive(Clone, Copy)]
+/// All the available interrupts for the GBA.
+///
+/// These are unlikely to be useful in user code and any interesting usages
+/// should have a easy to use wrapper for it. Game logic generally should not
+/// rely on any of these and instead should be purely based on creating a new
+/// state each frame.
+///
+/// Examples of such easy wrappers that use interrupts are provided where
+/// relevant.
 pub enum Interrupt {
+    /// Triggers on the start of each vertical blanking interval, useful for
+    /// timing actions that should occur once per frame. Most often used
+    /// automatically by agb as part of the
+    /// [`GraphicsFrame`][crate::display::GraphicsFrame].
     VBlank = 0,
+    /// Triggers on the start of each horizontal blanking interval. The
+    /// interrupt is most often used in agb as part of the
+    /// [`HBlankDmaDefinition`][crate::dma::HBlankDmaDefinition]
     HBlank = 1,
+    /// You may specify a particular line that this gets triggered on. Can be
+    /// thought of as a more flexible VBlank interrupt as it can trigger on any
+    /// line rather than only one.
     VCounter = 2,
+    /// Triggers when timer 0 overflows.
     Timer0 = 3,
+    /// Triggers when timer 1 overflows.
     Timer1 = 4,
+    /// Triggers when timer 1 overflows.
     Timer2 = 5,
+    /// Triggers when timer 1 overflows.
     Timer3 = 6,
+    /// Triggers when the serial transfer finishes. Not used available in agb.
     Serial = 7,
+    /// Triggers when Dma 0 completes.
     Dma0 = 8,
+    /// Triggers when Dma 1 completes.
     Dma1 = 9,
+    /// Triggers when Dma 2 completes.
     Dma2 = 10,
+    /// Triggers when Dma 3 completes.
     Dma3 = 11,
+    /// Triggers when specified keys are pressed. Useful in combination with a
+    /// timer to generate randomness by utilising cycle precision counters to
+    /// seed a random number generator.
     Keypad = 12,
+    /// Triggers when the cartridge (called a game pak) is removed from the
+    /// system.
     Gamepak = 13,
 }
 
@@ -203,6 +236,13 @@ impl Drop for InterruptInner {
     }
 }
 
+/// An opaque handle for an interrupt.
+///
+/// Dropping this stop this handler from running and free it's resources.
+/// Forgetting it will detach the handler and make the interrupt impossible to
+/// stop from running.
+///
+/// Created by [`add_interrupt_handler`].
 pub struct InterruptHandler {
     _inner: Pin<Box<InterruptInner>>,
 }
@@ -304,6 +344,24 @@ static NUM_VBLANKS: AtomicUsize = AtomicUsize::new(0); // overflows after 2.27 y
 static HAS_CREATED_INTERRUPT: AtomicBool = AtomicBool::new(false);
 
 #[non_exhaustive]
+/// A light weight VBlank handle.
+///
+/// Will set up the VBlank interrupt handler such that the VBlank interrupt can
+/// be waited for. Has internal logic to make missing the VBlank less of an
+/// issue by keeping track of the number of VBlanks that has occurred.
+///
+/// ```rust
+/// # #![no_std]
+/// # #![no_main]
+/// # core::include!("doctest_runner.rs");
+/// use agb::interrupt::VBlank;
+///
+/// # fn test(gba: agb::Gba) {
+/// let vblank = VBlank::get();
+///
+/// vblank.wait_for_vblank();
+/// # }
+/// ```
 pub struct VBlank {
     last_waited_number: Cell<usize>,
 }

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -23,6 +23,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(rustdoc::private_intra_doc_links)]
 #![deny(rustdoc::invalid_html_tags)]
+#![warn(missing_docs)]
 
 //! # agb
 //! `agb` is a library for making games on the Game Boy Advance using rust.
@@ -600,6 +601,14 @@ pub mod test_runner {
         loop {}
     }
 
+    /// Asserts that the current screen matches the provided image
+    ///
+    /// Uses capabilities built into `mgba-test-runner` to assert that the
+    /// current content of the screen matches the image located at the provided
+    /// path. Does nothing if you are not using `mgba-test-runner`.
+    ///
+    /// If the image does not exist, `mgba-test-runner` will write the screen to
+    /// the file and fail.
     pub fn assert_image_output(image: &str) {
         display::busy_wait_for_vblank();
         display::busy_wait_for_vblank();


### PR DESCRIPTION
Adds documentation for the remaining undocumented parts of agb.

Could still use more comprehensive module level docs.

Doc test for Dma would be nice, none of the examples are really short enough to include here though.