### PR TITLE
correct the number of affine matricies that are available

### DIFF
--- a/agb/src/display/object/affine.rs
+++ b/agb/src/display/object/affine.rs
@@ -17,10 +17,9 @@ pub(crate) struct AffineMatrixVram(Rc<AffineMatrixData>);
 /// An affine matrix that can be used on objects.
 ///
 /// It is just in time copied to vram, so you can have as many as you like
-/// of these but you can only use up to 16 in one frame. They are reference
+/// of these but you can only use up to 32 in one frame. They are reference
 /// counted (Cloning is cheap) and immutable, if you want to change a matrix
-/// you must make a new one and set it
-/// on all your objects.
+/// you must make a new one and set it on all your objects.
 #[derive(Debug, Clone)]
 pub struct AffineMatrixInstance {
     location: AffineMatrixVram,


### PR DESCRIPTION
The correct number of affine matrices is 32.