### PR TITLE
Fix for current nightly clippy

### DIFF
--- a/agb/tests/test_multiboot.rs
+++ b/agb/tests/test_multiboot.rs
@@ -8,7 +8,7 @@ fn hello() {}
 
 #[test_case]
 fn multiboot_test(_gba: &mut agb::Gba) {
-    let address: usize = hello as usize;
+    let address: usize = hello as *const () as usize;
 
     if option_env!("AGB_MULTIBOOT").is_some() {
         assert!(


### PR DESCRIPTION
Need to cast a function pointer to a pointer before it can be casted to a usize

- [x] no changelog update needed
