### PR TITLE
Rename RegularBackgroundTiles and AffineBackgroundTiles to remove Tiles

### DIFF
--- a/agb/examples/affine_background.rs
+++ b/agb/examples/affine_background.rs
@@ -7,7 +7,7 @@ use agb::{
     display::{
         HEIGHT, Priority, WIDTH,
         tiled::{
-            AffineBackgroundSize, AffineBackgroundTiles, AffineBackgroundWrapBehaviour,
+            AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour,
             AffineMatrixBackground, VRAM_MANAGER,
         },
     },
@@ -77,8 +77,8 @@ fn main(mut gba: agb::Gba) -> ! {
     }
 }
 
-fn create_background() -> AffineBackgroundTiles {
-    let mut bg = AffineBackgroundTiles::new(
+fn create_background() -> AffineBackground {
+    let mut bg = AffineBackground::new(
         Priority::P0,
         AffineBackgroundSize::Background32x32,
         AffineBackgroundWrapBehaviour::Wrap,

--- a/agb/examples/animated_background.rs
+++ b/agb/examples/animated_background.rs
@@ -9,9 +9,7 @@ use core::cmp::Ordering;
 use agb::{
     display::{
         Priority,
-        tiled::{
-            RegularBackgroundSize, RegularBackgroundTiles, TileEffect, TileSetting, VRAM_MANAGER,
-        },
+        tiled::{RegularBackground, RegularBackgroundSize, TileEffect, TileSetting, VRAM_MANAGER},
     },
     include_background_gfx,
 };
@@ -39,7 +37,7 @@ fn main(mut gba: agb::Gba) -> ! {
 
     VRAM_MANAGER.set_background_palettes(background::PALETTES);
 
-    let mut bg = RegularBackgroundTiles::new(
+    let mut bg = RegularBackground::new(
         Priority::P3,
         RegularBackgroundSize::Background32x32,
         tileset.format(),
@@ -61,7 +59,7 @@ fn main(mut gba: agb::Gba) -> ! {
         }
     }
 
-    let mut foreground = RegularBackgroundTiles::new(
+    let mut foreground = RegularBackground::new(
         Priority::P2,
         RegularBackgroundSize::Background32x32,
         tileset.format(),

--- a/agb/examples/background_text_render.rs
+++ b/agb/examples/background_text_render.rs
@@ -6,7 +6,7 @@ use agb::{
     display::{
         Priority, Rgb15,
         font::{AlignmentKind, Font, Layout, RegularBackgroundTextRenderer},
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     include_font,
 };
@@ -19,7 +19,7 @@ fn main(mut gba: agb::Gba) -> ! {
 
     VRAM_MANAGER.set_background_palette_colour(0, 1, Rgb15::WHITE);
 
-    let mut bg = RegularBackgroundTiles::new(
+    let mut bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/agb/examples/blend_rain.rs
+++ b/agb/examples/blend_rain.rs
@@ -11,9 +11,7 @@ use agb::{
     display::{
         GraphicsFrame, Priority,
         object::{Object, SpriteVram},
-        tiled::{
-            BackgroundId, RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER,
-        },
+        tiled::{BackgroundId, RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     fixnum::{Num, Vector2D, num, vec2},
     include_aseprite, include_background_gfx, include_wav,
@@ -50,14 +48,14 @@ fn main(mut gba: agb::Gba) -> ! {
     let mut player = Player::new(vec2(num!(100.), num!(100.)));
     let mut button_controller = ButtonController::new();
 
-    let mut bg_tiles = RegularBackgroundTiles::new(
+    let mut bg_tiles = RegularBackground::new(
         Priority::P3,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
     );
     bg_tiles.fill_with(&backgrounds::BEACH);
 
-    let mut hud_tiles = RegularBackgroundTiles::new(
+    let mut hud_tiles = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
@@ -207,7 +205,7 @@ impl Player {
     }
 }
 
-fn populate_hud(hud_tiles: &mut RegularBackgroundTiles) {
+fn populate_hud(hud_tiles: &mut RegularBackground) {
     // write out 'HEALTH:'
 
     for i in HEALTH_TEXT {

--- a/agb/examples/chicken.rs
+++ b/agb/examples/chicken.rs
@@ -9,8 +9,7 @@ use agb::{
         GraphicsFrame, HEIGHT, WIDTH,
         object::{Object, Sprite},
         tiled::{
-            InfiniteScrolledMap, RegularBackgroundSize, RegularBackgroundTiles, TileFormat,
-            VRAM_MANAGER,
+            InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER,
         },
     },
     fixnum::{Num, Rect, Vector2D, num, vec2},
@@ -78,7 +77,7 @@ fn entry(mut gba: agb::Gba) -> ! {
 
     VRAM_MANAGER.set_background_palettes(background::PALETTES);
 
-    let background = RegularBackgroundTiles::new(
+    let background = RegularBackground::new(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/agb/examples/dma_effect_affine_background_3d_plane.rs
+++ b/agb/examples/dma_effect_affine_background_3d_plane.rs
@@ -11,8 +11,8 @@ use agb::{
     display::{
         Priority,
         tiled::{
-            AffineBackgroundSize, AffineBackgroundTiles, AffineBackgroundWrapBehaviour,
-            AffineMatrixBackground, RegularBackgroundSize, RegularBackgroundTiles, VRAM_MANAGER,
+            AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour,
+            AffineMatrixBackground, RegularBackground, RegularBackgroundSize, VRAM_MANAGER,
         },
     },
     dma::HBlankDma,
@@ -36,7 +36,7 @@ fn main(mut gba: agb::Gba) -> ! {
 
     let mut wrap_behaviour = AffineBackgroundWrapBehaviour::NoWrap;
 
-    let mut bg = AffineBackgroundTiles::new(
+    let mut bg = AffineBackground::new(
         Priority::P1,
         AffineBackgroundSize::Background32x32,
         wrap_behaviour,
@@ -48,7 +48,7 @@ fn main(mut gba: agb::Gba) -> ! {
         }
     }
 
-    let mut help_bg = RegularBackgroundTiles::new(
+    let mut help_bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         backgrounds::HELP.tiles.format(),

--- a/agb/examples/dma_effect_affine_background_pipe.rs
+++ b/agb/examples/dma_effect_affine_background_pipe.rs
@@ -9,8 +9,8 @@ use agb::{
     display::{
         AffineMatrix, Priority, WIDTH,
         tiled::{
-            AffineBackgroundSize, AffineBackgroundTiles, AffineBackgroundWrapBehaviour,
-            AffineMatrixBackground, RegularBackgroundSize, RegularBackgroundTiles, VRAM_MANAGER,
+            AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour,
+            AffineMatrixBackground, RegularBackground, RegularBackgroundSize, VRAM_MANAGER,
         },
     },
     dma::HBlankDma,
@@ -81,8 +81,8 @@ fn main(mut gba: agb::Gba) -> ! {
     }
 }
 
-fn grid_background() -> AffineBackgroundTiles {
-    let mut bg = AffineBackgroundTiles::new(
+fn grid_background() -> AffineBackground {
+    let mut bg = AffineBackground::new(
         Priority::P1,
         AffineBackgroundSize::Background64x64,
         AffineBackgroundWrapBehaviour::Wrap,
@@ -98,8 +98,8 @@ fn grid_background() -> AffineBackgroundTiles {
     bg
 }
 
-fn help_background() -> RegularBackgroundTiles {
-    let mut bg = RegularBackgroundTiles::new(
+fn help_background() -> RegularBackground {
+    let mut bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         backgrounds::HELP.tiles.format(),

--- a/agb/examples/dma_effect_background_blob_monster.rs
+++ b/agb/examples/dma_effect_background_blob_monster.rs
@@ -12,9 +12,7 @@ use agb::{
     display::{
         GraphicsFrame, HEIGHT, Priority, WIDTH,
         object::Object,
-        tiled::{
-            RegularBackgroundSize, RegularBackgroundTiles, TileEffect, TileSetting, VRAM_MANAGER,
-        },
+        tiled::{RegularBackground, RegularBackgroundSize, TileEffect, TileSetting, VRAM_MANAGER},
     },
     dma::HBlankDma,
     fixnum::{Num, Vector2D, num, vec2},
@@ -61,7 +59,7 @@ struct BlobMonster {
 
     /// The background in use. This is a simple triangle pattern, but we use scroll offset DMA
     /// to breathe some life into the monster.
-    bg: RegularBackgroundTiles,
+    bg: RegularBackground,
 
     /// The current frame, used for animations
     frame: i32,
@@ -175,8 +173,8 @@ impl BlobMonster {
 
 // The blob monster background is a simple triangle. We use DMA to control the scroll position
 // in order to show the blob monster as something more than just a single triangle
-fn blob_monster_background() -> RegularBackgroundTiles {
-    let mut bg = RegularBackgroundTiles::new(
+fn blob_monster_background() -> RegularBackground {
+    let mut bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         backgrounds::MONSTER.tiles.format(),

--- a/agb/examples/dma_effect_background_colour.rs
+++ b/agb/examples/dma_effect_background_colour.rs
@@ -11,7 +11,7 @@ extern crate alloc;
 use agb::{
     display::{
         Rgb, Rgb15,
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     dma::HBlankDma,
     include_background_gfx, include_colours,
@@ -29,7 +29,7 @@ static SKY_GRADIENT: [Rgb15; 160] =
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
 
-    let mut map = RegularBackgroundTiles::new(
+    let mut map = RegularBackground::new(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/agb/examples/dma_effect_background_desert.rs
+++ b/agb/examples/dma_effect_background_desert.rs
@@ -10,7 +10,7 @@ use alloc::{boxed::Box, vec::Vec};
 use agb::{
     display::{
         HEIGHT,
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     dma::HBlankDma,
     fixnum::Num,
@@ -51,10 +51,10 @@ fn main(mut gba: agb::Gba) -> ! {
     }
 }
 
-fn get_logo() -> RegularBackgroundTiles {
+fn get_logo() -> RegularBackground {
     include_background_gfx!(mod backgrounds, LOGO => "examples/gfx/test_logo.aseprite");
 
-    let mut map = RegularBackgroundTiles::new(
+    let mut map = RegularBackground::new(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/agb/examples/dma_effect_background_magic_spell.rs
+++ b/agb/examples/dma_effect_background_magic_spell.rs
@@ -10,7 +10,7 @@ use alloc::{boxed::Box, vec::Vec};
 use agb::{
     display::{
         HEIGHT,
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     dma::HBlankDma,
     fixnum::Num,
@@ -51,10 +51,10 @@ fn main(mut gba: agb::Gba) -> ! {
     }
 }
 
-fn get_logo() -> RegularBackgroundTiles {
+fn get_logo() -> RegularBackground {
     include_background_gfx!(mod backgrounds, LOGO => "examples/gfx/test_logo.aseprite");
 
-    let mut map = RegularBackgroundTiles::new(
+    let mut map = RegularBackground::new(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/agb/examples/dma_effect_circular_window.rs
+++ b/agb/examples/dma_effect_circular_window.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 use agb::{
     display::{
         HEIGHT, WIDTH, WinIn,
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     dma::HBlankDma,
     fixnum::{Num, Rect, Vector2D, vec2},
@@ -85,10 +85,10 @@ fn main(mut gba: agb::Gba) -> ! {
     }
 }
 
-fn get_logo() -> RegularBackgroundTiles {
+fn get_logo() -> RegularBackground {
     include_background_gfx!(mod backgrounds, "000000", LOGO => "examples/gfx/test_logo.aseprite");
 
-    let mut map = RegularBackgroundTiles::new(
+    let mut map = RegularBackground::new(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/agb/examples/dynamic_tiles.rs
+++ b/agb/examples/dynamic_tiles.rs
@@ -4,7 +4,7 @@
 use agb::display::{
     Palette16, Priority, Rgb15,
     tiled::{
-        DynamicTile16, RegularBackgroundSize, RegularBackgroundTiles, TileEffect, TileFormat,
+        DynamicTile16, RegularBackground, RegularBackgroundSize, TileEffect, TileFormat,
         VRAM_MANAGER,
     },
 };
@@ -21,7 +21,7 @@ fn main(mut gba: agb::Gba) -> ! {
         .map(Rgb15::new),
     )]);
 
-    let mut bg = RegularBackgroundTiles::new(
+    let mut bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/agb/examples/fixnums.rs
+++ b/agb/examples/fixnums.rs
@@ -9,7 +9,7 @@ use agb::{
     display::{
         Graphics,
         object::{Object, SpriteVram},
-        tiled::{RegularBackgroundTiles, VRAM_MANAGER},
+        tiled::{RegularBackground, VRAM_MANAGER},
     },
     fixnum::{Num, Vector2D, vec2},
     include_aseprite, include_background_gfx,
@@ -21,7 +21,7 @@ include_background_gfx!(mod background, bg => deduplicate "examples/gfx/fixed_po
 
 fn integer(
     gfx: &mut Graphics,
-    bg: &RegularBackgroundTiles,
+    bg: &RegularBackground,
     initial_position: Vector2D<i32>,
     initial_velocity: Vector2D<i32>,
 ) -> (Vector2D<i32>, Vector2D<i32>) {
@@ -56,7 +56,7 @@ fn integer(
 
 fn fixed(
     gfx: &mut Graphics,
-    bg: &RegularBackgroundTiles,
+    bg: &RegularBackground,
     initial_position: Vector2D<i32>,
     initial_velocity: Vector2D<i32>,
 ) -> (Vector2D<i32>, Vector2D<i32>) {
@@ -93,7 +93,7 @@ fn fixed(
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
 
-    let mut bg = RegularBackgroundTiles::new(
+    let mut bg = RegularBackground::new(
         agb::display::Priority::P0,
         agb::display::tiled::RegularBackgroundSize::Background32x32,
         agb::display::tiled::TileFormat::FourBpp,

--- a/agb/examples/frame_lifecycle.rs
+++ b/agb/examples/frame_lifecycle.rs
@@ -7,7 +7,7 @@ use agb::{
     display::{
         GraphicsFrame, Priority,
         object::{Object, SpriteVram},
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     fixnum::{Num, Vector2D, num, vec2},
     include_aseprite, include_background_gfx,
@@ -55,7 +55,7 @@ fn main(mut gba: agb::Gba) -> ! {
     let mut player = Player::new(vec2(num!(100.), num!(100.)));
     let mut button_controller = ButtonController::new();
 
-    let mut bg_tiles = RegularBackgroundTiles::new(
+    let mut bg_tiles = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/agb/examples/hud.rs
+++ b/agb/examples/hud.rs
@@ -9,7 +9,7 @@ use agb::{
     display::{
         GraphicsFrame, Priority,
         object::{Object, SpriteVram},
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     fixnum::{Num, Vector2D, num, vec2},
     include_aseprite, include_background_gfx,
@@ -65,14 +65,14 @@ fn main(mut gba: agb::Gba) -> ! {
     let mut player = Player::new(vec2(num!(100.), num!(100.)));
     let mut button_controller = ButtonController::new();
 
-    let mut bg_tiles = RegularBackgroundTiles::new(
+    let mut bg_tiles = RegularBackground::new(
         Priority::P3,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
     );
     bg_tiles.fill_with(&backgrounds::BEACH);
 
-    let mut hud_tiles = RegularBackgroundTiles::new(
+    let mut hud_tiles = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
@@ -105,7 +105,7 @@ fn main(mut gba: agb::Gba) -> ! {
     }
 }
 
-fn populate_hud(hud_tiles: &mut RegularBackgroundTiles) {
+fn populate_hud(hud_tiles: &mut RegularBackground) {
     // write out 'HEALTH:'
 
     for i in HEALTH_TEXT {

--- a/agb/examples/infinite_scrolled_map.rs
+++ b/agb/examples/infinite_scrolled_map.rs
@@ -6,7 +6,7 @@
 use agb::{
     display::{
         Priority,
-        tiled::{InfiniteScrolledMap, RegularBackgroundSize, RegularBackgroundTiles, VRAM_MANAGER},
+        tiled::{InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, VRAM_MANAGER},
     },
     fixnum::vec2,
     include_background_gfx,
@@ -25,7 +25,7 @@ fn main(mut gba: agb::Gba) -> ! {
 
     VRAM_MANAGER.set_background_palettes(big_map::PALETTES);
 
-    let bg = RegularBackgroundTiles::new(
+    let bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         tileset.format(),

--- a/agb/examples/mixer_32768.rs
+++ b/agb/examples/mixer_32768.rs
@@ -11,7 +11,7 @@ use agb::{
     display::{
         Priority, Rgb15, WIDTH,
         font::{AlignmentKind, Font, Layout, RegularBackgroundTextRenderer},
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     include_font, include_wav,
     sound::mixer::{Frequency, SoundChannel, SoundData},
@@ -23,7 +23,7 @@ static CRAZY_GLUE: SoundData = include_wav!("examples/JoshWoodward-CrazyGlue.wav
 #[agb::entry]
 fn main(mut gba: Gba) -> ! {
     let mut gfx = gba.graphics.get();
-    let mut bg = RegularBackgroundTiles::new(
+    let mut bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
@@ -47,7 +47,7 @@ fn main(mut gba: Gba) -> ! {
     }
 }
 
-fn init_background(bg: &mut RegularBackgroundTiles) {
+fn init_background(bg: &mut RegularBackground) {
     static FONT: Font = include_font!("examples/font/ark-pixel-10px-proportional-ja.ttf", 10);
 
     VRAM_MANAGER.set_background_palette_colour(0, 1, Rgb15::WHITE);

--- a/agb/examples/mixer_basic.rs
+++ b/agb/examples/mixer_basic.rs
@@ -7,7 +7,7 @@ use agb::{
     display::{
         Priority, Rgb15, WIDTH,
         font::{AlignmentKind, Font, Layout, RegularBackgroundTextRenderer},
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     fixnum::num,
     include_font, include_wav,
@@ -23,7 +23,7 @@ fn main(mut gba: Gba) -> ! {
     let mut input = ButtonController::new();
 
     let mut gfx = gba.graphics.get();
-    let mut bg = RegularBackgroundTiles::new(
+    let mut bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
@@ -80,7 +80,7 @@ fn main(mut gba: Gba) -> ! {
     }
 }
 
-fn init_background(bg: &mut RegularBackgroundTiles) {
+fn init_background(bg: &mut RegularBackground) {
     static FONT: Font = include_font!("examples/font/ark-pixel-10px-proportional-ja.ttf", 10);
 
     VRAM_MANAGER.set_background_palette_colour(0, 1, Rgb15::WHITE);

--- a/agb/examples/scrolling_background.rs
+++ b/agb/examples/scrolling_background.rs
@@ -5,7 +5,7 @@
 use agb::{
     display::{
         Priority, WIDTH,
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     include_background_gfx,
 };
@@ -23,7 +23,7 @@ fn main(mut gba: agb::Gba) -> ! {
     // Get access to the graphics struct which is used to manage the frame lifecycle
     let mut gfx = gba.graphics.get();
 
-    let mut scrolling_tiles = RegularBackgroundTiles::new(
+    let mut scrolling_tiles = RegularBackground::new(
         Priority::P1,
         RegularBackgroundSize::Background64x32,
         TileFormat::FourBpp,
@@ -41,7 +41,7 @@ fn main(mut gba: agb::Gba) -> ! {
         }
     }
 
-    let mut help_tiles = RegularBackgroundTiles::new(
+    let mut help_tiles = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/agb/examples/windows.rs
+++ b/agb/examples/windows.rs
@@ -6,7 +6,7 @@
 use agb::{
     display::{
         HEIGHT, WIDTH, WinIn,
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     fixnum::{Num, Rect, Vector2D},
     include_background_gfx,
@@ -63,8 +63,8 @@ fn main(mut gba: agb::Gba) -> ! {
     }
 }
 
-fn get_logo() -> RegularBackgroundTiles {
-    let mut map = RegularBackgroundTiles::new(
+fn get_logo() -> RegularBackground {
+    let mut map = RegularBackground::new(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
@@ -75,8 +75,8 @@ fn get_logo() -> RegularBackgroundTiles {
     map
 }
 
-fn get_beach() -> RegularBackgroundTiles {
-    let mut map = RegularBackgroundTiles::new(
+fn get_beach() -> RegularBackground {
+    let mut map = RegularBackground::new(
         agb::display::Priority::P1,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/agb/src/display/font.rs
+++ b/agb/src/display/font.rs
@@ -105,7 +105,7 @@
 //! use agb::display::{
 //!     Palette16, Rgb15, Priority,
 //!     font::{AlignmentKind, Font, Layout, RegularBackgroundTextRenderer},
-//!     tiled::{RegularBackgroundTiles, VRAM_MANAGER, RegularBackgroundSize, TileFormat},
+//!     tiled::{RegularBackground, VRAM_MANAGER, RegularBackgroundSize, TileFormat},
 //! };
 //!
 //! static SIMPLE_PALETTE: &Palette16 = {
@@ -117,7 +117,7 @@
 //!
 //! # fn test(mut gba: agb::Gba) {
 //! VRAM_MANAGER.set_background_palette(0, SIMPLE_PALETTE);
-//! let mut bg = RegularBackgroundTiles::new(
+//! let mut bg = RegularBackground::new(
 //!     Priority::P0,
 //!     RegularBackgroundSize::Background32x32,
 //!     TileFormat::FourBpp,

--- a/agb/src/display/font/tiled.rs
+++ b/agb/src/display/font/tiled.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use super::LetterGroup;
 use crate::{
-    display::tiled::{DynamicTile16, RegularBackgroundTiles, TileEffect},
+    display::tiled::{DynamicTile16, RegularBackground, TileEffect},
     fixnum::{Vector2D, vec2},
 };
 
@@ -16,7 +16,7 @@ use crate::{
 /// use agb::display::{
 ///     Palette16, Rgb15, Priority,
 ///     font::{AlignmentKind, Font, Layout, RegularBackgroundTextRenderer},
-///     tiled::{RegularBackgroundTiles, VRAM_MANAGER, RegularBackgroundSize, TileFormat},
+///     tiled::{RegularBackground, VRAM_MANAGER, RegularBackgroundSize, TileFormat},
 /// };
 ///
 /// static SIMPLE_PALETTE: &Palette16 = {
@@ -28,7 +28,7 @@ use crate::{
 ///
 /// # fn test(mut gba: agb::Gba) {
 /// VRAM_MANAGER.set_background_palette(0, SIMPLE_PALETTE);
-/// let mut bg = RegularBackgroundTiles::new(
+/// let mut bg = RegularBackground::new(
 ///     Priority::P0,
 ///     RegularBackgroundSize::Background32x32,
 ///     TileFormat::FourBpp,
@@ -67,7 +67,7 @@ impl RegularBackgroundTextRenderer {
     }
 
     /// Displays the given letter group on the given background.
-    pub fn show(&mut self, bg: &mut RegularBackgroundTiles, group: &LetterGroup) {
+    pub fn show(&mut self, bg: &mut RegularBackground, group: &LetterGroup) {
         self.ensure_drawing_space(bg, group);
 
         let dynamic_origin = vec2(self.origin.x.rem_euclid(8), self.origin.y.rem_euclid(8));
@@ -92,7 +92,7 @@ impl RegularBackgroundTextRenderer {
         }
     }
 
-    fn ensure_drawing_space(&mut self, bg: &mut RegularBackgroundTiles, group: &LetterGroup) {
+    fn ensure_drawing_space(&mut self, bg: &mut RegularBackground, group: &LetterGroup) {
         let dynamic_origin = vec2(self.origin.x.rem_euclid(8), self.origin.y.rem_euclid(8));
         let tile_offset = vec2(self.origin.x / 8, self.origin.y / 8);
 
@@ -156,7 +156,7 @@ mod test {
 
         VRAM_MANAGER.set_background_palette(0, &PALETTE);
 
-        let mut bg = RegularBackgroundTiles::new(
+        let mut bg = RegularBackground::new(
             Priority::P0,
             RegularBackgroundSize::Background32x32,
             TileFormat::FourBpp,
@@ -199,7 +199,7 @@ mod test {
 
         VRAM_MANAGER.set_background_palette(0, &PALETTE);
 
-        let mut bg = RegularBackgroundTiles::new(
+        let mut bg = RegularBackground::new(
             Priority::P0,
             RegularBackgroundSize::Background32x64,
             TileFormat::FourBpp,
@@ -236,7 +236,7 @@ mod test {
 
         VRAM_MANAGER.set_background_palette(0, &PALETTE);
 
-        let mut bg = RegularBackgroundTiles::new(
+        let mut bg = RegularBackground::new(
             Priority::P0,
             RegularBackgroundSize::Background32x64,
             TileFormat::FourBpp,

--- a/agb/src/display/mod.rs
+++ b/agb/src/display/mod.rs
@@ -43,7 +43,7 @@
 //! ## `.show(frame: &mut GraphicsFrame)`
 //!
 //! The most common pattern involving [`GraphicsFrame`] you'll see in the `agb` library is a `.show()` method which typically
-//! accepts a mutable reference to a [`GraphicsFrame`] e.g. [`RegularBackgroundTiles::show`](tiled::RegularBackgroundTiles::show) and
+//! accepts a mutable reference to a [`GraphicsFrame`] e.g. [`RegularBackground::show`](tiled::RegularBackground::show) and
 //! [`Object::show`](object::Object::show).
 //!
 //! Due to this naming convention, it is also conventional in games written using `agb` to name the `render` method `show()`
@@ -134,13 +134,13 @@ impl GraphicsDist {
 /// # fn test(mut gba: Gba) {
 /// use agb::display::{
 ///     Priority,
-///     tiled::{RegularBackgroundTiles, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+///     tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
 /// };
 ///
 /// // This is an instance of Graphics
 /// let mut gfx = gba.graphics.get();
 ///
-/// let bg = RegularBackgroundTiles::new(
+/// let bg = RegularBackground::new(
 ///     Priority::P0,
 ///     RegularBackgroundSize::Background32x32,
 ///     TileFormat::FourBpp
@@ -203,7 +203,7 @@ impl<'gba> Graphics<'gba> {
 /// [`gfx.frame()`](Graphics::frame) and [`frame.commit()`](GraphicsFrame::commit).
 ///
 /// Normally you'll want to pass the current `&mut frame` to a `.show()` method
-/// for example [`RegularBackgroundTiles::show`](tiled::RegularBackgroundTiles::show)
+/// for example [`RegularBackground::show`](tiled::RegularBackground::show)
 /// or [`Object::show`](object::Object::show).
 pub struct GraphicsFrame<'frame> {
     pub(crate) oam_frame: OamFrame<'frame>,

--- a/agb/src/display/tiled.rs
+++ b/agb/src/display/tiled.rs
@@ -1,8 +1,8 @@
 //! Anything to do with tiled backgrounds
 //!
 //! Most games made for the Game Boy Advance use tiled backgrounds.
-//! You can create and manage regular backgrounds using the [`RegularBackgroundTiles`] struct,
-//! and affine backgrounds using the [`AffineBackgroundTiles`] struct.
+//! You can create and manage regular backgrounds using the [`RegularBackground`] struct,
+//! and affine backgrounds using the [`AffineBackground`] struct.
 //!
 //! Palettes are managed using the [`VRAM_MANAGER`] global value.
 //!
@@ -18,13 +18,12 @@ use core::marker::PhantomData;
 
 use affine_background::AffineBackgroundScreenBlock;
 pub use affine_background::{
-    AffineBackgroundSize, AffineBackgroundTiles, AffineBackgroundWrapBehaviour,
-    AffineMatrixBackground,
+    AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour, AffineMatrixBackground,
 };
 use alloc::rc::Rc;
 pub use infinite_scrolled_map::{InfiniteScrolledMap, PartialUpdateStatus};
 use regular_background::RegularBackgroundScreenblock;
-pub use regular_background::{RegularBackgroundSize, RegularBackgroundTiles};
+pub use regular_background::{RegularBackground, RegularBackgroundSize};
 pub use vram_manager::{DynamicTile16, TileFormat, TileSet, VRAM_MANAGER, VRamManager};
 
 pub(crate) use vram_manager::TileIndex;
@@ -42,9 +41,9 @@ use crate::{
 
 use super::DISPLAY_CONTROL;
 
-/// Represents a [regular background](RegularBackgroundTiles) that's about to be displayed.
+/// Represents a [regular background](RegularBackground) that's about to be displayed.
 ///
-/// This is returned by the [`show()`](RegularBackgroundTiles::show) method. You'll need this if you want
+/// This is returned by the [`show()`](RegularBackground::show) method. You'll need this if you want
 /// to apply additional effects on the background while it is being displayed, such as adding it to a
 /// [`Window`](super::Window::enable_background) or using one of the DMA registers.
 ///
@@ -72,9 +71,9 @@ impl BackgroundId {
     }
 }
 
-/// Represents an [affine background](AffineBackgroundTiles) that's about to be displayed.
+/// Represents an [affine background](AffineBackground) that's about to be displayed.
 ///
-/// This is returned by the [`show()`](AffineBackgroundTiles::show) method. You'll need this if you
+/// This is returned by the [`show()`](AffineBackground::show) method. You'll need this if you
 /// want to apply additional effects such as using it with DMA.
 ///
 /// See the `dma_effect_affine_background_*` [examples](https://agbrs.dev/examples) for examples of how to use the DMA transform function.
@@ -128,7 +127,7 @@ impl TileSetting {
     /// use agb::{
     ///     display::Priority,
     ///     display::tiled::{
-    ///         RegularBackgroundTiles, RegularBackgroundSize, TileEffect, TileSetting,
+    ///         RegularBackground, RegularBackgroundSize, TileEffect, TileSetting,
     ///         VRAM_MANAGER,
     ///     },
     ///     include_background_gfx,
@@ -137,7 +136,7 @@ impl TileSetting {
     /// agb::include_background_gfx!(mod water_tiles, tiles => "examples/water_tiles.png");
     ///
     /// # fn test(gba: agb::Gba) {
-    /// let mut bg = RegularBackgroundTiles::new(Priority::P0, RegularBackgroundSize::Background32x32, water_tiles::tiles.tiles.format());
+    /// let mut bg = RegularBackground::new(Priority::P0, RegularBackgroundSize::Background32x32, water_tiles::tiles.tiles.format());
     ///
     /// // put something in the background
     /// bg.set_tile((0, 0), &water_tiles::tiles.tiles, water_tiles::tiles.tile_settings[1]);

--- a/agb/src/display/tiled/affine_background.rs
+++ b/agb/src/display/tiled/affine_background.rs
@@ -85,9 +85,9 @@ impl AffineBackgroundSize {
 /// the GBA's VRAM will be allocated and unavailable for other backgrounds. You should use the
 /// smallest [`AffineBackgroundSize`] you can while still being able to render the scene you want.
 ///
-/// You can show up to 2 affine backgrounds at once (or 1 affine background and 2 [regular backgrounds](super::RegularBackgroundTiles)).
+/// You can show up to 2 affine backgrounds at once (or 1 affine background and 2 [regular backgrounds](super::RegularBackground)).
 ///
-/// to display a given affine background to the screen, you need to call its [show()](AffineBackgroundTiles::show()) method on
+/// to display a given affine background to the screen, you need to call its [show()](AffineBackground::show()) method on
 /// a given [`GraphicsFrame`](crate::display::GraphicsFrame).
 ///
 /// ## Example
@@ -100,12 +100,12 @@ impl AffineBackgroundSize {
 /// # fn foo(gba: &mut Gba) {
 /// use agb::display::{
 ///     Priority,
-///     tiled::{AffineBackgroundTiles, AffineBackgroundSize, AffineBackgroundWrapBehaviour, VRAM_MANAGER},
+///     tiled::{AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour, VRAM_MANAGER},
 /// };
 ///
 /// let mut gfx = gba.graphics.get();
 ///
-/// let bg = AffineBackgroundTiles::new(
+/// let bg = AffineBackground::new(
 ///     Priority::P0,
 ///     AffineBackgroundSize::Background16x16,
 ///     AffineBackgroundWrapBehaviour::NoWrap,
@@ -120,7 +120,7 @@ impl AffineBackgroundSize {
 /// }
 /// # }
 /// ```
-pub struct AffineBackgroundTiles {
+pub struct AffineBackground {
     priority: Priority,
 
     tiles: Tiles,
@@ -134,15 +134,15 @@ pub struct AffineBackgroundTiles {
     wrap_behaviour: AffineBackgroundWrapBehaviour,
 }
 
-impl AffineBackgroundTiles {
+impl AffineBackground {
     /// Create a new affine background with given `priority`, `size` and `warp_behaviour`.
     ///
     /// This allocates some space in VRAM to store the actual tile data, but doesn't show anything
-    /// until you call the [`show()`](AffineBackgroundTiles::show()) function on a [`GraphicsFrame`](crate::display::GraphicsFrame).
+    /// until you call the [`show()`](AffineBackground::show()) function on a [`GraphicsFrame`](crate::display::GraphicsFrame).
     ///
-    /// You can have more `AffineBackgroundTiles` instances then there are available backgrounds
+    /// You can have more `AffineBackground` instances then there are available backgrounds
     /// to show at once, but you can only show 2 at once in a given frame (or 1 and a up to 2
-    /// [regular backgrounds](super::RegularBackgroundTiles)).
+    /// [regular backgrounds](super::RegularBackground)).
     ///
     /// For [`Priority`], a higher priority is rendered first, so is behind lower priorities.
     /// Therefore, `P0` will be rendered at the _front_ and `P3` at the _back_. For equal priorities,
@@ -321,7 +321,7 @@ impl AffineBackgroundTiles {
 
     /// Set the current priority for the background.
     ///
-    /// This won't take effect until the next time you call [`show()`](AffineBackgroundTiles::show()).
+    /// This won't take effect until the next time you call [`show()`](AffineBackground::show()).
     /// Returns self so you can chain with other `set_` calls.
     pub fn set_priority(&mut self, priority: Priority) -> &mut Self {
         self.priority = priority;

--- a/agb/src/display/tiled/infinite_scrolled_map.rs
+++ b/agb/src/display/tiled/infinite_scrolled_map.rs
@@ -4,7 +4,7 @@ use crate::{
     fixnum::{Rect, Vector2D, vec2},
 };
 
-use super::{BackgroundId, RegularBackgroundTiles, TileSet, TileSetting};
+use super::{BackgroundId, RegularBackground, TileSet, TileSetting};
 
 /// In tiles
 const ONE_MORE_THAN_SCREEN_HEIGHT: i32 = HEIGHT / 8 + 1;
@@ -41,25 +41,25 @@ impl Position {
 ///
 /// Note that the `InfiniteScrolledMap` only works with _regular backgrounds_ and not affine backgrounds.
 ///
-/// You create an `InfiniteScrolledMap` by passing a [`RegularBackgroundTiles`] you've created before. Then,
+/// You create an `InfiniteScrolledMap` by passing a [`RegularBackground`] you've created before. Then,
 /// call [`set_scroll_pos()`](InfiniteScrolledMap::set_scroll_pos) to control the position of the scrolling.
 ///
 /// See [here](https://agbrs.dev/examples/infinite_scrolled_map) for an example of how to use it.
 pub struct InfiniteScrolledMap {
-    map: RegularBackgroundTiles,
+    map: RegularBackground,
 
     current_pos: Position,
 }
 
 impl InfiniteScrolledMap {
-    /// Creates a new [`InfiniteScrolledMap`] taking ownership of the [`RegularBackgroundTiles`]. Until you call
+    /// Creates a new [`InfiniteScrolledMap`] taking ownership of the [`RegularBackground`]. Until you call
     /// [`set_scroll_pos()`](InfiniteScrolledMap::set_scroll_pos) calling [`.show()`](InfiniteScrolledMap::show) on this will
     /// do no more than calling `.show` would have on the `map`.
     ///
     /// You need to call [`set_scroll_pos()`](InfiniteScrolledMap::set_scroll_pos) in order to actually render something to the
     /// map.
     #[must_use]
-    pub fn new(map: RegularBackgroundTiles) -> Self {
+    pub fn new(map: RegularBackground) -> Self {
         Self {
             map,
 
@@ -185,7 +185,7 @@ impl InfiniteScrolledMap {
     /// Scrolls the [`InfiniteScrolledMap`] to the provided location and does the minimum amount of
     /// rendering required in order to make the illusion that we have a map that's larger than the
     /// maximum background size provided by the Game Boy Advance. The behaviour is the same as
-    /// [`RegularBackgroundTiles::set_scroll_pos`] except without the wrapping behaviour.
+    /// [`RegularBackground::set_scroll_pos`] except without the wrapping behaviour.
     ///
     /// You should pass a function to the `tile` argument which, given a position, returns the tile
     /// that should be rendered in that location. Calling this with a new position that keeps some of
@@ -227,24 +227,24 @@ impl InfiniteScrolledMap {
         }
     }
 
-    /// Gets the current scroll position. See [`RegularBackgroundTiles::scroll_pos`]
+    /// Gets the current scroll position. See [`RegularBackground::scroll_pos`]
     #[must_use]
     pub fn scroll_pos(&self) -> Vector2D<i32> {
         self.map.scroll_pos()
     }
 
-    /// Sets the priority of the underlying map. See [`RegularBackgroundTiles::set_priority`]
+    /// Sets the priority of the underlying map. See [`RegularBackground::set_priority`]
     pub fn set_priority(&mut self, priority: Priority) {
         self.map.set_priority(priority);
     }
 
-    /// Gets the current priority of the underlying map. See [`RegularBackgroundTiles::priority`]
+    /// Gets the current priority of the underlying map. See [`RegularBackground::priority`]
     #[must_use]
     pub fn priority(&self) -> Priority {
         self.map.priority()
     }
 
-    /// Shows this map on the given [`GraphicsFrame`]. See [`RegularBackgroundTiles::show`] for more
+    /// Shows this map on the given [`GraphicsFrame`]. See [`RegularBackground::show`] for more
     /// details.
     pub fn show(&self, frame: &mut GraphicsFrame) -> BackgroundId {
         self.map.show(frame)

--- a/agb/src/display/tiled/regular_background.rs
+++ b/agb/src/display/tiled/regular_background.rs
@@ -92,9 +92,9 @@ impl RegularBackgroundSize {
 /// the GBA's VRAM will be allocated and unavailable for other backgrounds. You should use the
 /// smallest [`RegularBackgroundSize`] you can while still being able to render the scene you want.
 ///
-/// You can show up to 4 regular backgrounds at once (or 2 regular backgrounds and 1 [affine background](super::AffineBackgroundTiles)).
+/// You can show up to 4 regular backgrounds at once (or 2 regular backgrounds and 1 [affine background](super::AffineBackground)).
 ///
-/// To display a regular background to the screen, you need to call its [`show()`](RegularBackgroundTiles::show())
+/// To display a regular background to the screen, you need to call its [`show()`](RegularBackground::show())
 /// method on a given [`GraphicsFrame`](crate::display::GraphicsFrame).
 ///
 /// ## Example
@@ -107,12 +107,12 @@ impl RegularBackgroundSize {
 /// # fn foo(gba: &mut Gba) {
 /// use agb::display::{
 ///     Priority,
-///     tiled::{RegularBackgroundTiles, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+///     tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
 /// };
 ///
 /// let mut gfx = gba.graphics.get();
 ///
-/// let bg = RegularBackgroundTiles::new(
+/// let bg = RegularBackground::new(
 ///     Priority::P0,
 ///     RegularBackgroundSize::Background32x32,
 ///     TileFormat::FourBpp
@@ -127,7 +127,7 @@ impl RegularBackgroundSize {
 /// }
 /// # }
 /// ```
-pub struct RegularBackgroundTiles {
+pub struct RegularBackground {
     priority: Priority,
 
     tiles: Tiles,
@@ -138,14 +138,14 @@ pub struct RegularBackgroundTiles {
     scroll: Vector2D<i32>,
 }
 
-impl RegularBackgroundTiles {
+impl RegularBackground {
     /// Create a new RegularBackground with given `priority`, `size` and `colours`.
     ///
     /// This allocates some space in VRAM to store the actual tile data, but doesn't show anything until you call
-    /// the [`show()`](RegularBackgroundTiles::show()) function on a [`GraphicsFrame`](crate::display::GraphicsFrame).
+    /// the [`show()`](RegularBackground::show()) function on a [`GraphicsFrame`](crate::display::GraphicsFrame).
     ///
     /// You can have more `RegularBackgroundTile` instances then there are backgrounds, but you can only show
-    /// 4 at once in a given frame (or 2 and a single [affine background](super::AffineBackgroundTiles)).
+    /// 4 at once in a given frame (or 2 and a single [affine background](super::AffineBackground)).
     ///
     /// For [`Priority`], a higher priority is rendered first, so is behind lower priorities. Therefore, `P0`
     /// will be rendered at the _front_ and `P3` at the _back_. For equal priorities, backgrounds are rendered
@@ -170,7 +170,7 @@ impl RegularBackgroundTiles {
     /// in the background. So increasing the `x` coordinate of the scroll position moves the screen to the right,
     /// effectively rendering the background more to the left.
     ///
-    /// To get the current scroll position, you can call [`scroll_pos()`](RegularBackgroundTiles::scroll_pos()).
+    /// To get the current scroll position, you can call [`scroll_pos()`](RegularBackground::scroll_pos()).
     ///
     /// Returns self so you can chain with other `set_` calls.
     pub fn set_scroll_pos(&mut self, scroll: impl Into<Vector2D<i32>>) -> &mut Self {
@@ -184,7 +184,7 @@ impl RegularBackgroundTiles {
     /// in the background. So increasing the `x` coordinate of the scroll position moves the screen to the right,
     /// effectively rendering the background more to the left.
     ///
-    /// To set the current scroll position, you can call [`set_scroll_pos()`](RegularBackgroundTiles::set_scroll_pos()).
+    /// To set the current scroll position, you can call [`set_scroll_pos()`](RegularBackground::set_scroll_pos()).
     #[must_use]
     pub fn scroll_pos(&self) -> Vector2D<i32> {
         self.scroll
@@ -263,7 +263,7 @@ impl RegularBackgroundTiles {
     /// use agb::{
     ///     display::{
     ///         Priority,
-    ///         tiled::{RegularBackgroundTiles, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+    ///         tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     ///     },
     ///     include_background_gfx,
     /// };
@@ -272,7 +272,7 @@ impl RegularBackgroundTiles {
     ///
     /// # fn test(gba: agb::Gba) {
     /// VRAM_MANAGER.set_background_palettes(logo::PALETTES);
-    /// let mut bg = RegularBackgroundTiles::new(Priority::P0, RegularBackgroundSize::Background32x32, TileFormat::FourBpp);
+    /// let mut bg = RegularBackground::new(Priority::P0, RegularBackgroundSize::Background32x32, TileFormat::FourBpp);
     ///
     /// bg.fill_with(&logo::logo);
     /// # }
@@ -383,7 +383,7 @@ impl RegularBackgroundTiles {
 
     /// Sets the [`Priority`] of this background.
     ///
-    /// This won't take effect until the next call to [`show()`](RegularBackgroundTiles::show()).
+    /// This won't take effect until the next call to [`show()`](RegularBackground::show()).
     ///
     /// Returns self so you can chain with other `set_` calls.
     pub fn set_priority(&mut self, priority: Priority) -> &mut Self {

--- a/agb/src/display/tiled/regular_background/test.rs
+++ b/agb/src/display/tiled/regular_background/test.rs
@@ -13,7 +13,7 @@ fn test_commit_in_basic_case(gba: &mut Gba) {
     let mut graphics = gba.graphics.get();
     VRAM_MANAGER.set_background_palettes(agb_logo::PALETTES);
 
-    let mut bg_data = RegularBackgroundTiles::new(
+    let mut bg_data = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
@@ -42,7 +42,7 @@ fn test_commit_when_background_tiles_are_modified_after_show(gba: &mut Gba) {
     let mut graphics = gba.graphics.get();
     VRAM_MANAGER.set_background_palettes(agb_logo::PALETTES);
 
-    let mut bg_data = RegularBackgroundTiles::new(
+    let mut bg_data = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
@@ -79,7 +79,7 @@ fn test_commit_when_background_tiles_are_dropped_after_show(gba: &mut Gba) {
     let mut graphics = gba.graphics.get();
     VRAM_MANAGER.set_background_palettes(agb_logo::PALETTES);
 
-    let mut bg_data = RegularBackgroundTiles::new(
+    let mut bg_data = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
@@ -112,7 +112,7 @@ fn test_commit_when_background_tiles_rendered_twice(gba: &mut Gba) {
     let mut graphics = gba.graphics.get();
     VRAM_MANAGER.set_background_palettes(agb_logo::PALETTES);
 
-    let mut bg_data = RegularBackgroundTiles::new(
+    let mut bg_data = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -186,7 +186,7 @@
 ///
 /// ## `fill_with` and displaying a full screen background
 ///
-/// This example uses [`RegularBackgroundTiles::fill_with`](display::tiled::RegularBackgroundTiles::fill_with)
+/// This example uses [`RegularBackground::fill_with`](display::tiled::RegularBackground::fill_with)
 /// to fill the screen with a screen-sized image.
 ///
 /// ```rust
@@ -195,7 +195,7 @@
 /// # core::include!("doctest_runner.rs");
 /// use agb::{
 ///     display::{
-///         tiled::{RegularBackgroundSize, TileFormat, TileSet, TileSetting, RegularBackgroundTiles, VRAM_MANAGER},
+///         tiled::{RegularBackgroundSize, TileFormat, TileSet, TileSetting, RegularBackground, VRAM_MANAGER},
 ///         Priority,
 ///     },
 ///     include_background_gfx,
@@ -209,7 +209,7 @@
 /// # fn test(_: agb::Gba) {
 /// VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
 ///
-/// let mut bg = RegularBackgroundTiles::new(
+/// let mut bg = RegularBackground::new(
 ///     Priority::P0,
 ///     RegularBackgroundSize::Background32x32,
 ///     TileFormat::FourBpp,

--- a/book/games/pong/src/main.rs
+++ b/book/games/pong/src/main.rs
@@ -17,7 +17,7 @@ use agb::{
     display::{
         GraphicsFrame, Priority, WIDTH,
         object::Object,
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
     },
     fixnum::{Num, Rect, Vector2D, num, vec2},
     include_aseprite, include_background_gfx, include_wav,
@@ -157,14 +157,14 @@ fn main(mut gba: agb::Gba) -> ! {
     // Make sure the background palettes are set up
     VRAM_MANAGER.set_background_palettes(background::PALETTES);
 
-    let mut bg = RegularBackgroundTiles::new(
+    let mut bg = RegularBackground::new(
         Priority::P3,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
     );
     bg.fill_with(&background::PLAY_FIELD);
 
-    let mut player_health_background = RegularBackgroundTiles::new(
+    let mut player_health_background = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/book/src/articles/affine.md
+++ b/book/src/articles/affine.md
@@ -92,7 +92,7 @@ c & d & y \\\\
 
 To create affine backgrounds, please see the relevant section in the [backgrounds deep dive](./backgrounds.md#affine-backgrounds).
 
-You can apply a transformation matrix to an affine background using the [`.set_transform()`](https://docs.rs/agb/latest/agb/display/tiled/struct.AffineBackgroundTiles.html#method.set_transform) method and passing in the desired affine matrix.
+You can apply a transformation matrix to an affine background using the [`.set_transform()`](https://docs.rs/agb/latest/agb/display/tiled/struct.AffineBackground.html#method.set_transform) method and passing in the desired affine matrix.
 `set_transform()` takes an [`AffineMatrixBackground`](https://docs.rs/agb/latest/agb/display/tiled/struct.AffineMatrixBackground.html) rather than an `AffineMatrix` directly because they have different size requirements.
 
 You can convert from an `AffineMatrix` to an `AffineMatrixBackground` by using the `from_affine()` constructor or the `.into()` method.

--- a/book/src/articles/backgrounds.md
+++ b/book/src/articles/backgrounds.md
@@ -65,13 +65,13 @@ fn main() -> ! {
 }
 ```
 
-## `RegularBackgroundTiles`
+## `RegularBackground`
 
 With a `TileSet` ready and a palette set up, we need to actually declare which tiles to show where on the screen.
-This is done using the [`RegularBackgroundTiles`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackgroundTiles.html) struct.
-The `RegularBackgroundTiles` reserves some video RAM to store which tile goes where and other metadata about it like it's palette number and whether it should be flipped.
+This is done using the [`RegularBackground`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html) struct.
+The `RegularBackground` reserves some video RAM to store which tile goes where and other metadata about it like it's palette number and whether it should be flipped.
 
-[`RegularBackgroundTiles::new`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackgroundTiles.html#method.new) takes 3 arguments.
+[`RegularBackground::new`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.new) takes 3 arguments.
 The `priority` (which we'll set to `Priority::P0` for now), a tile format which you can get from `background::BEACH.format()` and a `size`.
 
 The size of the background can be one of [4 values](https://docs.rs/agb/latest/agb/display/tiled/enum.RegularBackgroundSize.html).
@@ -90,7 +90,7 @@ For this example, we'll just create a 32x32 background, but it is important to a
 use agb::{
     display::Priority,
     display::tiled::{
-        RegularBackgroundTiles, RegularBackgroundSize,
+        RegularBackground, RegularBackgroundSize,
         VRAM_MANAGER,
     },
     include_background_gfx,
@@ -106,7 +106,7 @@ fn main() -> ! {
     VRAM_MANAGER.set_background_palettes(background::PALETTES);
 
     // Create the background tiles ready for us to display on the screen
-    let mut tiles = RegularBackgroundTiles::new(
+    let mut tiles = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         background::BEACH.tiles.format()
@@ -117,7 +117,7 @@ fn main() -> ! {
 ```
 
 You'll now want to put tiles onto the background, ready to display them.
-This is done using the [`set_tile()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackgroundTiles.html#method.set_tile) method.
+This is done using the [`set_tile()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.set_tile) method.
 Let's loop over the width and height of the Game Boy Advance screen and set the tile in the background, so after the tiles are created, something like:
 
 ```rust
@@ -138,7 +138,7 @@ Note that if you run this, you still won't get anything showing on screen until 
 
 ## Showing a background on the screen
 
-To show a background on the screen, you'll need to to call the [`.show()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackgroundTiles.html#method.show) method passing in the current [`GraphicsFrame`](https://docs.rs/agb/latest/agb/display/GraphicsFrame.html).
+To show a background on the screen, you'll need to to call the [`.show()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.show) method passing in the current [`GraphicsFrame`](https://docs.rs/agb/latest/agb/display/GraphicsFrame.html).
 
 See the [`frame lifecycle`](./frame_lifecycle.md) article for more information about frame lifecycles, but to show our example so far, replace the loop with the following
 
@@ -157,7 +157,7 @@ loop {
 One of the key things you can use backgrounds to do is to display something scrolling.
 You can use this to make your level bigger than the world map, or to do some parallax effect in the background.
 
-You can scroll the background with the [`.set_scroll_pos()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackgroundTiles.html#method.set_scroll_pos) method.
+You can scroll the background with the [`.set_scroll_pos()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.set_scroll_pos) method.
 The `scroll_pos` passed to the `.set_scroll_pos()` method is effectively the 'camera' position.
 It chooses where the top left camera position should be.
 So increasing the `x` coordinate will slide the background to the right, to ensure that the top-left corner of the Game Boy Advance's screen is at that pixel.
@@ -172,7 +172,7 @@ These can be layered on top of each other to create different effects like the p
 
 ### Displaying multiple backgrounds
 
-You can display multiple backgrounds at once by calling the [`.show()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackgroundTiles.html#method.show) method on each background passing the same [`frame`](https://docs.rs/agb/latest/agb/display/GraphicsFrame.html) instance.
+You can display multiple backgrounds at once by calling the [`.show()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.show) method on each background passing the same [`frame`](https://docs.rs/agb/latest/agb/display/GraphicsFrame.html) instance.
 If you try to show more than 4 backgrounds, then the call to `.show()` will panic.
 
 ### Transparency
@@ -206,7 +206,7 @@ fn main() -> ! {
 }
 ```
 
-There is also a special tile setting you can use in the call to [`set_tile()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackgroundTiles.html#method.set_tile), [`TileSetting::BLANK`](https://docs.rs/agb/latest/agb/display/tiled/struct.TileSetting.html#associatedconstant.BLANK).
+There is also a special tile setting you can use in the call to [`set_tile()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.set_tile), [`TileSetting::BLANK`](https://docs.rs/agb/latest/agb/display/tiled/struct.TileSetting.html#associatedconstant.BLANK).
 This is a fully transparent tile, and if you ever want a tile in your background to be fully transparent, it is better to use this one for performance.
 
 ### Priority and interaction with objects
@@ -265,7 +265,7 @@ include_background_gfx!(
 );
 ```
 
-Also ensure that when you create the `RegularBackgroundTiles`, you pass [`TileFormat::EightBpp`](https://docs.rs/agb/latest/agb/display/tiled/enum.TileFormat.html#variant.EightBpp) (or using the `.format()` method on the tile data like we've been using in the other examples here).
+Also ensure that when you create the `RegularBackground`, you pass [`TileFormat::EightBpp`](https://docs.rs/agb/latest/agb/display/tiled/enum.TileFormat.html#variant.EightBpp) (or using the `.format()` method on the tile data like we've been using in the other examples here).
 A background must be in one of `FourBpp` or `EightBpp` mode.
 
 ## Tile effects
@@ -310,7 +310,7 @@ Sometimes you don't know what needs to be drawn on a tile ahead of time.
 [`DynamicTiles`](https://docs.rs/agb/latest/agb/display/tiled/struct.DynamicTile16.html) are a powerful way to show tiles whose contents are decided at runtime in your game.
 Their current main use is for text rendering, where they are used as the target for rendering text.
 
-Currently only 16-colour dynamic tiles are supported and can only be shown on 4 bits per pixel backgrounds via the [set_tile_dynamic16()](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackgroundTiles.html#method.set_tile_dynamic16) method on `RegularBackgroundTiles`.
+Currently only 16-colour dynamic tiles are supported and can only be shown on 4 bits per pixel backgrounds via the [set_tile_dynamic16()](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.set_tile_dynamic16) method on `RegularBackground`.
 
 ```rust
 // by default, `DynamicTile`s are left with whatever was in video RAM before it
@@ -320,7 +320,7 @@ let dynamic_tile = DynamicTile16::new().fill_with(0);
 
 // my_background here must have FourBpp set as it's TileFormat or you won't be able
 // to use DynamicTile16 on it.
-let my_background = RegularBackgroundTiles::new(
+let my_background = RegularBackground::new(
     Priority::P0,
     RegularBackgroundSize::Background32x32,
     TileFormat::FourBpp
@@ -391,10 +391,10 @@ use agb::display::tiled::VRAM_MANAGER;
 VRAM_MANAGER.set_backgroud_palettes(background::PALETTES);
 ```
 
-### Create the `AffineBackgroundTiles`
+### Create the `AffineBackground`
 
-These also work very similarly to [regular backgrounds](./backgrounds.md#regularbackgroundtiles).
-However, the constructor for [`AffineBackgroundTiles`](https://docs.rs/agb/latest/agb/display/tiled/struct.AffineBackgroundTiles.html#method.new) takes some different arguments.
+These also work very similarly to [regular backgrounds](./backgrounds.md#RegularBackground).
+However, the constructor for [`AffineBackground`](https://docs.rs/agb/latest/agb/display/tiled/struct.AffineBackground.html#method.new) takes some different arguments.
 
 The [`priority`](https://docs.rs/agb/latest/agb/display/enum.Priority.html) works in exactly the same way as regular backgrounds, with higher priorities being rendered first, so backgrounds with the lower priority are drawn on top of backgrounds with a higher priority.
 And similarly, objects with the same priority as an affine background are rendered above the background.
@@ -411,13 +411,13 @@ Play around with some of the [affine background examples](https://agbrs.dev/exam
 
 ### Putting tiles on screen
 
-The [`set_tile`](https://docs.rs/agb/latest/agb/display/tiled/struct.AffineBackgroundTiles.html#method.set_tile) method takes different arguments to the regular background case.
+The [`set_tile`](https://docs.rs/agb/latest/agb/display/tiled/struct.AffineBackground.html#method.set_tile) method takes different arguments to the regular background case.
 Instead of taking `TileSettings`, you give it a single `tile_index`.
 This is due to the limitation of affine backgrounds that you cannot flip tiles, so there are no settings to tweak.
 
 ### Showing the background on the screen
 
-As with most graphical things in `agb`, you show `AffineBackgroundTiles` on the screen by calling the [`.show()`](https://docs.rs/agb/latest/agb/display/tiled/struct.AffineBackgroundTiles.html#method.show) method passing in the current frame.
+As with most graphical things in `agb`, you show `AffineBackground` on the screen by calling the [`.show()`](https://docs.rs/agb/latest/agb/display/tiled/struct.AffineBackground.html#method.show) method passing in the current frame.
 
 ```rust
 let mut gfx = gba.graphics.get();

--- a/book/src/pong/09_background.md
+++ b/book/src/pong/09_background.md
@@ -60,15 +60,15 @@ VRAM_MANAGER.set_background_palettes(background::PALETTES);
 
 ### 2. Creating the background tiles
 
-Backgrounds are arranged in instances of [`RegularBackgroundTiles`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackgroundTiles.html).
+Backgrounds are arranged in instances of [`RegularBackground`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html).
 
 ```rust
 use agb::display::{
     Priority,
-    tiled::{RegularBackgroundTiles, RegularBackgroundSize, TileFormat},
+    tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
 };
 
-let mut bg = RegularBackgroundTiles::new(
+let mut bg = RegularBackground::new(
     Priority::P3,
     RegularBackgroundSize::Background32x32,
     TileFormat::FourBpp
@@ -83,7 +83,7 @@ This will mean that it is rendered below every background, and below any objects
 
 ### 3. Showing the tiles
 
-Just before the call to `frame.commit()`, call [`bg.show(&mut frame)`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackgroundTiles.html#method.show).
+Just before the call to `frame.commit()`, call [`bg.show(&mut frame)`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.show).
 
 ```rust
 bg.show(&mut frame);

--- a/book/src/pong/12_keeping_score.md
+++ b/book/src/pong/12_keeping_score.md
@@ -67,7 +67,7 @@ With these tiles imported, we now need to create a new background to store the p
 So next to where the current background gets created, create the player health background
 
 ```rust
-let mut player_health_background = RegularBackgroundTiles::new(
+let mut player_health_background = RegularBackground::new(
     Priority::P0,
     RegularBackgroundSize::Background32x32,
     TileFormat::FourBpp,

--- a/examples/combo/src/lib.rs
+++ b/examples/combo/src/lib.rs
@@ -10,8 +10,7 @@ use agb::{
         Priority,
         tile_data::TileData,
         tiled::{
-            InfiniteScrolledMap, RegularBackgroundSize, RegularBackgroundTiles, TileFormat,
-            VRAM_MANAGER,
+            InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER,
         },
     },
     fixnum::{Num, Vector2D},
@@ -56,7 +55,7 @@ fn get_game(gba: &mut agb::Gba) -> Game {
 
     VRAM_MANAGER.set_background_palettes(games::PALETTES);
 
-    let mut bg = InfiniteScrolledMap::new(RegularBackgroundTiles::new(
+    let mut bg = InfiniteScrolledMap::new(RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::EightBpp,

--- a/examples/hyperspace-roll/src/background.rs
+++ b/examples/hyperspace-roll/src/background.rs
@@ -1,9 +1,7 @@
 use agb::{
     display::{
         GraphicsFrame, Priority,
-        tiled::{
-            RegularBackgroundSize, RegularBackgroundTiles, TileSet, TileSetting, VRAM_MANAGER,
-        },
+        tiled::{RegularBackground, RegularBackgroundSize, TileSet, TileSetting, VRAM_MANAGER},
     },
     include_background_gfx, rng,
 };
@@ -23,7 +21,7 @@ pub fn load_palettes() {
 }
 
 pub(crate) fn load_help_text(
-    background: &mut RegularBackgroundTiles,
+    background: &mut RegularBackground,
     help_text_line: u16,
     at_tile: (u16, u16),
 ) {
@@ -40,7 +38,7 @@ pub(crate) fn load_help_text(
     }
 }
 
-pub(crate) fn load_description(face_id: usize, descriptions_map: &mut RegularBackgroundTiles) {
+pub(crate) fn load_description(face_id: usize, descriptions_map: &mut RegularBackground) {
     let description_data = if face_id < 10 {
         &backgrounds::descriptions1
     } else {
@@ -60,8 +58,8 @@ pub(crate) fn load_description(face_id: usize, descriptions_map: &mut RegularBac
 }
 
 // Expects a 64x32 map
-fn create_background_map(stars_tileset: &TileSet) -> RegularBackgroundTiles {
-    let mut map = RegularBackgroundTiles::new(
+fn create_background_map(stars_tileset: &TileSet) -> RegularBackground {
+    let mut map = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background64x32,
         stars_tileset.format(),
@@ -87,8 +85,8 @@ fn create_background_map(stars_tileset: &TileSet) -> RegularBackgroundTiles {
     map
 }
 
-pub fn show_title_screen(sfx: &mut Sfx) -> RegularBackgroundTiles {
-    let mut background = RegularBackgroundTiles::new(
+pub fn show_title_screen(sfx: &mut Sfx) -> RegularBackground {
+    let mut background = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         backgrounds::title.tiles.format(),
@@ -103,8 +101,8 @@ pub fn show_title_screen(sfx: &mut Sfx) -> RegularBackgroundTiles {
 }
 
 pub struct StarBackground {
-    background1: RegularBackgroundTiles,
-    background2: RegularBackgroundTiles,
+    background1: RegularBackground,
+    background2: RegularBackground,
 
     background1_timer: u32,
     background2_timer: u32,

--- a/examples/hyperspace-roll/src/battle.rs
+++ b/examples/hyperspace-roll/src/battle.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use agb::display::Priority;
 use agb::display::object::Object;
-use agb::display::tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat};
+use agb::display::tiled::{RegularBackground, RegularBackgroundSize, TileFormat};
 use agb::{hash_map::HashMap, input::Button};
 use alloc::vec;
 use alloc::vec::Vec;
@@ -490,7 +490,7 @@ pub(crate) fn battle_screen(
     agb.sfx.battle();
     agb.sfx.frame();
 
-    let mut help_background = RegularBackgroundTiles::new(
+    let mut help_background = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/examples/hyperspace-roll/src/customise.rs
+++ b/examples/hyperspace-roll/src/customise.rs
@@ -2,7 +2,7 @@ use agb::{
     display::{
         HEIGHT, Priority, WIDTH,
         object::Object,
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     input::{Button, Tri},
 };
@@ -144,13 +144,13 @@ pub(crate) fn customise_screen(
     mut player_dice: PlayerDice,
     level: u32,
 ) -> PlayerDice {
-    let mut descriptions_map = RegularBackgroundTiles::new(
+    let mut descriptions_map = RegularBackground::new(
         Priority::P1,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
     );
 
-    let mut help_background = RegularBackgroundTiles::new(
+    let mut help_background = RegularBackground::new(
         Priority::P1,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/examples/the-dungeon-puzzlers-lament/src/backgrounds.rs
+++ b/examples/the-dungeon-puzzlers-lament/src/backgrounds.rs
@@ -1,5 +1,5 @@
 use agb::{
-    display::tiled::{RegularBackgroundTiles, VRAM_MANAGER},
+    display::tiled::{RegularBackground, VRAM_MANAGER},
     include_background_gfx,
 };
 
@@ -18,7 +18,7 @@ pub fn load_palettes() {
     VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
 }
 
-pub fn load_ui(map: &mut RegularBackgroundTiles) {
+pub fn load_ui(map: &mut RegularBackground) {
     let ui_tileset = &backgrounds::ui.tiles;
 
     for y in 0..20u16 {
@@ -31,7 +31,7 @@ pub fn load_ui(map: &mut RegularBackgroundTiles) {
     }
 }
 
-pub fn load_level_background(map: &mut RegularBackgroundTiles, level_number: usize) {
+pub fn load_level_background(map: &mut RegularBackground, level_number: usize) {
     let level_map = &tilemaps::LEVELS_MAP[level_number];
 
     let level_tileset = &backgrounds::level.tiles;
@@ -46,6 +46,6 @@ pub fn load_level_background(map: &mut RegularBackgroundTiles, level_number: usi
     }
 }
 
-pub fn load_ending_page(map: &mut RegularBackgroundTiles) {
+pub fn load_ending_page(map: &mut RegularBackground) {
     map.fill_with(&backgrounds::ending);
 }

--- a/examples/the-dungeon-puzzlers-lament/src/game.rs
+++ b/examples/the-dungeon-puzzlers-lament/src/game.rs
@@ -3,7 +3,7 @@ use agb::{
         GraphicsFrame, HEIGHT, Palette16, Priority, Rgb15, WIDTH,
         font::{AlignmentKind, Layout, ObjectTextRenderer},
         object::{Object, PaletteVramSingle, Size, SpriteVram},
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     fixnum::Vector2D,
     input::{Button, ButtonController, Tri},
@@ -36,7 +36,7 @@ struct Lament {
     text_layout: Layout,
     text_objects: Vec<Object>,
     text_render: ObjectTextRenderer,
-    background: RegularBackgroundTiles,
+    background: RegularBackground,
 }
 
 fn generate_text_palette() -> PaletteVramSingle {
@@ -71,7 +71,7 @@ impl Lament {
             text_layout: layout,
             text_objects: Vec::new(),
             text_render: ObjectTextRenderer::new(palette, Size::S32x16),
-            background: RegularBackgroundTiles::new(
+            background: RegularBackground::new(
                 Priority::P1,
                 RegularBackgroundSize::Background32x32,
                 TileFormat::FourBpp,
@@ -102,13 +102,13 @@ impl Lament {
 
 struct Construction {
     game: GameState,
-    background: RegularBackgroundTiles,
+    background: RegularBackground,
 }
 
 impl Construction {
     fn new(level: usize) -> Self {
         let game = GameState::new(level);
-        let mut background = RegularBackgroundTiles::new(
+        let mut background = RegularBackground::new(
             Priority::P1,
             RegularBackgroundSize::Background32x32,
             TileFormat::FourBpp,

--- a/examples/the-dungeon-puzzlers-lament/src/game/game_state.rs
+++ b/examples/the-dungeon-puzzlers-lament/src/game/game_state.rs
@@ -2,7 +2,7 @@ use agb::{
     display::{
         GraphicsFrame,
         object::{Object, Tag},
-        tiled::RegularBackgroundTiles,
+        tiled::RegularBackground,
     },
     fixnum::Vector2D,
     input::{Button, ButtonController, Tri},
@@ -88,7 +88,7 @@ impl GameState {
         )
     }
 
-    pub fn load_level_background(&self, map: &mut RegularBackgroundTiles) {
+    pub fn load_level_background(&self, map: &mut RegularBackground) {
         crate::backgrounds::load_level_background(map, self.level_number);
     }
 

--- a/examples/the-dungeon-puzzlers-lament/src/lib.rs
+++ b/examples/the-dungeon-puzzlers-lament/src/lib.rs
@@ -7,7 +7,7 @@
 use agb::{
     display::{
         Graphics, GraphicsFrame, Priority,
-        tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     input::{Button, ButtonController},
     sound::mixer::Frequency,
@@ -56,13 +56,13 @@ pub fn entry(mut gba: agb::Gba) -> ! {
     let _ = save::init_save(&mut gba);
 
     let gfx = gba.graphics.get();
-    let mut ui_bg = RegularBackgroundTiles::new(
+    let mut ui_bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
     );
 
-    let mut ending_bg = RegularBackgroundTiles::new(
+    let mut ending_bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/examples/the-hat-chooses-the-wizard/src/level_display.rs
+++ b/examples/the-hat-chooses-the-wizard/src/level_display.rs
@@ -1,6 +1,6 @@
 use agb::display::{
     GraphicsFrame, HEIGHT, Priority, WIDTH,
-    tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, TileSet, TileSetting},
+    tiled::{RegularBackground, RegularBackgroundSize, TileFormat, TileSet, TileSetting},
 };
 
 const LEVEL_START: usize = 12 * 28;
@@ -9,12 +9,12 @@ const HYPHEN: usize = 12 * 28 + 11;
 pub const BLANK: usize = 11 * 28;
 
 pub struct LevelDisplay {
-    map: RegularBackgroundTiles,
+    map: RegularBackground,
 }
 
 impl LevelDisplay {
     pub fn new(tileset: &'_ TileSet<'_>, tile_settings: &[TileSetting]) -> Self {
-        let mut map = RegularBackgroundTiles::new(
+        let mut map = RegularBackground::new(
             Priority::P3,
             RegularBackgroundSize::Background32x32,
             TileFormat::FourBpp,

--- a/examples/the-hat-chooses-the-wizard/src/lib.rs
+++ b/examples/the-hat-chooses-the-wizard/src/lib.rs
@@ -11,8 +11,7 @@ use agb::{
         GraphicsFrame, HEIGHT, Priority, WIDTH,
         object::Object,
         tiled::{
-            InfiniteScrolledMap, RegularBackgroundSize, RegularBackgroundTiles, TileFormat,
-            VRAM_MANAGER,
+            InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER,
         },
     },
     fixnum::{FixedNum, Vector2D},
@@ -785,12 +784,12 @@ pub fn main(mut agb: agb::Gba) -> ! {
 
             sfx.frame();
 
-            let mut background = InfiniteScrolledMap::new(RegularBackgroundTiles::new(
+            let mut background = InfiniteScrolledMap::new(RegularBackground::new(
                 Priority::P2,
                 RegularBackgroundSize::Background32x64,
                 TileFormat::FourBpp,
             ));
-            let mut foreground = InfiniteScrolledMap::new(RegularBackgroundTiles::new(
+            let mut foreground = InfiniteScrolledMap::new(RegularBackground::new(
                 Priority::P0,
                 RegularBackgroundSize::Background64x32,
                 TileFormat::FourBpp,

--- a/examples/the-hat-chooses-the-wizard/src/splash_screen.rs
+++ b/examples/the-hat-chooses-the-wizard/src/splash_screen.rs
@@ -1,7 +1,7 @@
 use super::sfx::SfxPlayer;
 use agb::display::{
     Graphics, Priority,
-    tiled::{RegularBackgroundSize, RegularBackgroundTiles, TileFormat, VRAM_MANAGER},
+    tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
 };
 
 agb::include_background_gfx!(mod splash_screens,
@@ -15,7 +15,7 @@ pub enum SplashScreen {
 }
 
 pub fn show_splash_screen(gfx: &mut Graphics, which: SplashScreen, sfx: &mut SfxPlayer) {
-    let mut map = RegularBackgroundTiles::new(
+    let mut map = RegularBackground::new(
         Priority::P3,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -17,8 +17,7 @@ use agb::{
         GraphicsFrame, HEIGHT, Priority, Rgb15, WIDTH,
         object::{Object, Sprite, Tag},
         tiled::{
-            InfiniteScrolledMap, RegularBackgroundSize, RegularBackgroundTiles, TileFormat,
-            VRAM_MANAGER,
+            InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER,
         },
     },
     fixnum::{FixedNum, Rect, Vector2D, num, vec2},
@@ -2092,19 +2091,19 @@ fn game_with_level(gba: &mut agb::Gba) {
     VRAM_MANAGER.set_background_palettes(background::PALETTES);
 
     loop {
-        let backdrop = InfiniteScrolledMap::new(RegularBackgroundTiles::new(
+        let backdrop = InfiniteScrolledMap::new(RegularBackground::new(
             Priority::P2,
             RegularBackgroundSize::Background32x32,
             TileFormat::FourBpp,
         ));
 
-        let foreground = InfiniteScrolledMap::new(RegularBackgroundTiles::new(
+        let foreground = InfiniteScrolledMap::new(RegularBackground::new(
             Priority::P0,
             RegularBackgroundSize::Background32x32,
             TileFormat::FourBpp,
         ));
 
-        let clouds = InfiniteScrolledMap::new(RegularBackgroundTiles::new(
+        let clouds = InfiniteScrolledMap::new(RegularBackground::new(
             Priority::P3,
             RegularBackgroundSize::Background32x32,
             TileFormat::FourBpp,


### PR DESCRIPTION
This was unclear as to why they were named this way, so make it more obvious.

Since there's going to be a documentation audit shortly, I'll take the cowards way out of looking through the book and docs now, and look at that when we get round to the audit 🙃


- [x] no changelog update needed
