### PR TITLE
Fix kerning causing rendering to look weird

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Reduced palette colour duplication when `include_background_gfx!`ing 16 or 256 colour images with unique colours.
+- Fixed text rendering with kerning applying the kerning to the wrong character.
 
 ## [0.24.0] - 2026/06/10
 

--- a/agb/src/display/font/layout.rs
+++ b/agb/src/display/font/layout.rs
@@ -310,8 +310,8 @@ impl LetterGroup {
 
             previous_char = Some(c);
 
-            let x_offset_this = x_offset;
-            x_offset += kern + letter.advance_width as i32;
+            let x_offset_this = x_offset + kern;
+            x_offset = x_offset_this + letter.advance_width as i32;
 
             let palette_index: u32 = self.palette_index.into();
 

--- a/agb/src/display/font/layout.rs
+++ b/agb/src/display/font/layout.rs
@@ -408,8 +408,8 @@ impl LetterGroup {
 
             let y_position = font.ascent() - letter.height as i32 - letter.ymin as i32;
 
-            let x_offset_this = x_offset;
-            x_offset += kern + letter.advance_width as i32;
+            let x_offset_this = x_offset + kern;
+            x_offset = x_offset_this + letter.advance_width as i32;
 
             (0..letter.height as usize).flat_map(move |y| {
                 (0..letter.width as usize)


### PR DESCRIPTION
We were applying kerning to the wrong character when text rendering for both objects and backgrounds.

- [x] Changelog updated
