### PR TITLE
correct to use actual xoshiro128++ implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `swap_tiles` to `RegularBackground` and `AffineBackground` for cheaply moving around tiles.
 
+### Changed
+
+- Random number generator now correctly implements the `xoshiro128++` algorithm.
+
 ### Fixed
 
 - Reduced palette colour duplication when `include_background_gfx!`ing 16 or 256 colour images with unique colours.
 - Fixed text rendering with kerning applying the kerning to the wrong character.
 - Fixed crash when calaulating the cos of a near zero or sin of a near quarter turn value.
+- You can now pass 0s to `RandomNumberGenerator::new_with_seed()`.
 
 ## [0.24.0] - 2026/06/10
 

--- a/agb/src/rng.rs
+++ b/agb/src/rng.rs
@@ -33,7 +33,7 @@ impl RandomNumberGenerator {
     pub const fn next_i32(&mut self) -> i32 {
         let result = (self.state[0].wrapping_add(self.state[3]))
             .rotate_left(7)
-            .wrapping_mul(9);
+            .wrapping_add(self.state[0]);
         let t = self.state[1].wrapping_shr(9);
 
         self.state[2] ^= self.state[0];

--- a/agb/src/rng.rs
+++ b/agb/src/rng.rs
@@ -17,16 +17,14 @@ impl RandomNumberGenerator {
     }
 
     /// Produces a random number generator with the given initial state / seed.
-    /// None of the values can be 0.
+    /// If all the values are 0, then it'll use the same seed as for new()
     #[must_use]
     pub const fn new_with_seed(seed: [u32; 4]) -> Self {
-        // this can't be in a loop because const
-        assert!(seed[0] != 0, "seed must not be 0");
-        assert!(seed[1] != 0, "seed must not be 0");
-        assert!(seed[2] != 0, "seed must not be 0");
-        assert!(seed[3] != 0, "seed must not be 0");
-
-        Self { state: seed }
+        if seed[0] == 0 && seed[1] == 0 && seed[2] == 0 && seed[3] == 0 {
+            Self::new()
+        } else {
+            Self { state: seed }
+        }
     }
 
     /// Returns the next value for the random number generator

--- a/agb/src/rng.rs
+++ b/agb/src/rng.rs
@@ -33,8 +33,8 @@ impl RandomNumberGenerator {
     pub const fn next_i32(&mut self) -> i32 {
         let result = (self.state[0].wrapping_add(self.state[3]))
             .rotate_left(7)
-            .wrapping_mul(9);
-        let t = self.state[1].wrapping_shr(9);
+            .wrapping_add(self.state[0]);
+        let t = self.state[1].wrapping_shl(9);
 
         self.state[2] ^= self.state[0];
         self.state[3] ^= self.state[1];


### PR DESCRIPTION
During transcription there appears to be an error that was introduced such that we ended up using some strange combination of xoshiro128++ and xoshiro128**. This corrects it to use xoshiro128++.

Here is the original C implementation:

```C
static inline uint32_t rotl(const uint32_t x, int k) {
	return (x << k) | (x >> (32 - k));
}


static uint32_t s[4];

uint32_t next(void) {
	const uint32_t result = rotl(s[0] + s[3], 7) + s[0];

	const uint32_t t = s[1] << 9;

	s[2] ^= s[0];
	s[3] ^= s[1];
	s[1] ^= s[2];
	s[0] ^= s[3];

	s[2] ^= t;

	s[3] = rotl(s[3], 11);

	return result;
}
```

The only error I spotted being that we multiplied by 9 rather than adding `s[0]` on the first line.


This requires a `0.X` bump as we said we wouldn't change this in minor releases (we're still V0, so the third number is considered the minor release).