### PR TITLE
Added small section in backgrounds deep dive about `fill_with()`

### DIFF
--- a/book/src/articles/backgrounds.md
+++ b/book/src/articles/backgrounds.md
@@ -136,6 +136,18 @@ for y in 0..20 {
 
 Note that if you run this, you still won't get anything showing on screen until you show the background on the frame, which we'll do in the next section.
 
+## The `fill_with()` function
+If the included `.aseprite` file is the exact dimensions of the GBA screen
+(240x160 pixels), you can also simply call [`.fill_with()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.fill_with)
+on the RegularBackground you created with a reference to the included file:
+
+```rust
+tiles.fill_with(&background::BEACH);
+```
+
+The same note from before still applies. You must still show `tiles` to
+actually see the background on screen.
+
 # Showing a background on the screen
 
 To show a background on the screen, you'll need to to call the [`.show()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.show) method passing in the current [`GraphicsFrame`](https://docs.rs/agb/latest/agb/display/GraphicsFrame.html).

--- a/book/src/articles/backgrounds.md
+++ b/book/src/articles/backgrounds.md
@@ -136,7 +136,7 @@ for y in 0..20 {
 
 If the included `.aseprite` file is the exact dimensions of the GBA screen
 (240x160 pixels), you can also simply call [`.fill_with()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.fill_with)
-on the RegularBackground you created with a reference to the included file:
+on the `RegularBackground` you created with a reference to the included file:
 
 ```rust
 tiles.fill_with(&background::BEACH);

--- a/book/src/articles/backgrounds.md
+++ b/book/src/articles/backgrounds.md
@@ -136,7 +136,7 @@ for y in 0..20 {
 
 If the included `.aseprite` file is the exact dimensions of the GBA screen
 (240x160 pixels), you can also simply call [`.fill_with()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.fill_with)
-on the `RegularBackground` you created with a reference to the included file:
+on the `RegularBackground` you created with a reference to the imported TileSet:
 
 ```rust
 tiles.fill_with(&background::BEACH);

--- a/book/src/articles/backgrounds.md
+++ b/book/src/articles/backgrounds.md
@@ -134,9 +134,6 @@ for y in 0..20 {
 }
 ```
 
-Note that if you run this, you still won't get anything showing on screen until you show the background on the frame, which we'll do in the next section.
-
-## The `fill_with()` function
 If the included `.aseprite` file is the exact dimensions of the GBA screen
 (240x160 pixels), you can also simply call [`.fill_with()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.fill_with)
 on the RegularBackground you created with a reference to the included file:
@@ -145,8 +142,7 @@ on the RegularBackground you created with a reference to the included file:
 tiles.fill_with(&background::BEACH);
 ```
 
-The same note from before still applies. You must still show `tiles` to
-actually see the background on screen.
+Note that if you run either approach, you still won't get anything showing on screen until you show the background on the frame, which we'll do in the next section.
 
 # Showing a background on the screen
 


### PR DESCRIPTION
Added a small section on the `fill_with()` convenience function to the backgrounds deep dive article, since it was used in the pong introduction but wasn't mentioned in the deep dive.

The section reads as follows:

If the included `.aseprite` file is the exact dimensions of the GBA screen (240x160 pixels), you can also simply call [`.fill_with()`](https://docs.rs/agb/latest/agb/display/tiled/struct.RegularBackground.html#method.fill_with) on the `RegularBackground` you created with a reference to the included file:

```rust
tiles.fill_with(&background::BEACH);
```

---

One open question is whether the previous example should be changed since both now cover the same use case. It might be an idea to have the previous example iterate over `0..32` and `0..32` instead with a different referenced background to show that the convenience function is just that and the manual method must be used for other sizes. On the other hand the article is meant to be followed along with, so having two distinct backgrounds might make continuity iffy. I tend towards just leaving it like this or maybe just adding one sentence to the manual example that this can cover any size.

I would appreciate your opinions on this though.

- [x] Changelog updated / **no changelog update needed**
