### PR TITLE
Group gimli and addr2line package upgrades since they always have to go together

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,11 @@
         "patch",
         "minor"
       ]
+    },
+    {
+      "groupName": "Elf file handling",
+      "groupSlug": "elf-updates",
+      "matchPackageNames": ["gimli", "addr2line"]
     }
   ]
 }


### PR DESCRIPTION
Hopefully this'll mean I can just take renovate dependencies

- [x] no changelog update needed
