### PR TITLE
Purple night use slotmap

### DIFF
--- a/examples/the-purple-night/Cargo.toml
+++ b/examples/the-purple-night/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 
 [dependencies]
 agb = { path = "../../agb", version = "0.21.3" }
-generational-arena = { version = "0.2", default-features = false }
+slotmap = { version = "1", default-features = false }
 
 [build-dependencies]
 quote = "1"

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -25,7 +25,8 @@ use agb::{
     rng,
     sound::mixer::Frequency,
 };
-use generational_arena::Arena;
+
+type Arena<T> = slotmap::SlotMap<slotmap::DefaultKey, T>;
 
 agb::include_aseprite!(mod sprites, "gfx/objects.aseprite", "gfx/boss.aseprite");
 

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -1876,11 +1876,18 @@ impl Game {
                 }
                 UpdateInstruction::None => {}
             }
-            enemy.entity.show(frame, this_frame_offset);
+        }
+
+        for i in remove {
+            self.enemies.remove(i);
         }
 
         self.player.show(frame, this_frame_offset);
         self.boss.show(frame, this_frame_offset);
+
+        for enemy in self.enemies.values_mut() {
+            enemy.entity.show(frame, this_frame_offset);
+        }
 
         let background_offset = vec2(this_frame_offset.floor().x, 8);
 
@@ -1919,10 +1926,6 @@ impl Game {
                         as usize],
                 )
             });
-
-        for i in remove {
-            self.enemies.remove(i);
-        }
 
         let mut remove = Vec::with_capacity(10);
 


### PR DESCRIPTION
* We prefer slotmap in our newer games, it's an easy enough change to use it in purple night.
* Also fixes a bug where it flashes an image when enemies die.

- [x] no changelog update needed
