### PR TITLE
No need to state crate in `include_background_gfx!`

### DIFF
--- a/agb-image-converter/src/config.rs
+++ b/agb-image-converter/src/config.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use crate::{Colour, Colours};
 
 pub(crate) trait Config {
-    fn crate_prefix(&self) -> String;
     fn images(&self) -> HashMap<String, &dyn Image>;
     fn transparent_colour(&self) -> Option<Colour>;
 }

--- a/agb/src/display/blend.rs
+++ b/agb/src/display/blend.rs
@@ -354,7 +354,7 @@ mod test {
         test_runner::assert_image_output,
     };
 
-    include_background_gfx!(crate, mod background,
+    include_background_gfx!(mod background,
         LOGO => deduplicate "gfx/test_logo.aseprite",
         LOGO_256 => 256 "gfx/test_logo.aseprite",
     );

--- a/agb/src/display/tiled/regular_background/test.rs
+++ b/agb/src/display/tiled/regular_background/test.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{Gba, include_background_gfx, interrupt::VBlank, test_runner::assert_image_output};
 
-include_background_gfx!(crate, mod agb_logo, test_logo => deduplicate "gfx/test_logo.aseprite");
+include_background_gfx!(mod agb_logo, test_logo => deduplicate "gfx/test_logo.aseprite");
 
 const WIZARD_FACE_TILE: usize = 19 + 4 * 30;
 

--- a/agb/src/display/window.rs
+++ b/agb/src/display/window.rs
@@ -249,7 +249,7 @@ mod test {
         test_runner::assert_image_output,
     };
 
-    include_background_gfx!(crate, mod background,
+    include_background_gfx!(mod background,
         LOGO => deduplicate "gfx/test_logo.aseprite",
         LOGO_256 => 256 "gfx/test_logo.aseprite",
     );

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -41,6 +41,9 @@
 //! A more detailed walkthrough can be found in [the book](https://agbrs.dev/book), or you can play with the
 //! [interactive examples](https://agbrs.dev/examples) to get a better feel of what's possible.
 
+// needed to be able to refer to this crate as `agb`
+extern crate self as agb;
+
 /// Include background tiles from a png, bmp or aseprite file.
 ///
 /// This macro is used to convert a png, bmp or aseprite file into a format usable by the Game Boy Advance.
@@ -605,14 +608,6 @@ pub mod test_runner {
             mgba::DebugLevel::Info,
         )
         .unwrap();
-    }
-
-    // needed to fudge the #[entry] below
-    #[cfg(test)]
-    mod agb {
-        pub mod test_runner {
-            pub use super::super::agb_start_tests;
-        }
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Introduce `extern crate self as agb` in the `lib.rs` file which lets us  refer to `self` as `agb`. With that, it makes the macros simpler because they never need to refer to `agb` as `crate` any more.

- [x] no changelog update needed
