### PR TITLE
fix playground gist sharing by including tls and ca-certificates

### DIFF
--- a/website/play/Cargo.toml
+++ b/website/play/Cargo.toml
@@ -11,5 +11,5 @@ tower = "0.5.2"
 tower-http = { version = "0.6.2", features = ["cors"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-reqwest = { version = "0.13", default-features = false, features = ["json"] }
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 uuid = { version = "1.13.1", features = ["v4"] }

--- a/website/play/Dockerfile
+++ b/website/play/Dockerfile
@@ -11,6 +11,11 @@ RUN cargo build --release
 
 FROM debian:trixie
 
+RUN set -eux; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates; \
+    rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /usr/bin/docker /usr/bin/docker
 COPY --from=builder /build/target/release/play /bin/play
 


### PR DESCRIPTION
Updating reqwest to `0.13` breaks gist sharing. This time I'll fix it properly rather than let renovate update it again and break it again.