### PR TITLE
only add actually new colours when merging 16 and 256 colour palettes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `swap_tiles` to `RegularBackground` and `AffineBackground` for cheaply moving around tiles.
 
+### Fixed
+
+- Reduced palette colour duplication when `include_background_gfx!`ing 16 or 256 colour images with unique colours.
+
 ## [0.24.0] - 2026/06/10
 
 ### Added

--- a/agb-image-converter/src/palette256.rs
+++ b/agb-image-converter/src/palette256.rs
@@ -42,10 +42,7 @@ impl Palette256 {
             .collect();
 
         let current_colours_set = BTreeSet::from_iter(optimised_palette_colours.iter().cloned());
-        let new_colours: BTreeSet<_> = self
-            .colours
-            .symmetric_difference(&current_colours_set)
-            .collect();
+        let new_colours: BTreeSet<_> = self.colours.difference(&current_colours_set).collect();
 
         assert!(
             new_colours.len() + optimised_palette_colours.len() <= 256,


### PR DESCRIPTION
`BTreeSet::symmetric_difference` was being used to add missing colours, however, that also includes any colours that are already in the palette and don't need to be added. So of course the solution is simply to change that to a `BTreeSet::difference` call.

I was so surprised that no one had come across this bug that I wasn't sure it was one for a bit but, apart from increasing palette usage unnecessarily, it also results in some unusual `Cannot optimise 16 colour and 256 colour palettes together, produces too many colours` errors even without including any 256 colour images. And that can't be intended behaviour.

As a side note, I only noticed this because `pagination_packing` didn't do a great job of packing colours (46 unique colours over 12 palettes instead of the optimal 6 palettes as I'd planned in aseprite) but ig this is expected as optimal packing is probably an open problem.

- [x] Changelog updated