### PR TITLE
Simplify affine matrix generics

### DIFF
--- a/agb/examples/affine_object.rs
+++ b/agb/examples/affine_object.rs
@@ -18,7 +18,7 @@ include_aseprite!(mod sprites,
     "examples/gfx/box.aseprite",
 );
 
-fn show_with_boxes(matrix: AffineMatrix<Num<i32, 8>>, height: i32, frame: &mut GraphicsFrame) {
+fn show_with_boxes(matrix: AffineMatrix, height: i32, frame: &mut GraphicsFrame) {
     /// Calculate the x coordinate for a crab with a given index
     fn x(idx: i32) -> i32 {
         (WIDTH / 4) * (idx + 1) - 16

--- a/agb/examples/affine_transformations.rs
+++ b/agb/examples/affine_transformations.rs
@@ -202,7 +202,7 @@ impl AffineTransformKind {
         }
     }
 
-    fn matrix(self, values: Vector2D<Num<i32, 8>>) -> AffineMatrix<Num<i32, 8>> {
+    fn matrix(self, values: Vector2D<Num<i32, 8>>) -> AffineMatrix {
         match self {
             AffineTransformKind::Translation => {
                 // spin in a circle

--- a/agb/examples/dma_effect_affine_background_pipe.rs
+++ b/agb/examples/dma_effect_affine_background_pipe.rs
@@ -44,7 +44,7 @@ fn main(mut gba: agb::Gba) -> ! {
             let y = Num::new(y) - (theta * 2).sin() * 8;
 
             AffineMatrix::from_scale(vec2(num!(1) / scale, num!(-1)))
-                * AffineMatrix::from_translation(vec2(num!(WIDTH / 2), y))
+                * AffineMatrix::from_translation(-vec2(num!(WIDTH / 2), y))
         })
         .collect::<Vec<_>>();
 
@@ -70,7 +70,7 @@ fn main(mut gba: agb::Gba) -> ! {
         let transforms = scale_transform_matrices
             .iter()
             .map(|&line_matrix| {
-                AffineMatrixBackground::from(AffineMatrix::from_translation(-pos) * line_matrix)
+                AffineMatrixBackground::from(AffineMatrix::from_translation(pos) * line_matrix)
             })
             .collect::<Vec<_>>();
         HBlankDma::new(transform_dma, &transforms).show(&mut frame);

--- a/agb/src/display/affine.rs
+++ b/agb/src/display/affine.rs
@@ -177,26 +177,21 @@ where
 {
     #[must_use]
     /// Generates the matrix that represents a rotation
-    pub fn from_rotation<const M: usize>(angle: Num<I, M>) -> Self {
-        fn from_rotation<I: FixedWidthSignedInteger, const N: usize, const M: usize>(
-            angle: Num<I, M>,
-        ) -> AffineMatrix<Num<I, N>> {
-            let cos = angle.cos().change_base();
-            let sin = angle.sin().change_base();
+    pub fn from_rotation(angle: Num<I, N>) -> Self {
+        let cos = angle.cos();
+        let sin = angle.sin();
 
-            // This might look backwards, but the gba does texture mapping, ie a
-            // point in screen base is transformed using the matrix to graphics
-            // space rather than how you might conventionally think of it.
-            AffineMatrix {
-                a: cos,
-                b: -sin,
-                c: sin,
-                d: cos,
-                x: num!(0),
-                y: num!(0),
-            }
+        // This might look backwards, but the gba does texture mapping, ie a
+        // point in screen base is transformed using the matrix to graphics
+        // space rather than how you might conventionally think of it.
+        AffineMatrix {
+            a: cos,
+            b: -sin,
+            c: sin,
+            d: cos,
+            x: num!(0),
+            y: num!(0),
         }
-        from_rotation(angle.rem_euclid(num!(1)))
     }
 
     /// Change from one `Num` kind to another where the conversion is loss-less
@@ -270,7 +265,7 @@ mod tests {
 
         assert_eq!(c.position(), position);
 
-        let d = AffineMatrix::from_rotation::<12>(num!(0.5));
+        let d = AffineMatrix::from_rotation(num!(0.5));
 
         let e = a * d;
 

--- a/agb/src/display/affine.rs
+++ b/agb/src/display/affine.rs
@@ -94,7 +94,7 @@ use crate::fixnum::{FixedWidthSignedInteger, Num, SignedNumber, Vector2D, num, v
 /// # }
 /// ```
 #[allow(missing_docs)]
-pub struct AffineMatrix<T> {
+pub struct AffineMatrix<T = Num<i32, 8>> {
     pub a: T,
     pub b: T,
     pub c: T,

--- a/agb/src/display/affine.rs
+++ b/agb/src/display/affine.rs
@@ -132,15 +132,15 @@ impl<T: SignedNumber> AffineMatrix<T> {
             b: T::zero(),
             c: T::zero(),
             d: T::one(),
-            x: -position.x,
-            y: -position.y,
+            x: position.x,
+            y: position.y,
         }
     }
 
     #[must_use]
     /// The position fields of the matrix
     pub fn position(&self) -> Vector2D<T> {
-        vec2(-self.x, -self.y)
+        vec2(self.x, self.y)
     }
 
     #[must_use]
@@ -181,9 +181,6 @@ where
         let cos = angle.cos();
         let sin = angle.sin();
 
-        // This might look backwards, but the gba does texture mapping, ie a
-        // point in screen base is transformed using the matrix to graphics
-        // space rather than how you might conventionally think of it.
         AffineMatrix {
             a: cos,
             b: -sin,

--- a/agb/src/display/blend.rs
+++ b/agb/src/display/blend.rs
@@ -469,7 +469,7 @@ mod test {
             }
         }
 
-        bg.set_transform(AffineMatrix::<Num<i32, 8>>::from_rotation::<8>(num!(0.125)));
+        bg.set_transform(AffineMatrix::from_rotation(num!(0.125)));
 
         let mut frame = gfx.frame();
         let bg_id = bg.show(&mut frame);
@@ -620,8 +620,7 @@ mod test {
 
         frame.blend().darken(num!(0.75)).enable_object();
 
-        let matrix =
-            AffineMatrixObject::from(AffineMatrix::<Num<i32, 8>>::from_rotation::<8>(num!(0.125)));
+        let matrix = AffineMatrixObject::from(AffineMatrix::from_rotation(num!(0.125)));
 
         ObjectAffine::new(sprites::IDLE.sprite(0), matrix, AffineMode::AffineDouble)
             .set_pos((100, 100))

--- a/agb/src/display/blend.rs
+++ b/agb/src/display/blend.rs
@@ -349,7 +349,7 @@ mod test {
                 RegularBackground, RegularBackgroundSize, VRAM_MANAGER,
             },
         },
-        fixnum::{Num, Rect, num, vec2},
+        fixnum::{Rect, num, vec2},
         include_aseprite, include_background_gfx,
         test_runner::assert_image_output,
     };

--- a/agb/src/display/object/affine.rs
+++ b/agb/src/display/object/affine.rs
@@ -137,12 +137,8 @@ impl AffineMatrixObject {
     }
 }
 
-impl<I, const N: usize> From<AffineMatrix<Num<I, N>>> for AffineMatrixObject
-where
-    I: FixedWidthSignedInteger,
-    i32: From<I>,
-{
-    fn from(value: AffineMatrix<Num<I, N>>) -> Self {
+impl From<AffineMatrix<Num<i32, 8>>> for AffineMatrixObject {
+    fn from(value: AffineMatrix<Num<i32, 8>>) -> Self {
         AffineMatrixObject::new(value)
     }
 }

--- a/agb/src/display/object/affine.rs
+++ b/agb/src/display/object/affine.rs
@@ -32,10 +32,10 @@ impl AffineMatrixObjectElements {
     /// calculations.
     pub fn to_affine_matrix(self) -> AffineMatrix<Num<i16, 8>> {
         AffineMatrix {
-            a: self.a.change_base(),
-            b: self.b.change_base(),
-            c: self.c.change_base(),
-            d: self.d.change_base(),
+            a: self.a,
+            b: self.b,
+            c: self.c,
+            d: self.d,
             x: 0.into(),
             y: 0.into(),
         }
@@ -137,8 +137,8 @@ impl AffineMatrixObject {
     }
 }
 
-impl From<AffineMatrix<Num<i32, 8>>> for AffineMatrixObject {
-    fn from(value: AffineMatrix<Num<i32, 8>>) -> Self {
+impl From<AffineMatrix> for AffineMatrixObject {
+    fn from(value: AffineMatrix) -> Self {
         AffineMatrixObject::new(value)
     }
 }

--- a/agb/src/display/tiled/affine_background.rs
+++ b/agb/src/display/tiled/affine_background.rs
@@ -354,12 +354,8 @@ impl Default for AffineMatrixBackground {
     }
 }
 
-impl<I, const N: usize> From<AffineMatrix<Num<I, N>>> for AffineMatrixBackground
-where
-    I: FixedWidthSignedInteger,
-    i32: From<I>,
-{
-    fn from(value: AffineMatrix<Num<I, N>>) -> Self {
+impl From<AffineMatrix<Num<i32, 8>>> for AffineMatrixBackground {
+    fn from(value: AffineMatrix<Num<i32, 8>>) -> Self {
         Self::from_affine(value)
     }
 }

--- a/agb/src/display/tiled/affine_background.rs
+++ b/agb/src/display/tiled/affine_background.rs
@@ -354,8 +354,8 @@ impl Default for AffineMatrixBackground {
     }
 }
 
-impl From<AffineMatrix<Num<i32, 8>>> for AffineMatrixBackground {
-    fn from(value: AffineMatrix<Num<i32, 8>>) -> Self {
+impl From<AffineMatrix> for AffineMatrixBackground {
+    fn from(value: AffineMatrix) -> Self {
         Self::from_affine(value)
     }
 }
@@ -387,7 +387,7 @@ impl AffineMatrixBackground {
     #[must_use]
     /// Converts to the affine matrix that is usable in performing efficient
     /// calculations.
-    pub fn to_affine_matrix(&self) -> AffineMatrix<Num<i32, 8>> {
+    pub fn to_affine_matrix(&self) -> AffineMatrix {
         AffineMatrix {
             a: self.a.change_base(),
             b: self.b.change_base(),
@@ -434,7 +434,7 @@ impl AffineMatrixBackground {
     }
 }
 
-impl From<AffineMatrixBackground> for AffineMatrix<Num<i32, 8>> {
+impl From<AffineMatrixBackground> for AffineMatrix {
     fn from(mat: AffineMatrixBackground) -> Self {
         mat.to_affine_matrix()
     }

--- a/agb/src/display/tiled/affine_background.rs
+++ b/agb/src/display/tiled/affine_background.rs
@@ -410,7 +410,7 @@ impl AffineMatrixBackground {
     /// # fn from_scale_rotation_position(
     /// #     transform_origin: Vector2D<Num<i32, 8>>,
     /// #     scale: Vector2D<Num<i32, 8>>,
-    /// #     rotation: Num<i32, 16>,
+    /// #     rotation: Num<i32, 8>,
     /// #     position: Vector2D<Num<i32, 8>>,
     /// # ) {
     /// let A = AffineMatrix::from_translation(-transform_origin)

--- a/agb/src/display/window.rs
+++ b/agb/src/display/window.rs
@@ -333,7 +333,7 @@ mod test {
             }
         }
 
-        bg.set_transform(AffineMatrix::<Num<i32, 8>>::from_rotation::<8>(num!(0.125)));
+        bg.set_transform(AffineMatrix::<Num<i32, 8>>::from_rotation(num!(0.125)));
 
         let mut frame = gfx.frame();
         let bg_id = bg.show(&mut frame);

--- a/book/src/articles/affine.md
+++ b/book/src/articles/affine.md
@@ -56,12 +56,12 @@ use agb::{
     fixnum::{Num, num}
 };
 
-let rot_mat: AffineMatrix<Num<i32, 8>> =
-    AffineMatrix::from_rotation::<8>(num!(0.25));
-let scale_mat: AffineMatrix<Num<i32, 8>> =
+let rot_mat: AffineMatrix =
+    AffineMatrix::from_rotation(num!(0.25));
+let scale_mat: AffineMatrix =
     AffineMatrix::from_scale(vec2(num!(0.5), num!(0.5)));
 
-let final_transform: AffineMatrix<Num<i32, 8>> = rot_mat * scale_mat;
+let final_transform: AffineMatrix = rot_mat * scale_mat;
 ```
 
 Remember that the transform is transforming _screen_ coordinates to _object_ coordinates.


### PR DESCRIPTION
There were too many generics. I've made the API slightly less flexible but now you don't have to state as many pointless generics.

- [x] no changelog update needed - already part of it
