### PR TITLE
Do tile gc at a more sensible time

### DIFF
--- a/agb/src/display/blend.rs
+++ b/agb/src/display/blend.rs
@@ -192,7 +192,7 @@ impl Blend {
         self.brightness.set(value);
     }
 
-    pub(crate) fn commit(self) {
+    pub(crate) fn commit(&self) {
         BLEND_CONTROL.set(self.blend_control);
         BLEND_ALPHA.set(self.alpha);
         BLEND_BRIGHTNESS.set(self.brightness);

--- a/agb/src/display/tiled.rs
+++ b/agb/src/display/tiled.rs
@@ -14,8 +14,6 @@ mod registers;
 mod regular_background;
 mod vram_manager;
 
-use core::marker::PhantomData;
-
 use affine_background::AffineBackgroundScreenBlock;
 pub use affine_background::{
     AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour, AffineMatrixBackground,
@@ -326,31 +324,8 @@ struct AffineBackgroundData {
     commit_data: Option<AffineBackgroundCommitData>,
 }
 
-pub(crate) struct TiledBackground<'gba> {
-    _phantom: PhantomData<&'gba ()>,
-}
-
-impl TiledBackground<'_> {
-    pub(crate) unsafe fn new() -> Self {
-        Self {
-            _phantom: PhantomData,
-        }
-    }
-
-    pub(crate) fn iter(&mut self) -> BackgroundFrame<'_> {
-        BackgroundFrame {
-            _phantom: PhantomData,
-            num_regular: 0,
-            regular_backgrounds: Default::default(),
-            num_affine: 0,
-            affine_backgrounds: Default::default(),
-        }
-    }
-}
-
-pub(crate) struct BackgroundFrame<'bg> {
-    _phantom: PhantomData<&'bg ()>,
-
+#[derive(Default)]
+pub(crate) struct BackgroundFrame {
     num_regular: usize,
     regular_backgrounds: [RegularBackgroundData; 4],
 
@@ -358,7 +333,7 @@ pub(crate) struct BackgroundFrame<'bg> {
     affine_backgrounds: [AffineBackgroundData; 2],
 }
 
-impl BackgroundFrame<'_> {
+impl BackgroundFrame {
     fn set_next_regular(&mut self, data: RegularBackgroundData) -> RegularBackgroundId {
         let bg_index = self.next_regular_index();
 
@@ -400,7 +375,7 @@ impl BackgroundFrame<'_> {
         index + 2 // first affine BG is bg2
     }
 
-    pub fn commit(mut self) {
+    pub fn commit(&mut self) {
         let video_mode = self.num_affine as u16;
         let enabled_backgrounds =
             ((1u16 << self.num_regular) - 1) | (((1 << self.num_affine) - 1) << 2);
@@ -458,7 +433,5 @@ impl BackgroundFrame<'_> {
                 }
             }
         }
-
-        VRAM_MANAGER.gc();
     }
 }


### PR DESCRIPTION
We were doing the tile GC before updating the tile data in VRAM because otherwise we'd free the tiles, removing the last reference and causing them to disappear.

Now we don't free the tile data until after `commit` is finished, which allows us to run the tile GC much later in the process, which is better because we have a strict vblank deadline to finish committing, but GC can overrun that time.

- [x] no changelog update needed
