### PR TITLE
Remove `VRAM_MANAGER` from the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Moved background colour DMA control from `VRAM_MANAGER` to `GraphicsFrame`.
+- Moved palette handling from `VRAM_MANAGER` to `Graphics`.
 - Added a `rect` constructor for creating `Rect` objects.
 - Made `Rect<T>` and `Vector2D<T>` work with more types `T`.
 - More methods to `Rect<T>` and `Vector2D<T>` for getting components, clamping and sizing.

--- a/agb/examples/affine_background.rs
+++ b/agb/examples/affine_background.rs
@@ -8,7 +8,7 @@ use agb::{
         HEIGHT, Priority, WIDTH,
         tiled::{
             AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour,
-            AffineMatrixBackground, VRAM_MANAGER,
+            AffineMatrixBackground,
         },
     },
     fixnum::{Num, Vector2D, num, vec2},
@@ -25,8 +25,7 @@ include_background_gfx!(mod backgrounds,
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
-
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
+    gfx.set_background_palettes(backgrounds::PALETTES);
 
     let mut bg = create_background();
 

--- a/agb/examples/affine_object.rs
+++ b/agb/examples/affine_object.rs
@@ -7,7 +7,6 @@ use agb::{
     display::{
         AffineMatrix, GraphicsFrame, HEIGHT, Rgb15, WIDTH,
         object::{AffineMatrixObject, AffineMode, Object, ObjectAffine, SpriteVram},
-        tiled::VRAM_MANAGER,
     },
     fixnum::{Num, num, vec2},
     include_aseprite,
@@ -48,8 +47,7 @@ fn show_with_boxes(matrix: AffineMatrix, height: i32, frame: &mut GraphicsFrame)
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
-
-    VRAM_MANAGER.set_background_palette_colour(0, 0, Rgb15::WHITE);
+    gfx.set_background_palette_colour(0, 0, Rgb15::WHITE);
 
     let mut angle: Num<i32, 8> = num!(0);
 

--- a/agb/examples/affine_transformations.rs
+++ b/agb/examples/affine_transformations.rs
@@ -11,7 +11,6 @@ use agb::{
         AffineMatrix, GraphicsFrame, HEIGHT, Palette16, Rgb15, WIDTH,
         font::{AlignmentKind, Font, Layout, LayoutSettings, ObjectTextRenderer},
         object::{AffineMatrixObject, AffineMode, Object, ObjectAffine, Size, SpriteVram},
-        tiled::VRAM_MANAGER,
     },
     fixnum::{Num, Vector2D, num, vec2},
     include_aseprite, include_font,
@@ -32,8 +31,7 @@ fn entry(gba: agb::Gba) -> ! {
 
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
-
-    VRAM_MANAGER.set_background_palette_colour(0, 0, Rgb15::WHITE);
+    gfx.set_background_palette_colour(0, 0, Rgb15::WHITE);
 
     let mut demonstration = AffineDemonstration::new();
     let mut button_controller = ButtonController::new();

--- a/agb/examples/animated_background.rs
+++ b/agb/examples/animated_background.rs
@@ -9,7 +9,7 @@ use core::cmp::Ordering;
 use agb::{
     display::{
         Priority,
-        tiled::{RegularBackground, RegularBackgroundSize, TileEffect, TileSetting, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileEffect, TileSetting},
     },
     include_background_gfx,
 };
@@ -35,7 +35,7 @@ fn main(mut gba: agb::Gba) -> ! {
 
     let tileset = &background::platformer.tiles;
 
-    VRAM_MANAGER.set_background_palettes(background::PALETTES);
+    gfx.set_background_palettes(background::PALETTES);
 
     let mut bg = RegularBackground::new(
         Priority::P3,
@@ -95,7 +95,7 @@ fn main(mut gba: agb::Gba) -> ! {
         if frame_skip == 0 {
             // note that we're not even showing the frames again, we're replacing the tile data
             // in video RAM which will show up when that frame needs to be shown
-            VRAM_MANAGER.replace_tile(
+            gfx.replace_tile(
                 tileset,
                 background_tile_ids::SUNFLOWER.start,
                 tileset,

--- a/agb/examples/background_text_render.rs
+++ b/agb/examples/background_text_render.rs
@@ -6,7 +6,7 @@ use agb::{
     display::{
         Priority, Rgb, Rgb15,
         font::{Font, Layout, LayoutSettings, RegularBackgroundTextRenderer},
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     include_font,
 };
@@ -17,9 +17,9 @@ static FONT: Font = include_font!("examples/font/ark-pixel-10px-proportional-ja.
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
 
-    VRAM_MANAGER.set_background_palette_colour(0, 0, Rgb::new(0, 97, 132).into());
-    VRAM_MANAGER.set_background_palette_colour(0, 1, Rgb15::WHITE);
-    VRAM_MANAGER.set_background_palette_colour(0, 2, Rgb15::BLACK);
+    gfx.set_background_palette_colour(0, 0, Rgb::new(0, 97, 132).into());
+    gfx.set_background_palette_colour(0, 1, Rgb15::WHITE);
+    gfx.set_background_palette_colour(0, 2, Rgb15::BLACK);
 
     let mut bg = RegularBackground::new(
         Priority::P0,

--- a/agb/examples/blend_object_transparency.rs
+++ b/agb/examples/blend_object_transparency.rs
@@ -7,7 +7,7 @@ use agb::{
     display::{
         Priority,
         object::{GraphicsMode, Object},
-        tiled::{RegularBackground, RegularBackgroundSize, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize},
     },
     fixnum::{Num, num},
     include_aseprite, include_background_gfx,
@@ -18,9 +18,8 @@ include_background_gfx!(mod background, BEACH => deduplicate "examples/gfx/beach
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    VRAM_MANAGER.set_background_palettes(background::PALETTES);
-
     let mut gfx = gba.graphics.get();
+    gfx.set_background_palettes(background::PALETTES);
 
     let mut bg = RegularBackground::new(
         Priority::P0,

--- a/agb/examples/blend_rain.rs
+++ b/agb/examples/blend_rain.rs
@@ -6,9 +6,7 @@
 use agb::{
     display::{
         GraphicsFrame, Priority,
-        tiled::{
-            RegularBackground, RegularBackgroundId, RegularBackgroundSize, TileFormat, VRAM_MANAGER,
-        },
+        tiled::{RegularBackground, RegularBackgroundId, RegularBackgroundSize, TileFormat},
     },
     fixnum::{Num, num},
     include_aseprite, include_background_gfx, include_wav, rng,
@@ -29,11 +27,11 @@ static THUNDER: SoundData = include_wav!("examples/sfx/thunder.wav");
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    // Set up the background palettes as needed. These are produced by the include_background_gfx! macro call above.
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
-
     // Get access to the graphics struct which is used to manage the frame lifecycle
     let mut gfx = gba.graphics.get();
+
+    // Set up the background palettes as needed. These are produced by the include_background_gfx! macro call above.
+    gfx.set_background_palettes(backgrounds::PALETTES);
 
     let mut bg_tiles = RegularBackground::new(
         Priority::P3,

--- a/agb/examples/chicken.rs
+++ b/agb/examples/chicken.rs
@@ -8,9 +8,7 @@ use agb::{
     display::{
         GraphicsFrame, HEIGHT, WIDTH,
         object::{Object, Sprite},
-        tiled::{
-            InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER,
-        },
+        tiled::{InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat},
     },
     fixnum::{Num, Vector2D, num, rect, vec2},
     include_aseprite, include_background_gfx,
@@ -75,7 +73,7 @@ fn entry(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
     let mut input = agb::input::ButtonController::new();
 
-    VRAM_MANAGER.set_background_palettes(background::PALETTES);
+    gfx.set_background_palettes(background::PALETTES);
 
     let background = RegularBackground::new(
         agb::display::Priority::P0,

--- a/agb/examples/dma_effect_affine_background_3d_plane.rs
+++ b/agb/examples/dma_effect_affine_background_3d_plane.rs
@@ -12,7 +12,7 @@ use agb::{
         Priority,
         tiled::{
             AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour,
-            AffineMatrixBackground, RegularBackground, RegularBackgroundSize, VRAM_MANAGER,
+            AffineMatrixBackground, RegularBackground, RegularBackgroundSize,
         },
     },
     dma::HBlankDma,
@@ -30,9 +30,8 @@ include_background_gfx!(mod backgrounds,
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
-
     let mut gfx = gba.graphics.get();
+    gfx.set_background_palettes(backgrounds::PALETTES);
 
     let mut wrap_behaviour = AffineBackgroundWrapBehaviour::NoWrap;
 

--- a/agb/examples/dma_effect_affine_background_pipe.rs
+++ b/agb/examples/dma_effect_affine_background_pipe.rs
@@ -10,7 +10,7 @@ use agb::{
         AffineMatrix, Priority, WIDTH,
         tiled::{
             AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour,
-            AffineMatrixBackground, RegularBackground, RegularBackgroundSize, VRAM_MANAGER,
+            AffineMatrixBackground, RegularBackground, RegularBackgroundSize,
         },
     },
     dma::HBlankDma,
@@ -29,7 +29,7 @@ agb::include_background_gfx!(mod backgrounds,
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
 
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
+    gfx.set_background_palettes(backgrounds::PALETTES);
 
     let bg = grid_background();
     let help = help_background();

--- a/agb/examples/dma_effect_background_blob_monster.rs
+++ b/agb/examples/dma_effect_background_blob_monster.rs
@@ -12,7 +12,7 @@ use agb::{
     display::{
         GraphicsFrame, HEIGHT, Priority, WIDTH,
         object::Object,
-        tiled::{RegularBackground, RegularBackgroundSize, TileEffect, TileSetting, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileEffect, TileSetting},
     },
     dma::HBlankDma,
     fixnum::{Num, Vector2D, num, vec2},
@@ -31,9 +31,9 @@ include_aseprite!(mod sprites, "examples/gfx/monster-features.aseprite");
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
-
     let mut gfx = gba.graphics.get();
+    gfx.set_background_palettes(backgrounds::PALETTES);
+
     let mut monster = BlobMonster::new();
 
     loop {

--- a/agb/examples/dma_effect_background_colour.rs
+++ b/agb/examples/dma_effect_background_colour.rs
@@ -11,7 +11,7 @@ extern crate alloc;
 use agb::{
     display::{
         Rgb, Rgb15,
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     dma::HBlankDma,
     include_background_gfx, include_colours,
@@ -36,9 +36,9 @@ fn main(mut gba: agb::Gba) -> ! {
     );
 
     map.fill_with(&sky_background::SKY);
-    VRAM_MANAGER.set_background_palettes(sky_background::PALETTES);
+    gfx.set_background_palettes(sky_background::PALETTES);
 
-    let background_colour_index = VRAM_MANAGER
+    let background_colour_index: usize = gfx
         .find_colour_index_16(0, DARKEST_SKY_BLUE.to_rgb15())
         .expect("Should contain darkest sky blue colour");
 

--- a/agb/examples/dma_effect_background_desert.rs
+++ b/agb/examples/dma_effect_background_desert.rs
@@ -10,16 +10,20 @@ use alloc::{boxed::Box, vec::Vec};
 use agb::{
     display::{
         HEIGHT,
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     dma::HBlankDma,
     fixnum::Num,
     include_background_gfx,
 };
 
+include_background_gfx!(mod backgrounds, LOGO => "examples/gfx/test_logo.aseprite");
+
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
+    gfx.set_background_palettes(backgrounds::PALETTES);
+
     let map = get_logo();
 
     // Create sine wave through as the offset to create the stretchy wave.
@@ -51,15 +55,12 @@ fn main(mut gba: agb::Gba) -> ! {
 }
 
 fn get_logo() -> RegularBackground {
-    include_background_gfx!(mod backgrounds, LOGO => "examples/gfx/test_logo.aseprite");
-
     let mut map = RegularBackground::new(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
     );
 
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
     map.fill_with(&backgrounds::LOGO);
 
     map

--- a/agb/examples/dma_effect_background_magic_spell.rs
+++ b/agb/examples/dma_effect_background_magic_spell.rs
@@ -10,16 +10,20 @@ use alloc::{boxed::Box, vec::Vec};
 use agb::{
     display::{
         HEIGHT,
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     dma::HBlankDma,
     fixnum::Num,
     include_background_gfx,
 };
 
+include_background_gfx!(mod backgrounds, LOGO => "examples/gfx/test_logo.aseprite");
+
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
+    gfx.set_background_palettes(backgrounds::PALETTES);
+
     let map = get_logo();
 
     // Create sine wave through as the offset to create the stretchy wave.
@@ -51,15 +55,12 @@ fn main(mut gba: agb::Gba) -> ! {
 }
 
 fn get_logo() -> RegularBackground {
-    include_background_gfx!(mod backgrounds, LOGO => "examples/gfx/test_logo.aseprite");
-
     let mut map = RegularBackground::new(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
     );
 
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
     map.fill_with(&backgrounds::LOGO);
 
     map

--- a/agb/examples/dma_effect_circular_window.rs
+++ b/agb/examples/dma_effect_circular_window.rs
@@ -9,7 +9,7 @@ extern crate alloc;
 use agb::{
     display::{
         HEIGHT, WIDTH, WinIn,
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     dma::HBlankDma,
     fixnum::{Num, Vector2D, rect, vec2},
@@ -18,6 +18,8 @@ use agb::{
 
 use alloc::{boxed::Box, vec};
 
+include_background_gfx!(mod backgrounds, "000000", LOGO => "examples/gfx/test_logo.aseprite");
+
 #[agb::entry]
 fn entry(mut gba: agb::Gba) -> ! {
     main(gba)
@@ -25,6 +27,7 @@ fn entry(mut gba: agb::Gba) -> ! {
 
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
+    gfx.set_background_palettes(backgrounds::PALETTES);
 
     let map = get_logo();
 
@@ -86,15 +89,12 @@ fn main(mut gba: agb::Gba) -> ! {
 }
 
 fn get_logo() -> RegularBackground {
-    include_background_gfx!(mod backgrounds, "000000", LOGO => "examples/gfx/test_logo.aseprite");
-
     let mut map = RegularBackground::new(
         agb::display::Priority::P0,
         RegularBackgroundSize::Background32x32,
         TileFormat::FourBpp,
     );
 
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
     map.fill_with(&backgrounds::LOGO);
 
     map

--- a/agb/examples/dynamic_tiles.rs
+++ b/agb/examples/dynamic_tiles.rs
@@ -3,17 +3,14 @@
 
 use agb::display::{
     Palette16, Priority, Rgb15,
-    tiled::{
-        DynamicTile16, RegularBackground, RegularBackgroundSize, TileEffect, TileFormat,
-        VRAM_MANAGER,
-    },
+    tiled::{DynamicTile16, RegularBackground, RegularBackgroundSize, TileEffect, TileFormat},
 };
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
 
-    VRAM_MANAGER.set_background_palettes(&[Palette16::new(
+    gfx.set_background_palettes(&[Palette16::new(
         [
             0xff00, 0x0ff0, 0x00ff, 0xf00f, 0xf0f0, 0x0f0f, 0xaaaa, 0x5555, 0x0000, 0x0000, 0x0000,
             0x0000, 0x0000, 0x0000, 0x0000, 0x0000,

--- a/agb/examples/fixnums.rs
+++ b/agb/examples/fixnums.rs
@@ -9,7 +9,7 @@ use agb::{
     display::{
         Graphics,
         object::{Object, SpriteVram},
-        tiled::{RegularBackground, VRAM_MANAGER},
+        tiled::RegularBackground,
     },
     fixnum::{Num, Vector2D, vec2},
     include_aseprite, include_background_gfx,
@@ -99,7 +99,7 @@ fn main(mut gba: agb::Gba) -> ! {
         agb::display::tiled::TileFormat::FourBpp,
     );
 
-    VRAM_MANAGER.set_background_palettes(background::PALETTES);
+    gfx.set_background_palettes(background::PALETTES);
     bg.fill_with(&background::bg);
 
     let mut position = vec2(80, 80);

--- a/agb/examples/frame_lifecycle.rs
+++ b/agb/examples/frame_lifecycle.rs
@@ -7,7 +7,7 @@ use agb::{
     display::{
         GraphicsFrame, Priority,
         object::{Object, SpriteVram},
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     fixnum::{Num, Vector2D, num, vec2},
     include_aseprite, include_background_gfx,
@@ -46,11 +46,11 @@ impl Player {
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    // Set up the background palettes as needed. These are produced by the include_background_gfx! macro call above.
-    VRAM_MANAGER.set_background_palettes(background::PALETTES);
-
     // Get access to the graphics struct which is used to manage the frame lifecycle
     let mut gfx = gba.graphics.get();
+
+    // Set up the background palettes as needed. These are produced by the include_background_gfx! macro call above.
+    gfx.set_background_palettes(background::PALETTES);
 
     let mut player = Player::new(vec2(num!(100.), num!(100.)));
     let mut button_controller = ButtonController::new();

--- a/agb/examples/hud.rs
+++ b/agb/examples/hud.rs
@@ -9,7 +9,7 @@ use agb::{
     display::{
         GraphicsFrame, Priority,
         object::{Object, SpriteVram},
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     fixnum::{Num, Vector2D, num, vec2},
     include_aseprite, include_background_gfx,
@@ -56,11 +56,11 @@ impl Player {
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    // Set up the background palettes as needed. These are produced by the include_background_gfx! macro call above.
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
-
     // Get access to the graphics struct which is used to manage the frame lifecycle
     let mut gfx = gba.graphics.get();
+
+    // Set up the background palettes as needed. These are produced by the include_background_gfx! macro call above.
+    gfx.set_background_palettes(backgrounds::PALETTES);
 
     let mut player = Player::new(vec2(num!(100.), num!(100.)));
     let mut button_controller = ButtonController::new();

--- a/agb/examples/infinite_scrolled_map.rs
+++ b/agb/examples/infinite_scrolled_map.rs
@@ -6,7 +6,7 @@
 use agb::{
     display::{
         Priority,
-        tiled::{InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, VRAM_MANAGER},
+        tiled::{InfiniteScrolledMap, RegularBackground, RegularBackgroundSize},
     },
     fixnum::vec2,
     include_background_gfx,
@@ -23,7 +23,7 @@ fn main(mut gba: agb::Gba) -> ! {
 
     let tileset = &big_map::big_map.tiles;
 
-    VRAM_MANAGER.set_background_palettes(big_map::PALETTES);
+    gfx.set_background_palettes(big_map::PALETTES);
 
     let bg = RegularBackground::new(
         Priority::P0,

--- a/agb/examples/json_font_render.rs
+++ b/agb/examples/json_font_render.rs
@@ -8,7 +8,6 @@ use agb::{
         Palette16, Rgb, Rgb15,
         font::{Font, Layout, LayoutSettings, ObjectTextRenderer},
         object::Size,
-        tiled::VRAM_MANAGER,
     },
     fixnum::vec2,
     include_font,
@@ -37,7 +36,7 @@ fn entry(gba: agb::Gba) -> ! {
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
 
-    VRAM_MANAGER.set_background_palette_colour(0, 0, Rgb::new(0, 97, 132).into());
+    gfx.set_background_palette_colour(0, 0, Rgb::new(0, 97, 132).into());
 
     let layout = Layout::new(
         "Hello, this is some text that I want to display!",

--- a/agb/examples/mixer_32768.rs
+++ b/agb/examples/mixer_32768.rs
@@ -11,7 +11,7 @@ use agb::{
     display::{
         Priority, Rgb15, WIDTH,
         font::{AlignmentKind, Font, Layout, LayoutSettings, RegularBackgroundTextRenderer},
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     include_font, include_wav,
     sound::mixer::{Frequency, SoundChannel, SoundData},
@@ -23,6 +23,8 @@ static CRAZY_GLUE: SoundData = include_wav!("examples/JoshWoodward-CrazyGlue.wav
 #[agb::entry]
 fn main(mut gba: Gba) -> ! {
     let mut gfx = gba.graphics.get();
+    gfx.set_background_palette_colour(0, 1, Rgb15::WHITE);
+
     let mut bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
@@ -48,8 +50,6 @@ fn main(mut gba: Gba) -> ! {
 
 fn init_background(bg: &mut RegularBackground) {
     static FONT: Font = include_font!("examples/font/ark-pixel-10px-proportional-ja.ttf", 10);
-
-    VRAM_MANAGER.set_background_palette_colour(0, 1, Rgb15::WHITE);
 
     let text_layout = Layout::new(
         "Crazy glue by Josh Woodward\njoshwoodward.com",

--- a/agb/examples/mixer_basic.rs
+++ b/agb/examples/mixer_basic.rs
@@ -7,7 +7,7 @@ use agb::{
     display::{
         Priority, Rgb15, WIDTH,
         font::{AlignmentKind, Font, Layout, LayoutSettings, RegularBackgroundTextRenderer},
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     fixnum::num,
     include_font, include_wav,
@@ -23,6 +23,8 @@ fn main(mut gba: Gba) -> ! {
     let mut input = ButtonController::new();
 
     let mut gfx = gba.graphics.get();
+    gfx.set_background_palette_colour(0, 1, Rgb15::WHITE);
+
     let mut bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
@@ -81,8 +83,6 @@ fn main(mut gba: Gba) -> ! {
 
 fn init_background(bg: &mut RegularBackground) {
     static FONT: Font = include_font!("examples/font/ark-pixel-10px-proportional-ja.ttf", 10);
-
-    VRAM_MANAGER.set_background_palette_colour(0, 1, Rgb15::WHITE);
 
     let text_layout = Layout::new(
         "Dead code by Josh Woodward\njoshwoodward.com\n

--- a/agb/examples/object_text_render_simple.rs
+++ b/agb/examples/object_text_render_simple.rs
@@ -9,7 +9,6 @@ use agb::{
         Palette16, Rgb, Rgb15,
         font::{Font, Layout, LayoutSettings, ObjectTextRenderer},
         object::Size,
-        tiled::VRAM_MANAGER,
     },
     fixnum::vec2,
     include_font,
@@ -35,7 +34,7 @@ fn entry(gba: agb::Gba) -> ! {
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
 
-    VRAM_MANAGER.set_background_palette_colour(0, 0, Rgb::new(0, 97, 132).into());
+    gfx.set_background_palette_colour(0, 0, Rgb::new(0, 97, 132).into());
 
     let layout = Layout::new(
         "Hello, this is some text that I want to display!",

--- a/agb/examples/object_z_order.rs
+++ b/agb/examples/object_z_order.rs
@@ -10,7 +10,7 @@ use agb::{
     display::{
         Priority,
         object::Object,
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     include_aseprite, include_background_gfx,
     input::{Button, ButtonController},
@@ -25,7 +25,7 @@ include_background_gfx!(mod bg, BG => "examples/gfx/object_z_order_background.as
 #[agb::entry]
 fn entry(mut gba: Gba) -> ! {
     let mut gfx = gba.graphics.get();
-    VRAM_MANAGER.set_background_palettes(bg::PALETTES);
+    gfx.set_background_palettes(bg::PALETTES);
 
     let mut background = RegularBackground::new(
         Priority::P0,

--- a/agb/examples/save.rs
+++ b/agb/examples/save.rs
@@ -4,7 +4,7 @@
 #![no_main]
 
 use agb::{
-    display::{HEIGHT, Palette16, Rgb15, WIDTH, object::Object, tiled::VRAM_MANAGER},
+    display::{HEIGHT, Palette16, Rgb15, WIDTH, object::Object},
     fixnum::{Num, Vector2D, vec2},
     include_aseprite,
     input::ButtonController,
@@ -59,7 +59,7 @@ fn main(mut gba: agb::Gba) -> ! {
         .map(|data| data.position())
         .unwrap_or_else(|| vec2(WIDTH / 2, HEIGHT / 2).change_base());
 
-    VRAM_MANAGER.set_background_palette(
+    gfx.set_background_palette(
         0,
         &Palette16::new([0xffff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0].map(Rgb15::new)),
     );

--- a/agb/examples/scrolling_background.rs
+++ b/agb/examples/scrolling_background.rs
@@ -5,7 +5,7 @@
 use agb::{
     display::{
         Priority, WIDTH,
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     include_background_gfx,
 };
@@ -17,11 +17,11 @@ include_background_gfx!(mod background,
 
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
-    // Set up the background palettes as needed. These are produced by the include_background_gfx! macro call above.
-    VRAM_MANAGER.set_background_palettes(background::PALETTES);
-
     // Get access to the graphics struct which is used to manage the frame lifecycle
     let mut gfx = gba.graphics.get();
+
+    // Set up the background palettes as needed. These are produced by the include_background_gfx! macro call above.
+    gfx.set_background_palettes(background::PALETTES);
 
     let mut scrolling_tiles = RegularBackground::new(
         Priority::P1,

--- a/agb/examples/windows.rs
+++ b/agb/examples/windows.rs
@@ -6,7 +6,7 @@
 use agb::{
     display::{
         HEIGHT, WIDTH, WinIn,
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
     fixnum::{Num, Vector2D, rect, vec2},
     include_background_gfx,
@@ -26,9 +26,8 @@ fn entry(mut gba: agb::Gba) -> ! {
 }
 
 fn main(mut gba: agb::Gba) -> ! {
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
-
     let mut gfx = gba.graphics.get();
+    gfx.set_background_palettes(backgrounds::PALETTES);
 
     let logo_bg = get_logo();
     let beach_bg = get_beach();

--- a/agb/src/display/blend.rs
+++ b/agb/src/display/blend.rs
@@ -346,7 +346,7 @@ mod test {
             object::{AffineMatrixObject, AffineMode, GraphicsMode, Object, ObjectAffine},
             tiled::{
                 AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour,
-                RegularBackground, RegularBackgroundSize, VRAM_MANAGER,
+                RegularBackground, RegularBackgroundSize,
             },
         },
         fixnum::{num, rect, vec2},
@@ -366,8 +366,8 @@ mod test {
 
     #[test_case]
     fn can_blend_to_white(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = RegularBackground::new(
             Priority::P0,
@@ -389,8 +389,8 @@ mod test {
 
     #[test_case]
     fn can_blend_to_white_in_window(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = RegularBackground::new(
             Priority::P0,
@@ -420,8 +420,8 @@ mod test {
 
     #[test_case]
     fn can_blend_two_layers_into_each_other(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = RegularBackground::new(
             Priority::P0,
@@ -450,8 +450,8 @@ mod test {
 
     #[test_case]
     fn can_blend_affine_backgrounds(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = AffineBackground::new(
             Priority::P0,
@@ -483,8 +483,8 @@ mod test {
 
     #[test_case]
     fn can_blend_objects_to_create_transparency_effects(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = RegularBackground::new(
             Priority::P0,
@@ -514,8 +514,8 @@ mod test {
 
     #[test_case]
     fn can_blend_object_to_white(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = RegularBackground::new(
             Priority::P0,
@@ -542,8 +542,8 @@ mod test {
 
     #[test_case]
     fn can_blend_object_to_black(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = RegularBackground::new(
             Priority::P0,
@@ -570,8 +570,8 @@ mod test {
 
     #[test_case]
     fn can_blend_object_shape_to_black(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = RegularBackground::new(
             Priority::P0,
@@ -604,8 +604,8 @@ mod test {
 
     #[test_case]
     fn can_blend_affine_object_to_black(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = RegularBackground::new(
             Priority::P0,
@@ -634,8 +634,8 @@ mod test {
 
     #[test_case]
     fn can_fade_and_have_object_transparency(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = RegularBackground::new(
             Priority::P0,

--- a/agb/src/display/font.rs
+++ b/agb/src/display/font.rs
@@ -109,7 +109,7 @@
 //! use agb::display::{
 //!     Palette16, Rgb15, Priority,
 //!     font::{Font, Layout, LayoutSettings, RegularBackgroundTextRenderer},
-//!     tiled::{RegularBackground, VRAM_MANAGER, RegularBackgroundSize, TileFormat},
+//!     tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
 //! };
 //!
 //! static SIMPLE_PALETTE: &Palette16 = {
@@ -121,7 +121,6 @@
 //!
 //! # #[agb::doctest]
 //! # fn test(mut gba: agb::Gba) {
-//! VRAM_MANAGER.set_background_palette(0, SIMPLE_PALETTE);
 //! let mut bg = RegularBackground::new(
 //!     Priority::P0,
 //!     RegularBackgroundSize::Background32x32,
@@ -140,6 +139,7 @@
 //! // display the background in the usual means
 //!
 //! let mut gfx = gba.graphics.get();
+//! gfx.set_background_palette(0, SIMPLE_PALETTE);
 //! let mut frame = gfx.frame();
 //!
 //! bg.show(&mut frame);

--- a/agb/src/display/font/object.rs
+++ b/agb/src/display/font/object.rs
@@ -93,7 +93,6 @@ mod tests {
             Rgb, Rgb15,
             font::{ChangeColour, Font, Layout, layout::LayoutSettings},
             palette16::Palette16,
-            tiled::VRAM_MANAGER,
         },
         test_runner::assert_image_output,
     };
@@ -105,7 +104,7 @@ mod tests {
     fn check_font_rendering_simple(gba: &mut crate::Gba) {
         let mut gfx = gba.graphics.get();
 
-        VRAM_MANAGER.set_background_palette_colour(0, 0, Rgb::new(0xff, 0, 0xff).to_rgb15());
+        gfx.set_background_palette_colour(0, 0, Rgb::new(0xff, 0, 0xff).to_rgb15());
 
         static PALETTE: Palette16 = const {
             let mut palette = [Rgb15::BLACK; 16];
@@ -141,7 +140,7 @@ mod tests {
     fn check_japanese_rendering(gba: &mut crate::Gba) {
         let mut gfx = gba.graphics.get();
 
-        VRAM_MANAGER.set_background_palette_colour(0, 0, Rgb::new(0xff, 0, 0xff).to_rgb15());
+        gfx.set_background_palette_colour(0, 0, Rgb::new(0xff, 0, 0xff).to_rgb15());
 
         static PALETTE: Palette16 = const {
             let mut palette = [Rgb15::BLACK; 16];

--- a/agb/src/display/font/tiled.rs
+++ b/agb/src/display/font/tiled.rs
@@ -18,7 +18,7 @@ use crate::{
 /// use agb::display::{
 ///     Palette16, Rgb15, Priority,
 ///     font::{Font, Layout, LayoutSettings, RegularBackgroundTextRenderer},
-///     tiled::{RegularBackground, VRAM_MANAGER, RegularBackgroundSize, TileFormat},
+///     tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
 /// };
 ///
 /// static SIMPLE_PALETTE: &Palette16 = {
@@ -30,7 +30,6 @@ use crate::{
 ///
 /// # #[agb::doctest]
 /// # fn test(mut gba: agb::Gba) {
-/// VRAM_MANAGER.set_background_palette(0, SIMPLE_PALETTE);
 /// let mut bg = RegularBackground::new(
 ///     Priority::P0,
 ///     RegularBackgroundSize::Background32x32,
@@ -50,7 +49,9 @@ use crate::{
 /// // display the background in the usual means
 ///
 /// let mut gfx = gba.graphics.get();
-/// let mut frame = gfx.frame();
+/// gfx.set_background_palette(0, SIMPLE_PALETTE);
+///
+///  let mut frame = gfx.frame();
 ///
 /// bg.show(&mut frame);
 /// # }
@@ -152,7 +153,7 @@ mod test {
             Priority, Rgb15,
             font::{ChangeColour, Font, Layout, layout::LayoutSettings},
             palette16::Palette16,
-            tiled::{RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+            tiled::{RegularBackgroundSize, TileFormat},
         },
         test_runner::assert_image_output,
         timer::Divider,
@@ -173,7 +174,7 @@ mod test {
             Palette16::new(palette)
         };
 
-        VRAM_MANAGER.set_background_palette(0, &PALETTE);
+        gfx.set_background_palette(0, &PALETTE);
 
         let mut bg = RegularBackground::new(
             Priority::P0,
@@ -216,7 +217,7 @@ mod test {
             Palette16::new(palette)
         };
 
-        VRAM_MANAGER.set_background_palette(0, &PALETTE);
+        gfx.set_background_palette(0, &PALETTE);
 
         let mut bg = RegularBackground::new(
             Priority::P0,
@@ -244,15 +245,6 @@ mod test {
 
     #[test_case]
     fn background_text_single_group(gba: &mut Gba) {
-        static PALETTE: Palette16 = const {
-            let mut palette = [Rgb15::BLACK; 16];
-            palette[1] = Rgb15::WHITE;
-            palette[2] = Rgb15(0x10_7C);
-            Palette16::new(palette)
-        };
-
-        VRAM_MANAGER.set_background_palette(0, &PALETTE);
-
         let mut bg = RegularBackground::new(
             Priority::P0,
             RegularBackgroundSize::Background32x64,

--- a/agb/src/display/mod.rs
+++ b/agb/src/display/mod.rs
@@ -61,7 +61,7 @@
 //!
 //! This method takes ownership of the current `frame` instance, so you won't be able to use it for any further calls once this is done.
 //! You will need to create a new frame object from the `gfx` instance.
-use crate::{dma, interrupt::VBlank, memory_mapped::MemoryMapped};
+use crate::{display::tiled::TileSet, dma, interrupt::VBlank, memory_mapped::MemoryMapped};
 
 use alloc::{borrow::Cow, boxed::Box};
 use bilge::prelude::*;
@@ -132,7 +132,7 @@ impl GraphicsDist {
 /// # fn test(mut gba: Gba) {
 /// use agb::display::{
 ///     Priority,
-///     tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+///     tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
 /// };
 ///
 /// // This is an instance of Graphics
@@ -192,6 +192,97 @@ impl<'gba> Graphics<'gba> {
 
             background_palette: Cow::Borrowed(VRAM_MANAGER.vram_background_palette()),
         }
+    }
+
+    /// Sets all background palettes based on the entries given in `palettes`. Note that the GameBoy Advance
+    /// can have at most 16 palettes loaded at once, so only the first 16 will be loaded (although this
+    /// array can be shorter if you don't need all 16).
+    pub fn set_background_palettes(&mut self, palettes: &[Palette16]) {
+        VRAM_MANAGER.set_background_palettes(palettes);
+    }
+
+    /// Sets a single colour for a given background palette. Takes effect immediately
+    pub fn set_background_palette_colour(
+        &mut self,
+        pal_index: usize,
+        colour_index: usize,
+        colour: Rgb15,
+    ) {
+        VRAM_MANAGER.set_background_palette_colour(pal_index, colour_index, colour);
+    }
+
+    /// Sets a single colour in a 256 colour palette. `colour_index` must be less than 256.
+    pub fn set_background_palette_colour_256(&mut self, colour_index: usize, colour: Rgb15) {
+        assert!(colour_index < 256);
+        self.set_background_palette_colour(colour_index / 16, colour_index % 16, colour);
+    }
+
+    /// Gets the index of the colour for a given background palette, or None if it doesn't exist
+    #[must_use]
+    pub fn find_colour_index_16(&self, palette_index: usize, colour: Rgb15) -> Option<usize> {
+        VRAM_MANAGER.find_colour_index_16(palette_index, colour)
+    }
+
+    /// Sets the `pal_index` background palette to the 4bpp one given in `palette`.
+    /// Note that `pal_index` must be in the range 0..=15 as there are only 16 palettes available on
+    /// the GameBoy Advance.
+    pub fn set_background_palette(&self, pal_index: u8, palette: &Palette16) {
+        VRAM_MANAGER.set_background_palette(pal_index, palette);
+    }
+
+    /// Gets the index of the colour in the entire background palette, or None if it doesn't exist
+    #[must_use]
+    pub fn find_colour_index_256(&self, colour: Rgb15) -> Option<usize> {
+        for i in 0..16 {
+            if let Some(index) = self.find_colour_index_16(i, colour) {
+                return Some(i * 16 + index);
+            }
+        }
+
+        None
+    }
+
+    /// Replaces all instances of the tile found in the `source_tile_set` `source_tile` combination with
+    /// the one in `target_tile_set` `target_tile`. This will just do nothing if don't have any occurrences
+    /// of the `source_tile_set` `source_tile` combination.
+    ///
+    /// This is primarily intended for use with animated backgrounds since it is incredibly efficient, only
+    /// modifying the tile data once.
+    ///
+    /// Note that this only works with tiles in _regular_ backgrounds. Tiles in affine backgrounds should use
+    /// [`replace_tile_affine()`](Self::replace_tile_affine).
+    pub fn replace_tile(
+        &self,
+        source_tile_set: &TileSet,
+        source_tile: u16,
+        target_tile_set: &TileSet,
+        target_tile: u16,
+    ) {
+        VRAM_MANAGER.replace_tile(source_tile_set, source_tile, target_tile_set, target_tile);
+    }
+
+    /// Replaces all instances of the tile found in the `source_tile_set` `source_tile` combination with
+    /// the one in `target_tile_set` `target_tile`. This will just do nothing if don't have any occurrences
+    /// of the `source_tile_set` `source_tile` combination.
+    ///
+    /// This is primarily intended for use with animated backgrounds since it is incredibly efficient, only
+    /// modifying the tile data once.
+    ///
+    /// Note that this only works with tiles in _affine_ backgrounds. Tiles in regular backgrounds should use
+    /// [`replace_tile()`](Self::replace_tile).
+    pub fn replace_tile_affine(
+        &self,
+        source_tile_set: &TileSet,
+        source_tile: u16,
+        target_tile_set: &TileSet,
+        target_tile: u16,
+    ) {
+        VRAM_MANAGER.replace_tile_affine(
+            source_tile_set,
+            source_tile,
+            target_tile_set,
+            target_tile,
+        );
     }
 }
 
@@ -261,7 +352,7 @@ impl GraphicsFrame<'_> {
     /// can have at most 16 palettes loaded at once, so only the first 16 will be loaded (although this
     /// array can be shorter if you don't need all 16).
     ///
-    /// Unlike [`VRAM_MANAGER.set_background_palettes()`](crate::display::tiled::VRamManager::set_background_palettes) which
+    /// Unlike [`Graphics.set_background_palettes()`](crate::display::Graphics::set_background_palettes) which
     /// takes effect immediately, this version takes effect on [`.commit()`](GraphicsFrame::commit).
     /// This ensures that palette changes are synchronised with background and other graphical updates.
     pub fn set_background_palettes(&mut self, palettes: &[Palette16]) {

--- a/agb/src/display/object/unmanaged/object.rs
+++ b/agb/src/display/object/unmanaged/object.rs
@@ -455,7 +455,7 @@ impl ObjectAffine {
 #[cfg(test)]
 mod tests {
     use crate::{
-        display::{Palette16, Rgb, Rgb15, tiled::VRAM_MANAGER},
+        display::{Palette16, Rgb, Rgb15},
         include_aseprite,
         test_runner::assert_image_output,
     };
@@ -489,11 +489,10 @@ mod tests {
             "examples/gfx/crab.aseprite",
         );
 
-        VRAM_MANAGER.set_background_palette_colour(0, 0, Rgb::new(0x80, 0x80, 0x80).to_rgb15());
-
         static WHITE_PALETTE: Palette16 = Palette16::new([Rgb15::WHITE; 16]);
 
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palette_colour(0, 0, Rgb::new(0x80, 0x80, 0x80).to_rgb15());
 
         let mut frame = gfx.frame();
         Object::new(sprites::IDLE.sprite(0))

--- a/agb/src/display/palette16.rs
+++ b/agb/src/display/palette16.rs
@@ -6,7 +6,8 @@ use super::Rgb15;
 /// The Game Boy Advance can have up to 16, 16 colour palettes active at once. For
 /// objects, these are loaded dynamically as needed, but for backgrounds you will
 /// need to manually load the palettes using
-/// [`VRamManager::set_background_palette`](crate::display::tiled::VRamManager::set_background_palette)
+/// [`Graphics::set_background_palette`](crate::display::Graphics::set_background_palette)
+/// or [`GraphicsFrame::set_background_palette`](crate::display::GraphicsFrame::set_background_palette)
 #[repr(C)]
 #[derive(Clone)]
 pub struct Palette16 {

--- a/agb/src/display/tiled.rs
+++ b/agb/src/display/tiled.rs
@@ -4,7 +4,7 @@
 //! You can create and manage regular backgrounds using the [`RegularBackground`] struct,
 //! and affine backgrounds using the [`AffineBackground`] struct.
 //!
-//! Palettes are managed using the [`VRAM_MANAGER`] global value.
+//! Palettes are managed using the [`Graphics`](crate::display::Graphics) struct.
 //!
 //! See the [background deep dive](https://agbrs.dev/book/articles/backgrounds.html) for further details about backgrounds.
 #![warn(missing_docs)]
@@ -23,11 +23,9 @@ use alloc::rc::Rc;
 pub use infinite_scrolled_map::{InfiniteScrolledMap, PartialUpdateStatus};
 pub use regular_background::{RegularBackground, RegularBackgroundSize};
 use tiles::Tiles;
-pub use vram_manager::{
-    DynamicTile16, DynamicTile256, TileFormat, TileSet, VRAM_MANAGER, VRamManager,
-};
+pub use vram_manager::{DynamicTile16, DynamicTile256, TileFormat, TileSet};
 
-pub(crate) use vram_manager::TileIndex;
+pub(crate) use vram_manager::{TileIndex, VRAM_MANAGER};
 
 pub(crate) use registers::*;
 
@@ -151,7 +149,6 @@ impl TileSetting {
     ///     display::Priority,
     ///     display::tiled::{
     ///         RegularBackground, RegularBackgroundSize, TileEffect, TileSetting,
-    ///         VRAM_MANAGER,
     ///     },
     ///     include_background_gfx,
     /// };
@@ -222,7 +219,7 @@ impl TileSetting {
     /// The main use case for this is checking which tile_id was assigned when using the `deduplicate`
     /// option in [`include_background_gfx!()`](crate::include_background_gfx).
     ///
-    /// Be careful when passing this ID to [`VRAM_MANAGER.replace_tile()`](crate::display::tiled::VRamManager::replace_tile)
+    /// Be careful when passing this ID to [`Graphics.replace_tile()`](crate::display::Graphics::replace_tile)
     /// if you've generated this tile set with the `deduplicate` option, since tiles may be flipped or
     /// reused meaning replacing IDs could result in strange display behaviour.
     #[must_use]

--- a/agb/src/display/tiled/affine_background.rs
+++ b/agb/src/display/tiled/affine_background.rs
@@ -98,7 +98,7 @@ impl AffineBackgroundSize {
 /// # fn foo(gba: &mut Gba) {
 /// use agb::display::{
 ///     Priority,
-///     tiled::{AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour, VRAM_MANAGER},
+///     tiled::{AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour},
 /// };
 ///
 /// let mut gfx = gba.graphics.get();

--- a/agb/src/display/tiled/affine_background/test.rs
+++ b/agb/src/display/tiled/affine_background/test.rs
@@ -4,7 +4,6 @@ use crate::{
         Priority, Rgb, Rgb15,
         tiled::{
             AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour, DynamicTile256,
-            VRAM_MANAGER,
         },
     },
     interrupt::VBlank,
@@ -53,7 +52,7 @@ fn test_affine_dynamic_tile_256_checkerboard(gba: &mut Gba) {
                 Rgb::new(r, g, b).to_rgb15()
             }
         };
-        VRAM_MANAGER.set_background_palette_colour_256(i, colour);
+        graphics.set_background_palette_colour_256(i, colour);
     }
 
     let mut bg = AffineBackground::new(
@@ -105,7 +104,7 @@ fn test_affine_dynamic_tile_256_gradient(gba: &mut Gba) {
         let r = ((i % 32) * 8) as u8;
         let g = (((i / 4) % 32) * 8) as u8;
         let b = (((i / 2) % 32) * 8) as u8;
-        VRAM_MANAGER.set_background_palette_colour_256(i, Rgb::new(r, g, b).to_rgb15());
+        graphics.set_background_palette_colour_256(i, Rgb::new(r, g, b).to_rgb15());
     }
 
     let mut bg = AffineBackground::new(
@@ -156,14 +155,14 @@ fn test_affine_dynamic_tile_256_border_pattern(gba: &mut Gba) {
     const MAGENTA: Rgb15 = Rgb::new(255, 0, 255).to_rgb15();
 
     // Set up palette with distinct colours
-    VRAM_MANAGER.set_background_palette_colour_256(0, Rgb15::BLACK);
-    VRAM_MANAGER.set_background_palette_colour_256(1, RED);
-    VRAM_MANAGER.set_background_palette_colour_256(2, GREEN);
-    VRAM_MANAGER.set_background_palette_colour_256(3, BLUE);
-    VRAM_MANAGER.set_background_palette_colour_256(4, Rgb15::WHITE);
-    VRAM_MANAGER.set_background_palette_colour_256(5, YELLOW);
-    VRAM_MANAGER.set_background_palette_colour_256(6, CYAN);
-    VRAM_MANAGER.set_background_palette_colour_256(7, MAGENTA);
+    graphics.set_background_palette_colour_256(0, Rgb15::BLACK);
+    graphics.set_background_palette_colour_256(1, RED);
+    graphics.set_background_palette_colour_256(2, GREEN);
+    graphics.set_background_palette_colour_256(3, BLUE);
+    graphics.set_background_palette_colour_256(4, Rgb15::WHITE);
+    graphics.set_background_palette_colour_256(5, YELLOW);
+    graphics.set_background_palette_colour_256(6, CYAN);
+    graphics.set_background_palette_colour_256(7, MAGENTA);
 
     let mut bg = AffineBackground::new(
         Priority::P0,

--- a/agb/src/display/tiled/regular_background.rs
+++ b/agb/src/display/tiled/regular_background.rs
@@ -105,7 +105,7 @@ impl RegularBackgroundSize {
 /// # fn foo(gba: &mut Gba) {
 /// use agb::display::{
 ///     Priority,
-///     tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+///     tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
 /// };
 ///
 /// let mut gfx = gba.graphics.get();
@@ -285,7 +285,7 @@ impl RegularBackground {
     /// use agb::{
     ///     display::{
     ///         Priority,
-    ///         tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+    ///         tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     ///     },
     ///     include_background_gfx,
     /// };
@@ -293,8 +293,9 @@ impl RegularBackground {
     /// include_background_gfx!(mod logo, logo => deduplicate "examples/gfx/test_logo.aseprite");
     ///
     /// # #[agb::doctest]
-    /// # fn test(gba: agb::Gba) {
-    /// VRAM_MANAGER.set_background_palettes(logo::PALETTES);
+    /// # fn test(mut gba: agb::Gba) {
+    /// let mut gfx = gba.graphics.get();
+    /// gfx.set_background_palettes(logo::PALETTES);
     /// let mut bg = RegularBackground::new(Priority::P0, RegularBackgroundSize::Background32x32, TileFormat::FourBpp);
     ///
     /// bg.fill_with(&logo::logo);

--- a/agb/src/display/tiled/regular_background/test.rs
+++ b/agb/src/display/tiled/regular_background/test.rs
@@ -17,7 +17,7 @@ fn test_commit_in_basic_case(gba: &mut Gba) {
     vblank.wait_for_vblank();
 
     let mut graphics = gba.graphics.get();
-    VRAM_MANAGER.set_background_palettes(agb_logo::PALETTES);
+    graphics.set_background_palettes(agb_logo::PALETTES);
 
     let mut bg_data = RegularBackground::new(
         Priority::P0,
@@ -46,7 +46,7 @@ fn test_commit_when_background_tiles_are_modified_after_show(gba: &mut Gba) {
     vblank.wait_for_vblank();
 
     let mut graphics = gba.graphics.get();
-    VRAM_MANAGER.set_background_palettes(agb_logo::PALETTES);
+    graphics.set_background_palettes(agb_logo::PALETTES);
 
     let mut bg_data = RegularBackground::new(
         Priority::P0,
@@ -83,7 +83,7 @@ fn test_commit_when_background_tiles_are_dropped_after_show(gba: &mut Gba) {
     vblank.wait_for_vblank();
 
     let mut graphics = gba.graphics.get();
-    VRAM_MANAGER.set_background_palettes(agb_logo::PALETTES);
+    graphics.set_background_palettes(agb_logo::PALETTES);
 
     let mut bg_data = RegularBackground::new(
         Priority::P0,
@@ -116,7 +116,7 @@ fn test_commit_when_background_tiles_rendered_twice(gba: &mut Gba) {
     vblank.wait_for_vblank();
 
     let mut graphics = gba.graphics.get();
-    VRAM_MANAGER.set_background_palettes(agb_logo::PALETTES);
+    graphics.set_background_palettes(agb_logo::PALETTES);
 
     let mut bg_data = RegularBackground::new(
         Priority::P0,
@@ -176,7 +176,7 @@ fn test_dynamic_tile_16_checkerboard(gba: &mut Gba) {
     const YELLOW: Rgb15 = Rgb::new(255, 255, 0).to_rgb15();
     const GREY: Rgb15 = Rgb::new(128, 128, 128).to_rgb15();
 
-    VRAM_MANAGER.set_background_palette(
+    graphics.set_background_palette(
         0,
         &Palette16::new([
             RED,
@@ -240,7 +240,7 @@ fn test_dynamic_tile_256_gradient(gba: &mut Gba) {
         let red = ((i % 32) * 8) as u8;
         let green = (((i / 8) % 32) * 8) as u8;
         let blue = (((i / 4) % 32) * 8) as u8;
-        VRAM_MANAGER.set_background_palette_colour_256(i, Rgb::new(red, green, blue).to_rgb15());
+        graphics.set_background_palette_colour_256(i, Rgb::new(red, green, blue).to_rgb15());
     }
 
     let mut bg = RegularBackground::new(
@@ -286,7 +286,7 @@ fn test_dynamic_tile_16_multiple_tiles(gba: &mut Gba) {
     const CYAN: Rgb15 = Rgb::new(0, 255, 255).to_rgb15();
     const MAGENTA: Rgb15 = Rgb::new(255, 0, 255).to_rgb15();
 
-    VRAM_MANAGER.set_background_palette(
+    graphics.set_background_palette(
         0,
         &Palette16::new([
             Rgb15::BLACK, // 0 - transparent/black

--- a/agb/src/display/tiled/vram_manager.rs
+++ b/agb/src/display/tiled/vram_manager.rs
@@ -521,14 +521,14 @@ impl Drop for DynamicTile256 {
 /// memory managed by the `VRamManager` and are freed when no longer in use.
 ///
 /// All interactions for the VRamManager is done via the static [`VRAM_MANAGER`] instance.
-pub struct VRamManager {
+pub(crate) struct VRamManager {
     inner: SyncUnsafeCell<VRamManagerInner>,
 }
 
 /// The global instance of the VRamManager. You should always use this and never attempt to
 /// construct one yourself.
 // SAFETY: This is the _only_ one and `init()` is called in `new_in_entry` on the GBA struct
-pub static VRAM_MANAGER: VRamManager = unsafe { VRamManager::new() };
+pub(crate) static VRAM_MANAGER: VRamManager = unsafe { VRamManager::new() };
 
 impl VRamManager {
     const unsafe fn new() -> Self {
@@ -693,22 +693,10 @@ impl VRamManager {
         self.with(|inner| inner.set_background_palette_colour(pal_index, colour_index, colour));
     }
 
-    /// Sets a single colour in a 256 colour palette. `colour_index` must be less than 256.
-    pub fn set_background_palette_colour_256(&self, colour_index: usize, colour: Rgb15) {
-        assert!(colour_index < 256);
-        self.set_background_palette_colour(colour_index / 16, colour_index % 16, colour);
-    }
-
     /// Gets the index of the colour for a given background palette, or None if it doesn't exist
     #[must_use]
     pub fn find_colour_index_16(&self, palette_index: usize, colour: Rgb15) -> Option<usize> {
         self.with(|inner| inner.find_colour_index_16(palette_index, colour))
-    }
-
-    /// Gets the index of the colour in the entire background palette, or None if it doesn't exist
-    #[must_use]
-    pub fn find_colour_index_256(&self, colour: Rgb15) -> Option<usize> {
-        self.with(|inner| inner.find_colour_index_256(colour))
     }
 }
 
@@ -1042,12 +1030,6 @@ impl VRamManagerInner {
         assert!(palette_index < 16);
 
         (0..16).find(|i| PALETTE_BACKGROUND.get(palette_index * 16 + i) == colour)
-    }
-
-    /// Gets the index of the colour in the entire background palette, or None if it doesn't exist
-    #[must_use]
-    fn find_colour_index_256(&self, colour: Rgb15) -> Option<usize> {
-        (0..256).find(|&i| PALETTE_BACKGROUND.get(i) == colour)
     }
 }
 

--- a/agb/src/display/window.rs
+++ b/agb/src/display/window.rs
@@ -242,7 +242,7 @@ mod test {
             AffineMatrix, Priority,
             tiled::{
                 AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour,
-                RegularBackground, RegularBackgroundSize, VRAM_MANAGER,
+                RegularBackground, RegularBackgroundSize,
             },
         },
         fixnum::{Num, num, rect, vec2},
@@ -257,8 +257,8 @@ mod test {
 
     #[test_case]
     fn can_draw_window_box(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = RegularBackground::new(
             Priority::P0,
@@ -284,8 +284,8 @@ mod test {
 
     #[test_case]
     fn can_draw_inverse_window_box(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = RegularBackground::new(
             Priority::P0,
@@ -315,8 +315,8 @@ mod test {
 
     #[test_case]
     fn can_do_affine_background_windows(gba: &mut Gba) {
-        VRAM_MANAGER.set_background_palettes(background::PALETTES);
         let mut gfx = gba.graphics.get();
+        gfx.set_background_palettes(background::PALETTES);
 
         let mut bg = AffineBackground::new(
             Priority::P0,

--- a/agb/src/lib.rs
+++ b/agb/src/lib.rs
@@ -197,7 +197,7 @@ extern crate self as agb;
 /// # #![no_main]
 /// use agb::{
 ///     display::{
-///         tiled::{RegularBackgroundSize, TileFormat, TileSet, TileSetting, RegularBackground, VRAM_MANAGER},
+///         tiled::{RegularBackgroundSize, TileFormat, TileSet, TileSetting, RegularBackground},
 ///         Priority,
 ///     },
 ///     include_background_gfx,
@@ -209,8 +209,9 @@ extern crate self as agb;
 /// );
 ///
 /// # #[agb::doctest]
-/// # fn test(_: agb::Gba) {
-/// VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
+/// # fn test(mut gba: agb::Gba) {
+/// let mut gfx = gba.graphics.get();
+/// gfx.set_background_palettes(backgrounds::PALETTES);
 ///
 /// let mut bg = RegularBackground::new(
 ///     Priority::P0,

--- a/book/games/platform/src/main.rs
+++ b/book/games/platform/src/main.rs
@@ -13,13 +13,13 @@
 
 use agb::{
     display::{
+        GraphicsFrame, Priority,
         object::{Object, SpriteVram},
         tiled::{
             InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat, TileSetting,
         },
-        GraphicsFrame, Priority,
     },
-    fixnum::{num, rect, vec2, Num, Rect, Vector2D},
+    fixnum::{Num, Rect, Vector2D, num, rect, vec2},
     include_aseprite, include_background_gfx,
     input::{Button, ButtonController},
 };

--- a/book/games/platform/src/main.rs
+++ b/book/games/platform/src/main.rs
@@ -13,14 +13,13 @@
 
 use agb::{
     display::{
-        GraphicsFrame, Priority,
         object::{Object, SpriteVram},
         tiled::{
             InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat, TileSetting,
-            VRAM_MANAGER,
         },
+        GraphicsFrame, Priority,
     },
-    fixnum::{Num, Rect, Vector2D, num, rect, vec2},
+    fixnum::{num, rect, vec2, Num, Rect, Vector2D},
     include_aseprite, include_background_gfx,
     input::{Button, ButtonController},
 };
@@ -261,8 +260,7 @@ impl World {
 // and interrupt handlers correctly.
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
-
-    VRAM_MANAGER.set_background_palettes(tiles::PALETTES);
+    gfx.set_background_palettes(tiles::PALETTES);
 
     let mut level = 0;
     let mut world = World::new(levels::LEVELS[level]);

--- a/book/games/pong/src/main.rs
+++ b/book/games/pong/src/main.rs
@@ -15,17 +15,17 @@ extern crate alloc;
 
 use agb::{
     display::{
+        GraphicsFrame, Priority, WIDTH,
         object::Object,
         tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
-        GraphicsFrame, Priority, WIDTH,
     },
-    fixnum::{num, rect, vec2, Num, Rect, Vector2D},
+    fixnum::{Num, Rect, Vector2D, num, rect, vec2},
     include_aseprite, include_background_gfx, include_wav,
     input::ButtonController,
     sound::mixer::{Frequency, Mixer, SoundChannel, SoundData},
 };
 
-use agb_tracker::{include_xm, Track, Tracker};
+use agb_tracker::{Track, Tracker, include_xm};
 
 type Fixed = Num<i32, 8>;
 

--- a/book/games/pong/src/main.rs
+++ b/book/games/pong/src/main.rs
@@ -15,17 +15,17 @@ extern crate alloc;
 
 use agb::{
     display::{
-        GraphicsFrame, Priority, WIDTH,
         object::Object,
-        tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
+        GraphicsFrame, Priority, WIDTH,
     },
-    fixnum::{Num, Rect, Vector2D, num, rect, vec2},
+    fixnum::{num, rect, vec2, Num, Rect, Vector2D},
     include_aseprite, include_background_gfx, include_wav,
     input::ButtonController,
     sound::mixer::{Frequency, Mixer, SoundChannel, SoundData},
 };
 
-use agb_tracker::{Track, Tracker, include_xm};
+use agb_tracker::{include_xm, Track, Tracker};
 
 type Fixed = Num<i32, 8>;
 
@@ -155,7 +155,7 @@ fn main(mut gba: agb::Gba) -> ! {
     let mut mixer = gba.mixer.mixer(Frequency::Hz32768);
 
     // Make sure the background palettes are set up
-    VRAM_MANAGER.set_background_palettes(background::PALETTES);
+    gfx.set_background_palettes(background::PALETTES);
 
     let mut bg = RegularBackground::new(
         Priority::P3,

--- a/book/src/articles/backgrounds.md
+++ b/book/src/articles/backgrounds.md
@@ -44,11 +44,10 @@ Although the Game Boy Advance can display 32,768 colours, the background tiles a
 You will need to tell the video hardware what colour to use for each of the pixels in the `TileSet`.
 
 This is stored in the palette, which is also included in the module created by `include_background_gfx!`.
-To set the palettes available for backgrounds, use the [`set_background_palettes`](https://docs.rs/agb/latest/agb/display/tiled/struct.VRamManager.html#method.set_background_palettes) method on the `VRAM_MANAGER` instance.
+To set the palettes available for backgrounds, use the [`set_background_palettes`](https://docs.rs/agb/latest/agb/display/struct.Graphics.html#method.set_background_palettes) method on the `Graphics` instance.
 
 ```rust
 use agb::{
-    display::tiled::VRAM_MANAGER,
     include_background_gfx,
 };
 
@@ -58,8 +57,9 @@ include_background_gfx!(
 );
 
 #[agb::entry]
-fn main() -> ! {
-    VRAM_MANAGER.set_background_palettes(background::PALETTES);
+fn main(mut gba: agb::Gba) -> ! {
+    let mut gfx = gba.graphics.get();
+    gfx.set_background_palettes(background::PALETTES);
 
     loop {}
 }
@@ -93,7 +93,6 @@ use agb::{
     display::Priority,
     display::tiled::{
         RegularBackground, RegularBackgroundSize,
-        VRAM_MANAGER,
     },
     include_background_gfx,
 };
@@ -104,8 +103,9 @@ include_background_gfx!(
 );
 
 #[agb::entry]
-fn main() -> ! {
-    VRAM_MANAGER.set_background_palettes(background::PALETTES);
+fn main(mut gba: agb::Gba) -> ! {
+    let mut gfx = gba.graphics.get();
+    gfx.set_background_palettes(background::PALETTES);
 
     // Create the background tiles ready for us to display on the screen
     let mut tiles = RegularBackground::new(
@@ -195,7 +195,6 @@ You can alter what colour this is in the [`include_background_gfx!`](https://doc
 
 ```rust
 use agb::{
-    display::tiled::VRAM_MANAGER,
     include_background_gfx,
 };
 
@@ -206,11 +205,12 @@ include_background_gfx!(
 );
 
 #[agb::entry]
-fn main() -> ! {
+fn main(mut gba: &mut agb::Gba) -> ! {
+    let mut gfx = gba.graphics.get();
     // by setting the background colour here, the first colour will be the sky colour,
     // so rather than filling the screen with black you will now instead have it
     // filled with blue. Even though we don't show anything yet.
-    VRAM_MANAGER.set_background_palettes(background::PALETTES);
+    gfx.set_background_palettes(background::PALETTES);
 
     loop {}
 }
@@ -291,10 +291,10 @@ But for backgrounds imported using `include_background_gfx!()` you probably don'
 If you have some tiles you'd like to animate (such as some flowing water, or flowers blowing in the breeze), it can be quite inefficient to replace every instance of a tile with the animation every frame.
 What's much faster is just replacing the one copy of the tile that's been repeated across the background 10s or even 100s of times rather than resetting the entire tile data.
 
-To change which tile is being used, use the [`replace_tile`](https://docs.rs/agb/latest/agb/display/tiled/struct.VRamManager.html#method.replace_tile) method on the `VRAM_MANAGER` instance.
+To change which tile is being used, use the [`replace_tile`](https://docs.rs/agb/latest/agb/display/struct.Graphics.html#method.replace_tile) method on the `Graphics` instance.
 
 ```rust
-VRAM_MANAGER.replace_tile(
+gfx.replace_tile(
     tileset1, 4, tileset2, 5
 );
 ```
@@ -397,9 +397,7 @@ include_background_gfx!(
 Palette setup works in exactly the same way as [regular backgrounds](./backgrounds.md#palette-setup).
 
 ```rust
-use agb::display::tiled::VRAM_MANAGER;
-
-VRAM_MANAGER.set_backgroud_palettes(background::PALETTES);
+gfx.set_backgroud_palettes(background::PALETTES);
 ```
 
 ### Create the `AffineBackground`

--- a/book/src/articles/dma.md
+++ b/book/src/articles/dma.md
@@ -75,7 +75,6 @@ The `DmaControllable` for this is over a single [`Rgb15`](https://docs.rs/agb/la
 ```rust
 use agb::{
     include_colours,
-    display::tiled::VRAM_MANAGER,
     dma::HBlankDma,
 };
 
@@ -89,7 +88,7 @@ const DARKEST_SKY_BLUE: Rgb = Rgb::new(0x00, 0xbd, 0xff);
 
 // Find the index of the colour because it could be anywhere in the palette
 // (since the palette was created via `include_background_gfx!`).
-let background_colour_index = VRAM_MANAGER
+let background_colour_index = frame
     .find_colour_index_16(0, DARKEST_SKY_BLUE.to_rgb15())
     .expect("Should contain the dark sky blue colour");
 

--- a/book/src/articles/unit_tests.md
+++ b/book/src/articles/unit_tests.md
@@ -49,10 +49,11 @@ This only works when running the unit test under the `mgba-test-runner` installe
 ```rust
 #[test_case]
 fn test_background_shows_correctly(gba: &mut Gba) {
-    // you should never assume that the palettes are set up correctly in a test
-    VRAM_MANAGER.set_background_palettes(...);
-
     let mut gfx = gba.graphics.get();
+
+    // you should never assume that the palettes are set up correctly in a test
+    gfx.set_background_palettes(...);
+
     let mut frame = gfx.frame();
     show_some_background(&mut frame);
     frame.commit();

--- a/book/src/platformer/05_displaying_the_level.md
+++ b/book/src/platformer/05_displaying_the_level.md
@@ -16,7 +16,7 @@ use agb::{
         GraphicsFrame, Priority,
         tiled::{
             InfiniteScrolledMap, RegularBackground, RegularBackgroundSize,
-            TileFormat, TileSetting, VRAM_MANAGER,
+            TileFormat, TileSetting,
         },
     },
     fixnum::{Rect, Vector2D, rect, vec2},
@@ -104,7 +104,7 @@ Now we can write the main function to use our `World`:
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
 
-    VRAM_MANAGER.set_background_palettes(tiles::PALETTES);
+    gfx.set_background_palettes(tiles::PALETTES);
     let mut bg = World::new(levels::LEVELS[0]);
 
     loop {

--- a/book/src/platformer/06_the_player.md
+++ b/book/src/platformer/06_the_player.md
@@ -85,8 +85,7 @@ Update the `main` function to create and show the player:
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
-
-    VRAM_MANAGER.set_background_palettes(tiles::PALETTES);
+    gfx.set_background_palettes(tiles::PALETTES);
 
     let level = levels::LEVELS[0];
     let mut bg = World::new(level);
@@ -241,8 +240,7 @@ Update the main loop to call `update`:
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
-
-    VRAM_MANAGER.set_background_palettes(tiles::PALETTES);
+    gfx.set_background_palettes(tiles::PALETTES);
 
     let level = levels::LEVELS[0];
     let mut bg = World::new(level);

--- a/book/src/platformer/07_collision.md
+++ b/book/src/platformer/07_collision.md
@@ -155,8 +155,7 @@ Update the main function to pass the level to `update`:
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
-
-    VRAM_MANAGER.set_background_palettes(tiles::PALETTES);
+    gfx.set_background_palettes(tiles::PALETTES);
 
     let level = levels::LEVELS[0];
     let mut bg = World::new(level);

--- a/book/src/platformer/08_multiple_levels.md
+++ b/book/src/platformer/08_multiple_levels.md
@@ -87,8 +87,7 @@ With these changes, the main function becomes:
 #[agb::entry]
 fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
-
-    VRAM_MANAGER.set_background_palettes(tiles::PALETTES);
+    gfx.set_background_palettes(tiles::PALETTES);
 
     let mut level = 0;
     let mut world = World::new(levels::LEVELS[level]);

--- a/book/src/pong/06_background.md
+++ b/book/src/pong/06_background.md
@@ -60,13 +60,11 @@ To show the background on the screen, you'll need to do 3 things:
 
 ## 1. Register the palettes
 
-The palettes will need registering which you do with a call to [`VRAM_MANAGER.set_background_palettes()`](https://docs.rs/agb/latest/agb/display/tiled/struct.VRamManager.html#method.set_background_palettes).
+The palettes will need registering which you do with a call to [`gfx.set_background_palettes()`](https://docs.rs/agb/latest/agb/display/struct.Graphics.html#method.set_background_palettes).
 
 ```rust
-use agb::display::tiled::VRAM_MANAGER;
-
 // near the top of main()
-VRAM_MANAGER.set_background_palettes(background::PALETTES);
+gfx.set_background_palettes(background::PALETTES);
 ```
 
 ## 2. Creating the background tiles

--- a/examples/amplitude/src/lib.rs
+++ b/examples/amplitude/src/lib.rs
@@ -13,7 +13,6 @@ use agb::{
     display::{
         self, AffineMatrix, GraphicsFrame, Palette16, Rgb15,
         object::{AffineMatrixObject, AffineMode, Object, ObjectAffine, SpriteVram, Tag},
-        tiled::VRAM_MANAGER,
     },
     fixnum::{Num, Vector2D, num},
     include_aseprite,
@@ -365,7 +364,7 @@ pub fn main(mut gba: agb::Gba) -> ! {
     let mut gfx = gba.graphics.get();
     let sprite_cache = SpriteCache::new();
 
-    VRAM_MANAGER.set_background_palettes(&[Palette16::new([Rgb15::WHITE; 16])]);
+    gfx.set_background_palettes(&[Palette16::new([Rgb15::WHITE; 16])]);
 
     let mut max_score = 0;
 

--- a/examples/combo/src/lib.rs
+++ b/examples/combo/src/lib.rs
@@ -9,9 +9,7 @@ use agb::{
     display::{
         Priority,
         tile_data::TileData,
-        tiled::{
-            InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER,
-        },
+        tiled::{InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat},
     },
     fixnum::{Num, Vector2D},
     include_background_gfx,
@@ -52,8 +50,7 @@ fn get_game(gba: &mut agb::Gba) -> Game {
     let mut input = agb::input::ButtonController::new();
 
     let mut gfx = gba.graphics.get();
-
-    VRAM_MANAGER.set_background_palettes(games::PALETTES);
+    gfx.set_background_palettes(games::PALETTES);
 
     let mut bg = InfiniteScrolledMap::new(RegularBackground::new(
         Priority::P0,

--- a/examples/dynamic-isometric/src/main.rs
+++ b/examples/dynamic-isometric/src/main.rs
@@ -8,7 +8,7 @@ use agb::{
     Gba,
     display::{
         Priority,
-        tiled::{RegularBackground, RegularBackgroundSize, TileEffect, TileFormat, VRAM_MANAGER},
+        tiled::{RegularBackground, RegularBackgroundSize, TileEffect, TileFormat},
     },
     fixnum::{num, vec2},
     include_aseprite, include_background_gfx,
@@ -42,8 +42,6 @@ fn entry(gba: Gba) -> ! {
 }
 
 fn main(mut gba: Gba) -> ! {
-    VRAM_MANAGER.set_background_palettes(tiles::PALETTES);
-
     let mut floor_bg = RegularBackground::new(
         Priority::P3,
         RegularBackgroundSize::Background32x32,
@@ -58,6 +56,7 @@ fn main(mut gba: Gba) -> ! {
     wall_bg.set_scroll_pos((0, 7));
 
     let mut gfx = gba.graphics.get();
+    gfx.set_background_palettes(tiles::PALETTES);
 
     let mut tile_cache = TileCache::default();
 

--- a/examples/hyperspace-roll/src/background.rs
+++ b/examples/hyperspace-roll/src/background.rs
@@ -1,7 +1,7 @@
 use agb::{
     display::{
-        GraphicsFrame, Priority,
-        tiled::{RegularBackground, RegularBackgroundSize, TileSet, TileSetting, VRAM_MANAGER},
+        Graphics, GraphicsFrame, Priority,
+        tiled::{RegularBackground, RegularBackgroundSize, TileSet, TileSetting},
     },
     include_background_gfx, rng,
 };
@@ -16,8 +16,8 @@ include_background_gfx!(mod backgrounds, "121105",
     descriptions2 => deduplicate "gfx/descriptions2.png",
 );
 
-pub fn load_palettes() {
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
+pub fn load_palettes(gfx: &mut Graphics) {
+    gfx.set_background_palettes(backgrounds::PALETTES);
 }
 
 pub(crate) fn load_help_text(
@@ -85,14 +85,14 @@ fn create_background_map(stars_tileset: &TileSet) -> RegularBackground {
     map
 }
 
-pub fn show_title_screen(sfx: &mut Sfx) -> RegularBackground {
+pub fn show_title_screen(gfx: &mut Graphics, sfx: &mut Sfx) -> RegularBackground {
     let mut background = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
         backgrounds::title.tiles.format(),
     );
     background.set_scroll_pos((0i16, 0));
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
+    gfx.set_background_palettes(backgrounds::PALETTES);
 
     background.fill_with(&backgrounds::title);
     sfx.frame();

--- a/examples/hyperspace-roll/src/lib.rs
+++ b/examples/hyperspace-roll/src/lib.rs
@@ -134,7 +134,7 @@ pub fn main(mut gba: agb::Gba) -> ! {
         agb.sfx.title_screen();
 
         {
-            let title_screen_bg = show_title_screen(&mut agb.sfx);
+            let title_screen_bg = show_title_screen(&mut agb.gfx, &mut agb.sfx);
             let mut score_display = NumberDisplay::new((216, 9).into());
             score_display.set_value(Some(save::load_high_score()));
 
@@ -157,7 +157,7 @@ pub fn main(mut gba: agb::Gba) -> ! {
 
         agb.sfx.frame();
 
-        background::load_palettes();
+        background::load_palettes(&mut agb.gfx);
 
         loop {
             dice = customise::customise_screen(&mut agb, dice.clone(), current_level);

--- a/examples/the-dungeon-puzzlers-lament/src/backgrounds.rs
+++ b/examples/the-dungeon-puzzlers-lament/src/backgrounds.rs
@@ -1,5 +1,5 @@
 use agb::{
-    display::tiled::{RegularBackground, VRAM_MANAGER},
+    display::{Graphics, tiled::RegularBackground},
     include_background_gfx,
 };
 
@@ -14,8 +14,8 @@ mod tilemaps {
     include!(concat!(env!("OUT_DIR"), "/tilemaps.rs"));
 }
 
-pub fn load_palettes() {
-    VRAM_MANAGER.set_background_palettes(backgrounds::PALETTES);
+pub fn load_palettes(gfx: &mut Graphics) {
+    gfx.set_background_palettes(backgrounds::PALETTES);
 }
 
 pub fn load_ui(map: &mut RegularBackground) {

--- a/examples/the-dungeon-puzzlers-lament/src/lib.rs
+++ b/examples/the-dungeon-puzzlers-lament/src/lib.rs
@@ -55,7 +55,7 @@ impl<'gba> Agb<'gba> {
 pub fn entry(mut gba: agb::Gba) -> ! {
     let mut save_manager = save::init_save(&mut gba).expect("Failed to init save");
 
-    let gfx = gba.graphics.get();
+    let mut gfx = gba.graphics.get();
     let mut ui_bg = RegularBackground::new(
         Priority::P0,
         RegularBackgroundSize::Background32x32,
@@ -69,7 +69,7 @@ pub fn entry(mut gba: agb::Gba) -> ! {
     );
     backgrounds::load_ending_page(&mut ending_bg);
 
-    backgrounds::load_palettes();
+    backgrounds::load_palettes(&mut gfx);
     backgrounds::load_ui(&mut ui_bg);
 
     let mut input = agb::input::ButtonController::new();

--- a/examples/the-hat-chooses-the-wizard/src/lib.rs
+++ b/examples/the-hat-chooses-the-wizard/src/lib.rs
@@ -10,9 +10,7 @@ use agb::{
     display::{
         GraphicsFrame, HEIGHT, Priority, WIDTH,
         object::Object,
-        tiled::{
-            InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER,
-        },
+        tiled::{InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat},
     },
     fixnum::{FixedNum, Vector2D, vec2},
     input::{self, Button, ButtonController},
@@ -749,7 +747,7 @@ impl<'a> PlayingLevel<'a> {
 
 pub fn main(mut agb: agb::Gba) -> ! {
     let mut gfx = agb.graphics.get();
-    VRAM_MANAGER.set_background_palettes(tile_sheet::PALETTES);
+    gfx.set_background_palettes(tile_sheet::PALETTES);
 
     let tileset = &tile_sheet::background.tiles;
     let mut mixer = agb.mixer.mixer(Frequency::Hz10512);
@@ -761,7 +759,7 @@ pub fn main(mut agb: agb::Gba) -> ! {
     splash_screen::show_splash_screen(&mut gfx, splash_screen::SplashScreen::Start, &mut sfx);
 
     loop {
-        VRAM_MANAGER.set_background_palettes(tile_sheet::PALETTES);
+        gfx.set_background_palettes(tile_sheet::PALETTES);
 
         let mut current_level = 0;
 

--- a/examples/the-hat-chooses-the-wizard/src/splash_screen.rs
+++ b/examples/the-hat-chooses-the-wizard/src/splash_screen.rs
@@ -1,7 +1,7 @@
 use super::sfx::SfxPlayer;
 use agb::display::{
     Graphics, Priority,
-    tiled::{RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER},
+    tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
 };
 
 agb::include_background_gfx!(mod splash_screens,
@@ -33,7 +33,7 @@ pub fn show_splash_screen(gfx: &mut Graphics, which: SplashScreen, sfx: &mut Sfx
 
     map.fill_with(tile_data);
 
-    VRAM_MANAGER.set_background_palettes(splash_screens::PALETTES);
+    gfx.set_background_palettes(splash_screens::PALETTES);
 
     loop {
         let mut frame = gfx.frame();

--- a/examples/the-purple-night/src/lib.rs
+++ b/examples/the-purple-night/src/lib.rs
@@ -16,9 +16,7 @@ use agb::{
     display::{
         GraphicsFrame, HEIGHT, Priority, Rgb15, WIDTH,
         object::{Object, Sprite, Tag},
-        tiled::{
-            InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat, VRAM_MANAGER,
-        },
+        tiled::{InfiniteScrolledMap, RegularBackground, RegularBackgroundSize, TileFormat},
     },
     fixnum::{FixedNum, Rect, Vector2D, num, vec2},
     input::{Button, ButtonController, Tri},
@@ -1762,7 +1760,7 @@ impl Game {
                 self.offset.x = (tilemap::WIDTH * 8 - 248).into();
             }
             MoveState::FollowingPlayer => {
-                Game::update_sunrise(self.sunrise_timer);
+                Game::update_sunrise(self.sunrise_timer, frame);
                 if self.sunrise_timer < 120 {
                     self.sunrise_timer += 1;
                 } else {
@@ -1784,7 +1782,7 @@ impl Game {
                     if boss.gone {
                         self.fade_count += 1;
                         self.fade_count = self.fade_count.min(600);
-                        Game::update_fade_out(self.fade_count);
+                        Game::update_fade_out(self.fade_count, frame);
                     }
                 }
             }
@@ -2020,7 +2018,7 @@ impl Game {
         }
     }
 
-    fn update_sunrise(time: u16) {
+    fn update_sunrise(time: u16, frame: &mut GraphicsFrame) {
         let mut modified_palette = background::PALETTES[0].clone();
 
         let a = modified_palette.colour(0);
@@ -2031,10 +2029,10 @@ impl Game {
 
         let modified_palettes = [modified_palette];
 
-        VRAM_MANAGER.set_background_palettes(&modified_palettes);
+        frame.set_background_palettes(&modified_palettes);
     }
 
-    fn update_fade_out(time: u16) {
+    fn update_fade_out(time: u16, frame: &mut GraphicsFrame) {
         let mut modified_palette = background::PALETTES[0].clone();
 
         let c = modified_palette.colour(1);
@@ -2051,7 +2049,7 @@ impl Game {
 
         let modified_palettes = [modified_palette];
 
-        VRAM_MANAGER.set_background_palettes(&modified_palettes);
+        frame.set_background_palettes(&modified_palettes);
     }
 
     fn new(level: Level, start_at_boss: bool) -> Self {
@@ -2091,7 +2089,7 @@ fn game_with_level(gba: &mut agb::Gba) {
     let mut start_at_boss = false;
 
     let mut gfx = gba.graphics.get();
-    VRAM_MANAGER.set_background_palettes(background::PALETTES);
+    gfx.set_background_palettes(background::PALETTES);
 
     loop {
         let backdrop = InfiniteScrolledMap::new(RegularBackground::new(


### PR DESCRIPTION
Moved over to a combination of `Graphics` and `GraphicsFrame` depending on when you want the change to happen.

- [x] Changelog updated
