### PR TITLE
Only expose `AffineMatrixInstance` which is now called `AffineMatrixObject`

### DIFF
--- a/agb/examples/affine_object.rs
+++ b/agb/examples/affine_object.rs
@@ -6,7 +6,7 @@
 use agb::{
     display::{
         AffineMatrix, GraphicsFrame, HEIGHT, Rgb15, WIDTH,
-        object::{AffineMatrixInstance, AffineMode, Object, ObjectAffine, SpriteVram},
+        object::{AffineMatrixObject, AffineMode, Object, ObjectAffine, SpriteVram},
         tiled::VRAM_MANAGER,
     },
     fixnum::{Num, num, vec2},
@@ -26,7 +26,7 @@ fn show_with_boxes(matrix: AffineMatrix<Num<i32, 8>>, height: i32, frame: &mut G
 
     let crab = SpriteVram::from(sprites::IDLE.sprite(0));
     let square = SpriteVram::from(sprites::BOX.sprite(0));
-    let instance = AffineMatrixInstance::new(matrix);
+    let instance = AffineMatrixObject::new(matrix);
 
     for idx in 0..3 {
         Object::new(square.clone())

--- a/agb/examples/affine_transformations.rs
+++ b/agb/examples/affine_transformations.rs
@@ -10,7 +10,7 @@ use agb::{
     display::{
         AffineMatrix, GraphicsFrame, HEIGHT, Palette16, Rgb15, WIDTH,
         font::{AlignmentKind, Font, Layout, ObjectTextRenderer},
-        object::{AffineMatrixInstance, AffineMode, Object, ObjectAffine, Size, SpriteVram},
+        object::{AffineMatrixObject, AffineMode, Object, ObjectAffine, Size, SpriteVram},
         tiled::VRAM_MANAGER,
     },
     fixnum::{Num, Vector2D, num, vec2},
@@ -138,7 +138,7 @@ impl AffineDemonstration {
 
         let matrix = self.demonstration.matrix(self.position);
 
-        let obj_matrix = AffineMatrixInstance::new(matrix);
+        let obj_matrix = AffineMatrixObject::new(matrix);
 
         ObjectAffine::new(
             self.crab_sprite.clone(),

--- a/agb/src/display/object.rs
+++ b/agb/src/display/object.rs
@@ -13,7 +13,7 @@ pub use sprites::{
 
 pub(crate) use sprites::SPRITE_LOADER;
 
-pub use affine::{AffineMatrixInstance, AffineMatrixObject};
+pub use affine::AffineMatrixObject;
 pub use unmanaged::{AffineMode, GraphicsMode, Object, ObjectAffine};
 pub(crate) use unmanaged::{Oam, OamFrame};
 

--- a/agb/src/display/object/unmanaged/object.rs
+++ b/agb/src/display/object/unmanaged/object.rs
@@ -6,8 +6,7 @@ use alloc::{boxed::Box, vec, vec::Vec};
 use crate::display::{
     GraphicsFrame, Priority,
     object::{
-        AffineMatrixInstance, OBJECT_ATTRIBUTE_MEMORY, affine::AffineMatrixVram,
-        sprites::SpriteVram,
+        AffineMatrixObject, OBJECT_ATTRIBUTE_MEMORY, affine::AffineMatrixVram, sprites::SpriteVram,
     },
 };
 
@@ -290,12 +289,12 @@ impl ObjectAffine {
     /// Creates an unmanaged object from a sprite in vram.
     pub fn new(
         sprite: impl Into<SpriteVram>,
-        affine_matrix: AffineMatrixInstance,
+        affine_matrix: AffineMatrixObject,
         affine_mode: AffineMode,
     ) -> Self {
         fn new(
             sprite: SpriteVram,
-            affine_matrix: AffineMatrixInstance,
+            affine_matrix: AffineMatrixObject,
             affine_mode: AffineMode,
         ) -> ObjectAffine {
             let sprite_location = sprite.location();
@@ -338,7 +337,7 @@ impl ObjectAffine {
     }
 
     /// Sets the affine matrix to an instance of a matrix
-    pub fn set_affine_matrix(&mut self, matrix: AffineMatrixInstance) -> &mut Self {
+    pub fn set_affine_matrix(&mut self, matrix: AffineMatrixObject) -> &mut Self {
         self.matrix = matrix.vram();
 
         self

--- a/book/src/articles/affine.md
+++ b/book/src/articles/affine.md
@@ -105,7 +105,7 @@ So you'll also need to set the position of the sprite separately.
 
 ```rust
 let affine_matrix = calculate_affine_matrix();
-let affine_matrix_instance = AffineMatrixInstance::new(affine_matrix);
+let affine_matrix_instance = AffineMatrixObject::new(affine_matrix);
 
 ObjectAffine::new(sprite, affine_matrix_instance, AffineMode::Affine)
     .set_position(affine_matrix.position().round())

--- a/book/src/articles/objects_deep_dive.md
+++ b/book/src/articles/objects_deep_dive.md
@@ -68,30 +68,29 @@ fn chicken(frame: &mut GraphicsFrame) {
 
 Affine objects can be rotated and scaled by an affine transformation.
 These objects are created using the [`ObjectAffine`](https://docs.rs/agb/latest/agb/display/object/struct.ObjectAffine.html) type.
-This like an [`Object`](https://docs.rs/agb/latest/agb/display/object/struct.Object.html) requires a sprite but also requires an [`AffineMatrixInstance`](https://docs.rs/agb/latest/agb/display/object/struct.AffineMatrixInstance.html) and an `AffineMode`.
-The affine matrix instance can be thought of as an affine matrix stored in oam.
+This, like an [`Object`](https://docs.rs/agb/latest/agb/display/object/struct.Object.html), requires a sprite but also requires an [`AffineMatrixObject`](https://docs.rs/agb/latest/agb/display/object/struct.AffineMatrixObject.html) and an `AffineMode`.
+The affine matrix object can be thought of as an affine matrix stored in oam.
 
 The [affine article](./affine.md) goes over some detail in how to create affine matrices.
-With a given affine matrix, you can use `AffineMatrixObject::from_affine` which creates an [`AffineMatrixObject`](https://docs.rs/agb/latest/agb/display/object/struct.AffineMatrixObject.html) that is suitable for use in objects.
-You can turn different `AffineMatrixObject` instances into individual [`AffineMatrixInstance`](https://docs.rs/agb/latest/agb/display/object/struct.AffineMatrixInstance.html).
+With a given affine matrix, you can use `AffineMatrixObject::new` or the `From` impl to create an [`AffineMatrixObject`](https://docs.rs/agb/latest/agb/display/object/struct.AffineMatrixObject.html).
 
-When using the same affine matrix for multiple sprites, it is important to reuse the `AffineMatrixInstance` as otherwise you may run out of affine matrices.
+When using the same affine matrix for multiple sprites, it is important to reuse the `AffineMatrixObject` as otherwise you may run out of affine matrices.
 You can use up to 32 affine matrices at once.
-`AffineMatrixInstance` implements `Clone`, and cloning is very cheap as it just increases a reference count.
+`AffineMatrixObject` implements `Clone`, and cloning is very cheap as it just increases a reference count.
 
 An `AffineMatrix` also stores a translation component.
 However, creating the `AffineMatrixObject` will lose this translation component, so you'll also need to set it as the position as follows:
 
 ```rust
 let affine_matrix = calculate_affine_matrix();
-let affine_matrix_instance = AffineMatrixInstance::new(affine_matrix);
+let affine_matrix_instance = AffineMatrixObject::new(affine_matrix);
 
 ObjectAffine::new(sprite, affine_matrix_instance, AffineMode::Affine)
     .set_position(affine_matrix.position().round())
     .show(frame);
 ```
 
-Beware that the position of an affine object is the centre of the sprite, and not the top left corner like it is for regular sprites.
+Be aware that the position of an affine object is the centre of the sprite, and not the top left corner like it is for regular sprites.
 
 Affine objects have two display modes, the regular and the double modes.
 The double mode allows for the sprite to be scaled to twice the size of the original sprite while the single would cut off anything outside of the regular bounding box.

--- a/examples/amplitude/src/lib.rs
+++ b/examples/amplitude/src/lib.rs
@@ -12,10 +12,7 @@ use core::ops::Range;
 use agb::{
     display::{
         self, AffineMatrix, GraphicsFrame, Palette16, Rgb15,
-        object::{
-            AffineMatrixInstance, AffineMatrixObject, AffineMode, Object, ObjectAffine, SpriteVram,
-            Tag,
-        },
+        object::{AffineMatrixObject, AffineMode, Object, ObjectAffine, SpriteVram, Tag},
         tiled::VRAM_MANAGER,
     },
     fixnum::{Num, Vector2D, num},
@@ -245,7 +242,7 @@ impl Game {
                 AffineMatrix::from_rotation(saw.angle);
 
             saw.object
-                .set_affine_matrix(AffineMatrixInstance::new(angle_affine_matrix));
+                .set_affine_matrix(AffineMatrixObject::new(angle_affine_matrix));
 
             saw.object.set_pos(saw.position.floor() - (16, 16).into());
 
@@ -275,7 +272,7 @@ impl Game {
 
             let mut saw = ObjectAffine::new(
                 sprite_cache.saw.clone(),
-                AffineMatrixInstance::new(AffineMatrixObject::default()),
+                AffineMatrixObject::default(),
                 AffineMode::Affine,
             );
             let position = (300, rng::next_i32().rem_euclid(display::HEIGHT));


### PR DESCRIPTION
To be added to the changelog...