### PR TITLE
add changelog entry for nightly issue from 2025-08-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue using nightly versions newer than `2025-08-12`.
+
 ## [0.22.4] - 2025/07/15
 
 ### Fixed


### PR DESCRIPTION
If we're going to release just this, it should have a changelog entry

- [x] Changelog updated