### PR TITLE
Fix warnings from rustc for 2025-06-06

### DIFF
--- a/agb/src/panics_render.rs
+++ b/agb/src/panics_render.rs
@@ -90,7 +90,10 @@ impl QrCodeBuffers {
         })
     }
 
-    fn generate_qr_code(&mut self, data: &str) -> Result<qrcodegen_no_heap::QrCode, DataTooLong> {
+    fn generate_qr_code(
+        &mut self,
+        data: &str,
+    ) -> Result<qrcodegen_no_heap::QrCode<'_>, DataTooLong> {
         qrcodegen_no_heap::QrCode::encode_text(
             data,
             &mut self.temp_buffer,

--- a/agb/src/save/mod.rs
+++ b/agb/src/save/mod.rs
@@ -282,7 +282,7 @@ impl SaveData {
     /// This will erase any data in any sector overlapping the input range. To
     /// calculate which offset ranges would be affected, use the
     /// [`align_range`](`SaveData::align_range`) function.
-    pub fn prepare_write(&mut self, range: Range<usize>) -> Result<SavePreparedBlock, Error> {
+    pub fn prepare_write(&mut self, range: Range<usize>) -> Result<SavePreparedBlock<'_>, Error> {
         self.check_bounds(range.clone())?;
         if self.info.uses_prepare_write {
             let range = self.align_range(range.clone());


### PR DESCRIPTION
lifetime flowing from input to output with different syntax can be confusing.

Build should pass now

- [x] no changelog update needed
