### PR TITLE
use agb::fixnum rather than agb_fixnum in example

### DIFF
--- a/agb/examples/save.rs
+++ b/agb/examples/save.rs
@@ -5,13 +5,13 @@
 
 use agb::{
     display::{HEIGHT, Palette16, Rgb15, WIDTH, object::Object, tiled::VRAM_MANAGER},
+    fixnum::{Num, Vector2D, vec2},
     include_aseprite,
     input::ButtonController,
     save::{Error, SaveManager},
 };
 
 extern crate alloc;
-use agb_fixnum::{Num, Vector2D, vec2};
 
 include_aseprite!(
     mod sprites,


### PR DESCRIPTION
Checking the logs for the playground server I noticed one had failed to build.
The underlying reason being not having agb_fixnum in the template crate we use, which we have decided we shouldn't be using anyway.

This won't fix what's on the website, it will only be fixed in the next release.