### PR TITLE
DMA3 mixer speedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed performance regression in 0.22 when dealing with backgrounds which haven't changed between frames.
 - Fixed a memory leak when creating and destroying AffineBackgrounds a few times.
 
+### Improved
+
+- Improved the performance of the mixer by about 10% in cases where you're playing a lot of mono sounds
+  at speeds <= 1.5x (common with trackers).
+
 ## [0.22.1] - 2025/06/06
 
 ### Added

--- a/agb/src/sound/mixer/mod.rs
+++ b/agb/src/sound/mixer/mod.rs
@@ -393,7 +393,13 @@ impl SoundChannel {
     /// how fast they play.
     #[inline(always)]
     pub fn playback(&mut self, playback_speed: impl Into<Num<u32, 8>>) -> &mut Self {
-        self.playback_speed = playback_speed.into();
+        let mut playback_speed = playback_speed.into();
+        let channel_len = Num::new(self.data.len() as u32);
+        while playback_speed >= channel_len {
+            playback_speed -= channel_len;
+        }
+
+        self.playback_speed = playback_speed;
         self
     }
 

--- a/agb/src/sound/mixer/mod.rs
+++ b/agb/src/sound/mixer/mod.rs
@@ -359,19 +359,9 @@ impl SoundChannel {
     #[inline(always)]
     #[must_use]
     pub fn new_high_priority(data: SoundData) -> Self {
-        SoundChannel {
-            data: data.data(),
-            pos: 0.into(),
-            should_loop: false,
-            playback_speed: 1.into(),
-            is_playing: true,
-            panning: 0.into(),
-            is_done: false,
-            priority: SoundPriority::High,
-            volume: 1.into(),
-            is_stereo: false,
-            restart_point: 0.into(),
-        }
+        let mut new = Self::new(data);
+        new.priority = SoundPriority::High;
+        new
     }
 
     /// Sets that a sound channel should loop back to the start once it has

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -533,7 +533,6 @@ impl MixerBuffer {
         let left_amount: Num<i16, 4> = left_amount.change_base();
 
         let channel_len = Num::<u32, 8>::new(channel.data.len() as u32);
-        let playback_speed = channel.playback_speed;
 
         // SAFETY: always aligned correctly by construction
         let working_buffer_i32: &mut [i32] = unsafe {
@@ -558,8 +557,9 @@ impl MixerBuffer {
             }
         }
 
-        let playback_buffer = if playback_speed <= num!(1.5) {
-            let total_to_play = (playback_speed * self.frequency.buffer_size() as u32).floor() + 1;
+        let playback_buffer = if channel.playback_speed <= num!(1.5) {
+            let total_to_play =
+                (channel.playback_speed * self.frequency.buffer_size() as u32).floor() + 1;
 
             if channel_len <= total_to_play.into() {
                 assert!((channel_len.floor() as usize / 2) * 2 <= temp_storage.len());

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -533,11 +533,7 @@ impl MixerBuffer {
         let left_amount: Num<i16, 4> = left_amount.change_base();
 
         let channel_len = Num::<u32, 8>::new(channel.data.len() as u32);
-        let mut playback_speed = channel.playback_speed;
-
-        while playback_speed >= channel_len - channel.restart_point {
-            playback_speed -= channel_len;
-        }
+        let playback_speed = channel.playback_speed;
 
         // SAFETY: always aligned correctly by construction
         let working_buffer_i32: &mut [i32] = unsafe {


### PR DESCRIPTION
Small performance improvement (about 10%) on mixer things when playing sounds slowly. Does this by copying using DMA3 into a temporary buffer if it turns out that will be faster.

![image](https://github.com/user-attachments/assets/30bbbb1a-cd2d-45dd-a874-b74fa7e1fc41)

- [ ] Changelog updated / no changelog update needed
