### PR TITLE
Fix comment errors and add some tests

### DIFF
--- a/agb-fixnum/src/num.rs
+++ b/agb-fixnum/src/num.rs
@@ -926,7 +926,7 @@ mod test {
     #[should_panic]
     fn sqrt_must_be_positive(){
         let n: Num<i32, 8> = Num::new(-1);
-        n.sqrt();
+        let _ = n.sqrt();
     }
 
     #[test]

--- a/agb-fixnum/src/num.rs
+++ b/agb-fixnum/src/num.rs
@@ -909,11 +909,24 @@ mod test {
     }
 
     #[test]
+    fn test_new_from_parts(){
+        let n = Num::<i32, 4>::new_from_parts((2, 1 << 26));
+        assert_eq!(n.to_raw(), (2 << 4) + 1);
+    }
+
+    #[test]
     fn sqrt() {
         for x in 1..1024 {
             let n: Num<i32, 8> = Num::new(x * x);
             assert_eq!(n.sqrt(), x.into());
         }
+    }
+
+    #[test]
+    #[should_panic]
+    fn sqrt_must_be_positive(){
+        let n: Num<i32, 8> = Num::new(-1);
+        n.sqrt();
     }
 
     #[test]

--- a/agb-fixnum/src/num.rs
+++ b/agb-fixnum/src/num.rs
@@ -909,7 +909,7 @@ mod test {
     }
 
     #[test]
-    fn test_new_from_parts(){
+    fn test_new_from_parts() {
         let n = Num::<i32, 4>::new_from_parts((2, 1 << 26));
         assert_eq!(n.to_raw(), (2 << 4) + 1);
     }
@@ -924,7 +924,7 @@ mod test {
 
     #[test]
     #[should_panic]
-    fn sqrt_must_be_positive(){
+    fn sqrt_must_be_positive() {
         let n: Num<i32, 8> = Num::new(-1);
         let _ = n.sqrt();
     }

--- a/agb-fixnum/src/rect.rs
+++ b/agb-fixnum/src/rect.rs
@@ -274,7 +274,7 @@ mod test {
     }
 
     #[test]
-    fn test_rect_contains_point(){
+    fn test_rect_contains_point() {
         let rect1: Rect<i32> = Rect::new(Vector2D::new(-1, -1), Vector2D::new(2, 2));
         assert!(rect1.contains_point(Vector2D::default()));
         let rect2: Rect<i32> = Rect::new(Vector2D::new(1, 1), Vector2D::new(2, 2));
@@ -282,7 +282,7 @@ mod test {
     }
 
     #[test]
-    fn test_rect_touches(){
+    fn test_rect_touches() {
         let a: Rect<i32> = Rect::new(Vector2D::new(0, 0), Vector2D::new(2, 2));
         let b: Rect<i32> = Rect::new(Vector2D::new(1, 1), Vector2D::new(2, 2));
         let c: Rect<i32> = Rect::new(Vector2D::new(3, 3), Vector2D::new(1, 1));
@@ -291,7 +291,7 @@ mod test {
     }
 
     #[test]
-    fn test_rect_overlapping(){
+    fn test_rect_overlapping() {
         let a: Rect<i32> = Rect::new(Vector2D::new(0, 0), Vector2D::new(2, 2));
         let b: Rect<i32> = Rect::new(Vector2D::new(3, 3), Vector2D::new(1, 1));
         assert_eq!(a.overlapping_rect(b), None);
@@ -303,44 +303,44 @@ mod test {
     }
 
     #[test]
-    fn test_rect_clamp_point(){
+    fn test_rect_clamp_point() {
         let rect: Rect<i32> = Rect::new(Vector2D::new(0, 0), Vector2D::new(10, 10));
         assert_eq!(rect.clamp_point(Vector2D::new(5, 5)), Vector2D::new(5, 5));
         assert_eq!(rect.clamp_point(Vector2D::new(-5, 15)), Vector2D::new(0, 10));
     }
 
     #[test]
-    fn test_rect_top_left(){
+    fn test_rect_top_left() {
         let rect: Rect<i32> = Rect::new(Vector2D::new(3, 4), Vector2D::new(1, 1));
         assert_eq!(rect.top_left(), Vector2D::new(3, 4));
     }
 
     #[test]
-    fn test_rect_top_right(){
+    fn test_rect_top_right() {
         let rect: Rect<i32> = Rect::new(Vector2D::new(1, 2), Vector2D::new(3, 4));
         assert_eq!(rect.top_right(), Vector2D::new(4, 2));
     }
 
     #[test]
-    fn test_rect_bottom_left(){
+    fn test_rect_bottom_left() {
         let rect: Rect<i32> = Rect::new(Vector2D::new(1, 2), Vector2D::new(3, 4));
         assert_eq!(rect.bottom_left(), Vector2D::new(1, 6));
     }
 
     #[test]
-    fn test_rect_bottom_right(){
+    fn test_rect_bottom_right() {
         let rect: Rect<i32> = Rect::new(Vector2D::new(1, 2), Vector2D::new(3, 4));
         assert_eq!(rect.bottom_right(), Vector2D::new(4, 6));
     }
 
     #[test]
-    fn test_rect_centre(){
+    fn test_rect_centre() {
         let rect: Rect<i32> = Rect::new(Vector2D::new(0, 0), Vector2D::new(4, 6));
         assert_eq!(rect.centre(), Vector2D::new(2, 3));
     }
 
     #[test]
-    fn test_rect_abs(){
+    fn test_rect_abs() {
         let rect = Rect::new(Vector2D::new(1_i32, 2_i32), Vector2D::new(3_i32, 4_i32));
         let result = rect.abs();
         assert_eq!(result.position, Vector2D::new(1_i32, 2_i32));

--- a/agb-fixnum/src/rect.rs
+++ b/agb-fixnum/src/rect.rs
@@ -272,4 +272,78 @@ mod test {
             ]
         );
     }
+
+    #[test]
+    fn test_rect_contains_point(){
+        let rect1: Rect<i32> = Rect::new(Vector2D::new(-1, -1), Vector2D::new(2, 2));
+        assert!(rect1.contains_point(Vector2D::default()));
+        let rect2: Rect<i32> = Rect::new(Vector2D::new(1, 1), Vector2D::new(2, 2));
+        assert!(!rect2.contains_point(Vector2D::default()));
+    }
+
+    #[test]
+    fn test_rect_touches(){
+        let a: Rect<i32> = Rect::new(Vector2D::new(0, 0), Vector2D::new(2, 2));
+        let b: Rect<i32> = Rect::new(Vector2D::new(1, 1), Vector2D::new(2, 2));
+        let c: Rect<i32> = Rect::new(Vector2D::new(3, 3), Vector2D::new(1, 1));
+        assert!(a.touches(b));
+        assert!(!a.touches(c));
+    }
+
+    #[test]
+    fn test_rect_overlapping(){
+        let a: Rect<i32> = Rect::new(Vector2D::new(0, 0), Vector2D::new(2, 2));
+        let b: Rect<i32> = Rect::new(Vector2D::new(3, 3), Vector2D::new(1, 1));
+        assert_eq!(a.overlapping_rect(b), None);
+        let d: Rect<i32> = Rect::new(Vector2D::new(1, 1), Vector2D::new(2, 2));
+        assert_eq!(
+            a.overlapping_rect(d),
+            Some(Rect::new(Vector2D::new(1, 1), Vector2D::new(1, 1)))
+        );
+    }
+
+    #[test]
+    fn test_rect_clamp_point(){
+        let rect: Rect<i32> = Rect::new(Vector2D::new(0, 0), Vector2D::new(10, 10));
+        assert_eq!(rect.clamp_point(Vector2D::new(5, 5)), Vector2D::new(5, 5));
+        assert_eq!(rect.clamp_point(Vector2D::new(-5, 15)), Vector2D::new(0, 10));
+    }
+
+    #[test]
+    fn test_rect_top_left(){
+        let rect: Rect<i32> = Rect::new(Vector2D::new(3, 4), Vector2D::new(1, 1));
+        assert_eq!(rect.top_left(), Vector2D::new(3, 4));
+    }
+
+    #[test]
+    fn test_rect_top_right(){
+        let rect: Rect<i32> = Rect::new(Vector2D::new(1, 2), Vector2D::new(3, 4));
+        assert_eq!(rect.top_right(), Vector2D::new(4, 2));
+    }
+
+    #[test]
+    fn test_rect_bottom_left(){
+        let rect: Rect<i32> = Rect::new(Vector2D::new(1, 2), Vector2D::new(3, 4));
+        assert_eq!(rect.bottom_left(), Vector2D::new(1, 6));
+    }
+
+    #[test]
+    fn test_rect_bottom_right(){
+        let rect: Rect<i32> = Rect::new(Vector2D::new(1, 2), Vector2D::new(3, 4));
+        assert_eq!(rect.bottom_right(), Vector2D::new(4, 6));
+    }
+
+    #[test]
+    fn test_rect_centre(){
+        let rect: Rect<i32> = Rect::new(Vector2D::new(0, 0), Vector2D::new(4, 6));
+        assert_eq!(rect.centre(), Vector2D::new(2, 3));
+    }
+
+    #[test]
+    fn test_rect_abs(){
+        let rect = Rect::new(Vector2D::new(1_i32, 2_i32), Vector2D::new(3_i32, 4_i32));
+        let result = rect.abs();
+        assert_eq!(result.position, Vector2D::new(1_i32, 2_i32));
+        assert_eq!(result.size, Vector2D::new(3_i32, 4_i32));
+    }
 }

--- a/agb-fixnum/src/rect.rs
+++ b/agb-fixnum/src/rect.rs
@@ -306,7 +306,10 @@ mod test {
     fn test_rect_clamp_point() {
         let rect: Rect<i32> = Rect::new(Vector2D::new(0, 0), Vector2D::new(10, 10));
         assert_eq!(rect.clamp_point(Vector2D::new(5, 5)), Vector2D::new(5, 5));
-        assert_eq!(rect.clamp_point(Vector2D::new(-5, 15)), Vector2D::new(0, 10));
+        assert_eq!(
+            rect.clamp_point(Vector2D::new(-5, 15)),
+            Vector2D::new(0, 10)
+        );
     }
 
     #[test]

--- a/agb-fixnum/src/vec2.rs
+++ b/agb-fixnum/src/vec2.rs
@@ -432,7 +432,7 @@ mod test {
     }
 
     #[test]
-    fn test_vector_manhattan_distance(){
+    fn test_vector_manhattan_distance() {
         let v = Vector2D::<i32> { x: -3, y: 4 };
         assert_eq!(v.manhattan_distance(), 7);
         let v2 = Vector2D::<i32>::default();
@@ -440,14 +440,14 @@ mod test {
     }
 
     #[test]
-    fn test_fast_magnitude(){
+    fn test_fast_magnitude() {
         let n: Vector2D<Num<i32, 16>> = (3, 4).into();
         let result = n.fast_magnitude();
         assert!((result - (num!(4) * num!(0.960433870103) + num!(3) * num!(0.397824734759))).abs() < num!(0.1));
     }
 
     #[test]
-    fn test_normalise(){
+    fn test_normalise() {
         let n: Vector2D<Num<i32, 16>> = (3, 4).into();
         let result = n.normalise();
         assert!((result.x - num!(3) / num!(5)).abs() < num!(0.1));
@@ -455,7 +455,7 @@ mod test {
     }
 
     #[test]
-    fn test_fast_normalise(){
+    fn test_fast_normalise() {
         let n: Vector2D<Num<i32, 16>> = (3, 4).into();
         let mag = n.fast_magnitude();
         let result = n.fast_normalise();
@@ -464,7 +464,7 @@ mod test {
     }
 
     #[test]
-    fn test_vector_new_from_angle(){
+    fn test_vector_new_from_angle() {
         let angle: Num<i32, 8> = Default::default();
         let vec = Vector2D::<Num<i32, 8>>::new_from_angle(angle);
         assert_eq!(vec.x, Num::<i32, 8>::from_f64(1.0));

--- a/agb-fixnum/src/vec2.rs
+++ b/agb-fixnum/src/vec2.rs
@@ -433,7 +433,7 @@ mod test {
 
     #[test]
     fn test_vector_manhattan_distance(){
-        let mut v = Vector2D::<i32> { x: -3, y: 4 };
+        let v = Vector2D::<i32> { x: -3, y: 4 };
         assert_eq!(v.manhattan_distance(), 7);
         let v2 = Vector2D::<i32>::default();
         assert_eq!(v2.manhattan_distance(), 0);

--- a/agb-fixnum/src/vec2.rs
+++ b/agb-fixnum/src/vec2.rs
@@ -433,9 +433,7 @@ mod test {
 
     #[test]
     fn test_vector_manhattan_distance(){
-        let mut v = Vector2D::<i32>::default();
-        v.x = -3;
-        v.y = 4;
+        let mut v = Vector2D::<i32> { x: -3, y: 4 };
         assert_eq!(v.manhattan_distance(), 7);
         let v2 = Vector2D::<i32>::default();
         assert_eq!(v2.manhattan_distance(), 0);

--- a/agb-fixnum/src/vec2.rs
+++ b/agb-fixnum/src/vec2.rs
@@ -443,7 +443,10 @@ mod test {
     fn test_fast_magnitude() {
         let n: Vector2D<Num<i32, 16>> = (3, 4).into();
         let result = n.fast_magnitude();
-        assert!((result - (num!(4) * num!(0.960433870103) + num!(3) * num!(0.397824734759))).abs() < num!(0.1));
+        assert!(
+            (result - (num!(4) * num!(0.960433870103) + num!(3) * num!(0.397824734759))).abs()
+                < num!(0.1)
+        );
     }
 
     #[test]

--- a/agb-fixnum/src/vec2.rs
+++ b/agb-fixnum/src/vec2.rs
@@ -430,4 +430,46 @@ mod test {
 
         assert_eq!(v1 + v1, (v2 + v2).into());
     }
+
+    #[test]
+    fn test_vector_manhattan_distance(){
+        let mut v = Vector2D::<i32>::default();
+        v.x = -3;
+        v.y = 4;
+        assert_eq!(v.manhattan_distance(), 7);
+        let v2 = Vector2D::<i32>::default();
+        assert_eq!(v2.manhattan_distance(), 0);
+    }
+
+    #[test]
+    fn test_fast_magnitude(){
+        let n: Vector2D<Num<i32, 16>> = (3, 4).into();
+        let result = n.fast_magnitude();
+        assert!((result - (num!(4) * num!(0.960433870103) + num!(3) * num!(0.397824734759))).abs() < num!(0.1));
+    }
+
+    #[test]
+    fn test_normalise(){
+        let n: Vector2D<Num<i32, 16>> = (3, 4).into();
+        let result = n.normalise();
+        assert!((result.x - num!(3) / num!(5)).abs() < num!(0.1));
+        assert!((result.y - num!(4) / num!(5)).abs() < num!(0.1));
+    }
+
+    #[test]
+    fn test_fast_normalise(){
+        let n: Vector2D<Num<i32, 16>> = (3, 4).into();
+        let mag = n.fast_magnitude();
+        let result = n.fast_normalise();
+        assert!((result.x - num!(3) / mag).abs() < num!(0.1));
+        assert!((result.y - num!(4) / mag).abs() < num!(0.1));
+    }
+
+    #[test]
+    fn test_vector_new_from_angle(){
+        let angle: Num<i32, 8> = Default::default();
+        let vec = Vector2D::<Num<i32, 8>>::new_from_angle(angle);
+        assert_eq!(vec.x, Num::<i32, 8>::from_f64(1.0));
+        assert_eq!(vec.y, Num::<i32, 8>::from_f64(0.0));
+    }
 }

--- a/agb-hashmap/src/hash_set.rs
+++ b/agb-hashmap/src/hash_set.rs
@@ -97,7 +97,7 @@ impl<K, ALLOCATOR: ClonableAllocator> HashSet<K, ALLOCATOR> {
     ///
     /// # Panics
     ///
-    /// Panics if capacity is larger than 2^32 * .85
+    /// Panics if capacity >= 2^31 * 0.6
     #[must_use]
     pub fn with_capacity_in(capacity: usize, alloc: ALLOCATOR) -> Self {
         Self {

--- a/agb-hashmap/src/lib.rs
+++ b/agb-hashmap/src/lib.rs
@@ -989,20 +989,20 @@ mod test {
     use super::*;
 
     #[test]
-    fn can_create_with_size(){
+    fn can_create_with_size() {
         let map: HashMap<i32, i32, Global> = HashMap::with_size_in(2, Global);
         assert_eq!(map.len(), 0);
     }
 
     #[test]
-    fn can_create_with_capacity(){
+    fn can_create_with_capacity() {
         let map: HashMap<i32, i32, Global> = HashMap::with_capacity_in(0, Global);
         assert_eq!(map.len(), 0);
     }
 
     #[test]
     #[should_panic]
-    fn cannot_create_with_overflows(){
+    fn cannot_create_with_overflows() {
         let _ = HashMap::<i32, i32, Global>::with_capacity_in((1 << 31) * 3 / 5, Global);
     }
 
@@ -1092,7 +1092,7 @@ mod test {
     }
 
     #[test]
-    fn can_entry_or_insert(){
+    fn can_entry_or_insert() {
         let mut map = HashMap::new();
         map.insert(1, 10);
         let v = map.entry(1).or_insert(20);
@@ -1100,7 +1100,7 @@ mod test {
     }
 
     #[test]
-    fn can_entry_or_insert_with(){
+    fn can_entry_or_insert_with() {
         let mut map = HashMap::new();
         map.insert(3, 15);
         let v = map.entry(3).or_insert_with(|| 25);
@@ -1108,7 +1108,7 @@ mod test {
     }
 
     #[test]
-    fn can_entry_or_insert_with_key(){
+    fn can_entry_or_insert_with_key() {
         let mut map = HashMap::new();
         map.insert(5, 50);
         let v = map.entry(5).or_insert_with_key(|k| k * 10);
@@ -1116,7 +1116,7 @@ mod test {
     }
 
     #[test]
-    fn can_entry_or_default_for_existing_key(){
+    fn can_entry_or_default_for_existing_key() {
         let mut map = HashMap::new();
         map.insert(9, 9);
         let v = map.entry(9).or_default();
@@ -1124,7 +1124,7 @@ mod test {
     }
 
     #[test]
-    fn can_entry_or_default_for_missing_key(){
+    fn can_entry_or_default_for_missing_key() {
         let mut map = HashMap::new();
         let v = map.entry(10).or_default();
         assert_eq!(*v, 0);
@@ -1355,7 +1355,7 @@ mod test {
     }
 
     #[test]
-    fn test_value_mut(){
+    fn test_value_mut() {
         let mut map = HashMap::new();
         map.insert("x", 1);
         for v in map.values_mut() {
@@ -1365,7 +1365,7 @@ mod test {
     }
 
     #[test]
-    fn test_iter_mut(){
+    fn test_iter_mut() {
         let mut map = HashMap::new();
         map.insert(1, 1);
         map.insert(2, 2);
@@ -1599,7 +1599,7 @@ mod test {
     }
 
     #[test]
-    fn test_fast_mod(){
+    fn test_fast_mod() {
         let h = HashType(10);
         assert_eq!(h.fast_mod(8), 2);
     }

--- a/agb-hashmap/src/lib.rs
+++ b/agb-hashmap/src/lib.rs
@@ -229,7 +229,7 @@ impl<K, V, ALLOCATOR: ClonableAllocator> HashMap<K, V, ALLOCATOR> {
     ///
     /// # Panics
     ///
-    /// Panics if capacity is larger than 2^32 * .85
+    /// Panics if capacity >= 2^31 * 0.6
     #[must_use]
     pub fn with_capacity_in(capacity: usize, alloc: ALLOCATOR) -> Self {
         for i in 0..32 {
@@ -989,6 +989,24 @@ mod test {
     use super::*;
 
     #[test]
+    fn can_create_with_size(){
+        let map: HashMap<i32, i32, Global> = HashMap::with_size_in(2, Global);
+        assert_eq!(map.len(), 0);
+    }
+
+    #[test]
+    fn can_create_with_capacity(){
+        let map: HashMap<i32, i32, Global> = HashMap::with_capacity_in(0, Global);
+        assert_eq!(map.len(), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn cannot_create_with_overflows(){
+        let _ = HashMap::<i32, i32, Global>::with_capacity_in((1 << 31) * 3 / 5, Global);
+    }
+
+    #[test]
     fn can_store_and_retrieve_8_elements() {
         let mut map = HashMap::new();
 
@@ -1071,6 +1089,46 @@ mod test {
         for i in 0..65 {
             assert_eq!(map.get(&i), Some(&(i % 4)));
         }
+    }
+
+    #[test]
+    fn can_entry_or_insert(){
+        let mut map = HashMap::new();
+        map.insert(1, 10);
+        let v = map.entry(1).or_insert(20);
+        assert_eq!(*v, 10);
+    }
+
+    #[test]
+    fn can_entry_or_insert_with(){
+        let mut map = HashMap::new();
+        map.insert(3, 15);
+        let v = map.entry(3).or_insert_with(|| 25);
+        assert_eq!(*v, 15);
+    }
+
+    #[test]
+    fn can_entry_or_insert_with_key(){
+        let mut map = HashMap::new();
+        map.insert(5, 50);
+        let v = map.entry(5).or_insert_with_key(|k| k * 10);
+        assert_eq!(*v, 50);
+    }
+
+    #[test]
+    fn can_entry_or_default_for_existing_key(){
+        let mut map = HashMap::new();
+        map.insert(9, 9);
+        let v = map.entry(9).or_default();
+        assert_eq!(*v, 9);
+    }
+
+    #[test]
+    fn can_entry_or_default_for_missing_key(){
+        let mut map = HashMap::new();
+        let v = map.entry(10).or_default();
+        assert_eq!(*v, 0);
+        assert_eq!(map.get(&10), Some(&0));
     }
 
     struct NoisyDrop {
@@ -1297,6 +1355,28 @@ mod test {
     }
 
     #[test]
+    fn test_value_mut(){
+        let mut map = HashMap::new();
+        map.insert("x", 1);
+        for v in map.values_mut() {
+            *v += 1;
+        }
+        assert_eq!(map.get(&"x"), Some(&2));
+    }
+
+    #[test]
+    fn test_iter_mut(){
+        let mut map = HashMap::new();
+        map.insert(1, 1);
+        map.insert(2, 2);
+        for (k, v) in map.iter_mut() {
+            *v += *k;
+        }
+        assert_eq!(map.get(&1), Some(&2));
+        assert_eq!(map.get(&2), Some(&4));
+    }
+
+    #[test]
     fn test_retain() {
         let mut map = HashMap::new();
 
@@ -1516,6 +1596,12 @@ mod test {
             assert!(map_str == "{1: 2, 3: 4}" || map_str == "{3: 4, 1: 2}");
             assert_eq!(format!("{empty:?}"), "{}");
         }
+    }
+
+    #[test]
+    fn test_fast_mod(){
+        let h = HashType(10);
+        assert_eq!(h.fast_mod(8), 2);
     }
 
     #[cfg(not(miri))]


### PR DESCRIPTION
Hi, I submitted #1003 and I found some other code comment inconsistencies.
In agb-master/agb-hashmap/src/lib.rs, the comment indicates that code will panic if capacity > 2^32 * 0.85.
```rust
/// # Panics
    ///
    /// Panics if capacity is larger than 2^32 * .85
    #[must_use]
    pub fn with_capacity_in(capacity: usize, alloc: ALLOCATOR) -> Self {
        for i in 0..32 {
            let attempted_size = 1usize << i;
            if number_before_resize(attempted_size) > capacity {
                return Self::with_size_in(attempted_size, alloc);
            }
        }

        panic!(
            "Failed to come up with a size which satisfies capacity {}",
            capacity
        );
    }
const fn number_before_resize(capacity: usize) -> usize {
    capacity * 60 / 100
}
```
But following test will failed(3650722201=2^32 * 0.85).
```rust
#[test]
fn test(){
    let _ = HashMap::<i32, i32, Global>::with_capacity_in(3650722201, Global);
}
```
Actually, after compare git history I think this is a comment error, there are 3 errors in "Panics if capacity is larger than 2^32 * .85". 
1. 2^32 should be 2^31
2. 0.85 should be 0.6 
3. larger than should be >=, as following test will fail when =.
```rust
#[test]
    fn test(){
        let _ = HashMap::<i32, i32, Global>::with_capacity_in((1 << 31) * 3 / 5 , Global);
    }
```
So the comment should be changed to "Panics if capacity >= 2^31 * 0.6".
Same error occurs in agb-master/agb-hashmap/src/hash_set.rs.
```rust
/// # Panics
    ///
    /// Panics if capacity is larger than 2^32 * .85
    #[must_use]
    pub fn with_capacity_in(capacity: usize, alloc: ALLOCATOR) -> Self {
        Self {
            map: HashMap::with_capacity_in(capacity, alloc),
        }
    }
```
What's more, I add some tests to improve the check on agb-fixnum and agb-hashmap. Thank you for taking the time to read my PR!
- [x] no changelog update needed
