### PR TITLE
Remove bilge

### DIFF
--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -25,11 +25,13 @@ agb_fixnum = { version = "0.25.0", path = "../agb-fixnum", features = ["serde"] 
 agb_hashmap = { version = "0.25.0", path = "../agb-hashmap", features = ["allocator_api", "serde"] }
 agb_save = { version = "0.25.0", path = "../agb-save" }
 serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
-bilge = "0.3"
 qrcodegen-no-heap = { version = "1.8", optional = true }
 portable-atomic = { version = "1.6.0", default-features = false, features = ["unsafe-assume-single-core", "fallback"] }
 once_cell = { version = "1.20.1", default-features = false, features = ["critical-section"] }
 critical-section = { version = "1.1.2", features = ["restore-state-u16"] }
+bitbybit = "2.0.0"
+arbitrary-int = "2.1.0"
+bilge = "0.3"
 
 [package.metadata.docs.rs]
 default-target = "thumbv4t-none-eabi"

--- a/agb/Cargo.toml
+++ b/agb/Cargo.toml
@@ -31,7 +31,6 @@ once_cell = { version = "1.20.1", default-features = false, features = ["critica
 critical-section = { version = "1.1.2", features = ["restore-state-u16"] }
 bitbybit = "2.0.0"
 arbitrary-int = "2.1.0"
-bilge = "0.3"
 
 [package.metadata.docs.rs]
 default-target = "thumbv4t-none-eabi"

--- a/agb/src/display/bitmap3.rs
+++ b/agb/src/display/bitmap3.rs
@@ -1,7 +1,7 @@
 use crate::memory_mapped::MemoryMapped2DArray;
 
 use super::{DISPLAY_CONTROL, HEIGHT, WIDTH, tiled::DisplayControlRegister};
-use bilge::prelude::*;
+use arbitrary_int::{u3, u4};
 
 use core::marker::PhantomData;
 

--- a/agb/src/display/blend/registers.rs
+++ b/agb/src/display/blend/registers.rs
@@ -1,13 +1,17 @@
 use agb_fixnum::Num;
-use bilge::prelude::*;
+use arbitrary_int::*;
+use bitbybit::{bitenum, bitfield};
 
 use crate::display::tiled::BackgroundId;
 
-#[bitsize(6)]
-#[derive(FromBits, Default, Clone, Copy)]
+#[bitfield(u6)]
+#[derive(Default)]
 pub(crate) struct BlendTarget {
+    #[bits(0..=3, rw)]
     backgrounds: u4,
+    #[bits(4..=4, rw)]
     object: bool,
+    #[bits(5..=5, rw)]
     backdrop: bool,
 }
 
@@ -25,8 +29,8 @@ impl BlendTarget {
     }
 }
 
-#[bitsize(2)]
-#[derive(FromBits, Default, Clone, Copy)]
+#[bitenum(u2, exhaustive = true)]
+#[derive(Default)]
 pub(crate) enum Effect {
     #[default]
     None,
@@ -35,22 +39,24 @@ pub(crate) enum Effect {
     Decrease,
 }
 
-#[bitsize(16)]
-#[derive(Default, Clone, Copy)]
+#[bitfield(u16)]
+#[derive(Default)]
 pub(crate) struct BlendControlRegister {
-    pub(crate) first_target: BlendTarget,
-    pub(crate) colour_effect: Effect,
-    pub(crate) second_target: BlendTarget,
-    _unused: u2,
+    #[bits(0..=5, rw)]
+    first_target: BlendTarget,
+    #[bits(6..=7, rw)]
+    colour_effect: Effect,
+    #[bits(8..=13, rw)]
+    second_target: BlendTarget,
 }
 
-#[bitsize(16)]
-#[derive(Default, Clone, Copy)]
+#[bitfield(u16)]
+#[derive(Default)]
 pub(crate) struct BlendControlAlpha {
+    #[bits(0..=4, rw)]
     first: u5,
-    _unused: u3,
+    #[bits(8..=12, rw)]
     second: u5,
-    _unused2: u3,
 }
 
 impl BlendControlAlpha {
@@ -63,11 +69,11 @@ impl BlendControlAlpha {
     }
 }
 
-#[bitsize(16)]
-#[derive(Default, Clone, Copy)]
+#[bitfield(u16)]
+#[derive(Default)]
 pub(crate) struct BlendControlBrightness {
+    #[bits(0..=4, rw)]
     brightness: u5,
-    _unused: u11,
 }
 
 impl BlendControlBrightness {

--- a/agb/src/display/mod.rs
+++ b/agb/src/display/mod.rs
@@ -64,8 +64,8 @@
 use crate::{display::tiled::TileSet, dma, interrupt::VBlank, memory_mapped::MemoryMapped};
 
 use alloc::{borrow::Cow, boxed::Box};
-use bilge::prelude::*;
 
+use bitbybit::bitenum;
 use tiled::{BackgroundFrame, DisplayControlRegister, VRAM_MANAGER};
 
 use object::{Oam, OamFrame, initilise_oam};
@@ -452,9 +452,9 @@ pub fn busy_wait_for_vblank() {
 /// thought of as rendering first, and so is behind that of a lower priority.
 /// For an equal priority background layer and object, the background has a
 /// higher priority and therefore is behind the object.
-#[bitsize(2)]
+#[bitenum(u2, exhaustive = true)]
 #[allow(missing_docs)]
-#[derive(FromBits, PartialEq, Eq, Clone, Copy, Debug, Default)]
+#[derive(PartialEq, Eq, Debug, Default)]
 pub enum Priority {
     #[default]
     P0 = 0,

--- a/agb/src/display/object/unmanaged/attributes.rs
+++ b/agb/src/display/object/unmanaged/attributes.rs
@@ -1,4 +1,5 @@
-use bilge::prelude::*;
+use arbitrary_int::*;
+use bitbybit::{bitenum, bitfield};
 
 use crate::display::Priority;
 
@@ -16,14 +17,14 @@ pub struct AttributesRegular {
 impl Default for AttributesRegular {
     fn default() -> Self {
         Self {
-            a0: ObjectAttribute0::new(
-                0,
-                ObjectMode::Normal,
-                GraphicsModeInternal::Normal,
-                false,
-                ColourMode::Four,
-                u2::new(0),
-            ),
+            a0: ObjectAttribute0::builder()
+                .with_y(0)
+                .with_object_mode(ObjectMode::Normal)
+                .with_graphics_mode(GraphicsModeInternal::Normal)
+                .with_mosaic(false)
+                .with_colour_mode(ColourMode::Four)
+                .with_shape(u2::new(0u8))
+                .build(),
             a1: Default::default(),
             a2: Default::default(),
         }
@@ -40,17 +41,17 @@ pub struct AttributesAffine {
 impl AttributesAffine {
     pub fn new(mode: AffineMode) -> Self {
         Self {
-            a0: ObjectAttribute0::new(
-                0,
-                match mode {
+            a0: ObjectAttribute0::builder()
+                .with_y(0)
+                .with_object_mode(match mode {
                     AffineMode::Affine => ObjectMode::Affine,
                     AffineMode::AffineDouble => ObjectMode::AffineDouble,
-                },
-                GraphicsModeInternal::Normal,
-                false,
-                ColourMode::Four,
-                u2::new(0),
-            ),
+                })
+                .with_graphics_mode(GraphicsModeInternal::Normal)
+                .with_mosaic(false)
+                .with_colour_mode(ColourMode::Four)
+                .with_shape(u2::new(0u8))
+                .build(),
             a1: Default::default(),
             a2: Default::default(),
         }
@@ -68,7 +69,11 @@ pub enum AffineMode {
 
 impl AttributesRegular {
     pub fn write(self, ptr: *mut u16) {
-        let attrs = [self.a0.into(), self.a1.into(), self.a2.into()];
+        let attrs = [
+            self.a0.raw_value(),
+            self.a1.raw_value(),
+            self.a2.raw_value(),
+        ];
 
         unsafe {
             ptr.add(0).write_volatile(attrs[0]);
@@ -160,7 +165,11 @@ impl AttributesRegular {
 
 impl AttributesAffine {
     pub fn write(self, ptr: *mut u16) {
-        let attrs = [self.a0.into(), self.a1.into(), self.a2.into()];
+        let attrs = [
+            self.a0.raw_value(),
+            self.a1.raw_value(),
+            self.a2.raw_value(),
+        ];
 
         unsafe {
             ptr.add(0).write_volatile(attrs[0]);
@@ -260,8 +269,8 @@ pub enum GraphicsMode {
     Window,
 }
 
-#[bitsize(2)]
-#[derive(FromBits, Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[bitenum(u2, exhaustive = true)]
+#[derive(Debug, PartialEq, Eq, Default)]
 enum ObjectMode {
     Normal,
     Affine,
@@ -270,8 +279,8 @@ enum ObjectMode {
     AffineDouble,
 }
 
-#[bitsize(2)]
-#[derive(TryFromBits, Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[bitenum(u2, exhaustive = false)]
+#[derive(Debug, PartialEq, Eq, Default)]
 enum GraphicsModeInternal {
     #[default]
     Normal,
@@ -279,8 +288,8 @@ enum GraphicsModeInternal {
     Window,
 }
 
-#[bitsize(1)]
-#[derive(FromBits, Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[bitenum(u1, exhaustive = true)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub enum ColourMode {
     #[default]
     Four,
@@ -291,40 +300,55 @@ pub enum ColourMode {
 mod attributes {
     use super::*;
 
-    #[bitsize(16)]
-    #[derive(TryFromBits, Clone, Copy, PartialEq, Eq, DebugBits, Default)]
+    #[bitfield(u16)]
+    #[derive(Debug, PartialEq, Eq, Default)]
     pub(super) struct ObjectAttribute0 {
+        #[bits(0..=7, rw)]
         pub y: u8,
+        #[bits(8..=9, rw)]
         pub object_mode: ObjectMode,
-        pub graphics_mode: GraphicsModeInternal,
+        #[bits(10..=11, rw)]
+        pub graphics_mode: Option<GraphicsModeInternal>,
+        #[bit(12, rw)]
         pub mosaic: bool,
+        #[bit(13, rw)]
         pub colour_mode: ColourMode,
+        #[bits(14..=15, rw)]
         pub shape: u2,
     }
 
-    #[bitsize(16)]
-    #[derive(FromBits, Clone, Copy, PartialEq, Eq, DebugBits, Default)]
+    #[bitfield(u16)]
+    #[derive(PartialEq, Eq, Debug, Default)]
     pub(super) struct ObjectAttribute1Standard {
+        #[bits(0..=8, rw)]
         pub x: u9,
-        __: u3,
+        #[bit(12, rw)]
         pub horizontal_flip: bool,
+        #[bit(13, rw)]
         pub vertical_flip: bool,
+        #[bits(14..=15, rw)]
         pub size: u2,
     }
 
-    #[bitsize(16)]
-    #[derive(FromBits, Clone, Copy, PartialEq, Eq, DebugBits, Default)]
+    #[bitfield(u16)]
+    #[derive(PartialEq, Eq, Debug, Default)]
     pub(super) struct ObjectAttribute1Affine {
+        #[bits(0..=8, rw)]
         pub x: u9,
+        #[bits(9..=13, rw)]
         pub affine_index: u5,
+        #[bits(14..=15, rw)]
         pub size: u2,
     }
 
-    #[bitsize(16)]
-    #[derive(FromBits, Clone, Copy, PartialEq, Eq, DebugBits, Default)]
+    #[bitfield(u16)]
+    #[derive(PartialEq, Eq, Debug, Default)]
     pub(super) struct ObjectAttribute2 {
+        #[bits(0..=9, rw)]
         pub tile_index: u10,
+        #[bits(10..=11, rw)]
         pub priority: Priority,
+        #[bits(12..=15, rw)]
         pub palette_bank: u4,
     }
 }

--- a/agb/src/display/tiled.rs
+++ b/agb/src/display/tiled.rs
@@ -16,6 +16,8 @@ mod screenblock;
 mod tiles;
 mod vram_manager;
 
+use arbitrary_int::{u3, u4};
+
 pub use affine_background::{
     AffineBackground, AffineBackgroundSize, AffineBackgroundWrapBehaviour, AffineMatrixBackground,
 };
@@ -28,8 +30,6 @@ pub use vram_manager::{DynamicTile16, DynamicTile256, TileFormat, TileSet};
 pub(crate) use vram_manager::{TileIndex, VRAM_MANAGER};
 
 pub(crate) use registers::*;
-
-use bilge::prelude::*;
 
 use crate::{
     agb_alloc::{block_allocator::BlockAllocator, bump_allocator::StartEnd, impl_zst_allocator},

--- a/agb/src/display/tiled/affine_background.rs
+++ b/agb/src/display/tiled/affine_background.rs
@@ -1,7 +1,7 @@
 #![warn(missing_docs)]
 use agb_fixnum::FixedWidthSignedInteger;
 use alloc::rc::Rc;
-use bilge::prelude::*;
+use arbitrary_int::u5;
 use core::alloc::Layout;
 
 use crate::{

--- a/agb/src/display/tiled/registers.rs
+++ b/agb/src/display/tiled/registers.rs
@@ -1,4 +1,5 @@
-use bilge::prelude::*;
+use arbitrary_int::*;
+use bitbybit::{bitenum, bitfield};
 
 use crate::display::Priority;
 
@@ -6,24 +7,33 @@ use super::{
     AffineBackgroundSize, AffineBackgroundWrapBehaviour, RegularBackgroundSize, TileFormat,
 };
 
-#[bitsize(16)]
-#[derive(FromBits, Clone, Copy, Default)]
+#[bitfield(u16)]
+#[derive(Default)]
 pub(crate) struct DisplayControlRegister {
+    #[bits(0..=2, rw)]
     pub video_mode: u3,
-    _reserved: u1,
+    #[bits(4..=4, rw)]
     _display_frame_select: u1,
+    #[bits(5..=5, rw)]
     hblank_interval_free: bool,
+    #[bits(6..=6, rw)]
     pub obj_character_mapping: bool,
+    #[bits(7..=7, rw)]
     pub forced_blank: bool,
+    #[bits(8..=11, rw)]
     pub enabled_backgrounds: u4,
+    #[bits(12..=12, rw)]
     pub obj_display: bool,
+    #[bits(13..=13, rw)]
     pub window0_display: bool,
+    #[bits(14..=14, rw)]
     pub window1_display: bool,
+    #[bits(15..=15, rw)]
     pub obj_window_display: bool,
 }
 
-#[bitsize(1)]
-#[derive(Clone, Copy, FromBits, Default)]
+#[bitenum(u1, exhaustive = true)]
+#[derive(Default)]
 pub(crate) enum BackgroundControlTileFormat {
     #[default]
     FourBpp = 0,
@@ -39,8 +49,8 @@ impl From<TileFormat> for BackgroundControlTileFormat {
     }
 }
 
-#[bitsize(1)]
-#[derive(Clone, Copy, FromBits, Default)]
+#[bitenum(u1, exhaustive = true)]
+#[derive(Default)]
 pub(crate) enum BackgroundControlAffineOverflowBehaviour {
     #[default]
     Transparent = 0,
@@ -56,24 +66,27 @@ impl From<AffineBackgroundWrapBehaviour> for BackgroundControlAffineOverflowBeha
     }
 }
 
-#[bitsize(2)]
-#[derive(Clone, Copy, FromBits, Default)]
-pub(crate) struct BackgroundControlScreenSize(u2);
+#[bitfield(u2)]
+#[derive(Default)]
+pub(crate) struct BackgroundControlScreenSize {
+    #[bits(0..=1, rw)]
+    pub value: u2,
+}
 
 impl From<RegularBackgroundSize> for BackgroundControlScreenSize {
     fn from(value: RegularBackgroundSize) -> Self {
-        Self::new(u2::new(value as u8))
+        Self::builder().with_value(u2::new(value as u8)).build()
     }
 }
 
 impl From<AffineBackgroundSize> for BackgroundControlScreenSize {
     fn from(value: AffineBackgroundSize) -> Self {
-        Self::new(u2::new(value as u8))
+        Self::builder().with_value(u2::new(value as u8)).build()
     }
 }
 
-#[bitsize(2)]
-#[derive(Clone, Copy, FromBits, Default)]
+#[bitenum(u2, exhaustive = true)]
+#[derive(Default)]
 pub(crate) enum BackgroundControlPriority {
     #[default]
     P0,
@@ -93,15 +106,21 @@ impl From<Priority> for BackgroundControlPriority {
     }
 }
 
-#[bitsize(16)]
-#[derive(Clone, Copy, FromBits, Default)]
+#[bitfield(u16)]
+#[derive(Default)]
 pub(crate) struct BackgroundControlRegister {
+    #[bits(0..=1, rw)]
     pub priority: BackgroundControlPriority,
+    #[bits(2..=3, rw)]
     pub char_base_block: u2,
-    _zero: u2,
+    #[bits(6..=6, rw)]
     pub mosaic: bool,
+    #[bits(7..=7, rw)]
     pub tile_format: BackgroundControlTileFormat,
+    #[bits(8..=12, rw)]
     pub screen_base_block: u5,
+    #[bits(13..=13, rw)]
     pub overflow_behaviour: BackgroundControlAffineOverflowBehaviour,
+    #[bits(14..=15, rw)]
     pub screen_size: BackgroundControlScreenSize,
 }

--- a/agb/src/display/tiled/regular_background.rs
+++ b/agb/src/display/tiled/regular_background.rs
@@ -1,4 +1,6 @@
 #![warn(missing_docs)]
+use arbitrary_int::u5;
+use bitbybit::bitenum;
 use core::{alloc::Layout, mem};
 
 use alloc::rc::Rc;
@@ -18,8 +20,6 @@ use super::{
     TileEffect, TileFormat, TileSet, TileSetting, VRAM_MANAGER,
 };
 
-use bilge::prelude::*;
-
 /// The backgrounds in the GameBoy Advance are made of 8x8 tiles. Each different background option lets
 /// you decide how big the background should be before it wraps. Ideally, you should use the smallest background
 /// size you can while minimising the number of times you have to redraw tiles.
@@ -27,8 +27,8 @@ use bilge::prelude::*;
 /// If you want more space than can be provided here, or want to keep more video ram free, then you should use
 /// the [`InfiniteScrolledMap`](super::InfiniteScrolledMap) which will dynamically load tile data for any size
 /// as you scroll around.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(u16)]
+#[bitenum(u2, exhaustive = true)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum RegularBackgroundSize {
     /// 32x32 tiles (256x256 pixels)
     Background32x32 = 0,


### PR DESCRIPTION
Swap bilge for bitbybit since rust is removing support for proc_macro_error2 which bilge depends on.

- [x] no changelog update needed
