### PR TITLE
Clean up template comments

### DIFF
--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -1,9 +1,6 @@
 // Games made using `agb` are no_std which means you don't have access to the standard
 // rust library. This is because the game boy advance doesn't really have an operating
 // system, so most of the content of the standard library doesn't apply.
-//
-// Provided you haven't disabled it, agb does provide an allocator, so it is possible
-// to use both the `core` and the `alloc` built in crates.
 #![no_std]
 // `agb` defines its own `main` function, so you must declare your game's main function
 // using the #[agb::entry] proc macro. Failing to do so will cause failure in linking

--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -18,6 +18,6 @@ extern crate alloc;
 // The main function must take 1 arguments and never returns, and must be marked with
 // the #[agb::entry] macro.
 #[agb::entry]
-fn main(mut gba: agb::Gba) -> ! {
+fn main(gba: agb::Gba) -> ! {
     agb::no_game(gba);
 }

--- a/template/src/main.rs
+++ b/template/src/main.rs
@@ -11,9 +11,12 @@
 #![cfg_attr(test, reexport_test_harness_main = "test_main")]
 #![cfg_attr(test, test_runner(agb::test_runner::test_runner))]
 
-// The main function must take 1 arguments and never return. The agb::entry decorator
-// ensures that everything is in order. `agb` will call this after setting up the stack
-// and interrupt handlers correctly. It will also handle creating the `Gba` struct for you.
+// By default no_std crates don't get alloc, so you won't be able to use things like Vec
+// until you declare the extern crate. `agb` provides an allocator so it will all work
+extern crate alloc;
+
+// The main function must take 1 arguments and never returns, and must be marked with
+// the #[agb::entry] macro.
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
     agb::no_game(gba);


### PR DESCRIPTION
1. Remove the section about the allocator being disable-able
2. Add `extern crate alloc;` to the default template
3. Remove the `mut` because having it warn by default is a bit sad

- [x] no changelog update needed
