### PR TITLE
Fix stereo sound volume being wrong and crash when playing mono sounds at 1.5x speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed Num<_, _>'s signum implementation to return `num!(1)` rather than `Num::from_raw(1)`.
+- Fixed crash when playing a mono sample at exactly 1.5x speed.
+- Fixed clipping when changing the volume of a stereo sound.
 
 ## [0.25.0] - 2026/07/22
 

--- a/agb/examples/mixer_32768.rs
+++ b/agb/examples/mixer_32768.rs
@@ -13,7 +13,9 @@ use agb::{
         font::{AlignmentKind, Font, Layout, LayoutSettings, RegularBackgroundTextRenderer},
         tiled::{RegularBackground, RegularBackgroundSize, TileFormat},
     },
+    fixnum::num,
     include_font, include_wav,
+    input::{ButtonController, Tri},
     sound::mixer::{Frequency, SoundChannel, SoundData},
 };
 
@@ -35,11 +37,22 @@ fn main(mut gba: Gba) -> ! {
 
     let mut mixer = gba.mixer.mixer(Frequency::Hz32768);
 
-    let mut channel = SoundChannel::new(CRAZY_GLUE);
-    channel.stereo();
-    mixer.play_sound(channel).unwrap();
+    let mut channel = SoundChannel::new_high_priority(CRAZY_GLUE);
+    channel.stereo().should_loop();
+    let channel_id = mixer.play_sound(channel).unwrap();
+
+    let mut input = ButtonController::new();
 
     loop {
+        input.update();
+        let volume = match input.y_tri() {
+            Tri::Positive => num!(0.5),
+            Tri::Zero => num!(1),
+            Tri::Negative => num!(1.5),
+        };
+
+        mixer.channel(&channel_id).unwrap().volume(volume);
+
         let mut frame = gfx.frame();
         bg.show(&mut frame);
 
@@ -52,7 +65,7 @@ fn init_background(bg: &mut RegularBackground) {
     static FONT: Font = include_font!("examples/font/ark-pixel-10px-proportional-ja.ttf", 10);
 
     let text_layout = Layout::new(
-        "Crazy glue by Josh Woodward\njoshwoodward.com",
+        "Crazy glue by Josh Woodward\njoshwoodward.com\n\nUP to go louder, DOWN for quieter",
         &FONT,
         &LayoutSettings::new()
             .with_max_line_length(WIDTH)

--- a/agb/src/sound/mixer/mixer.s
+++ b/agb/src/sound/mixer/mixer.s
@@ -136,10 +136,6 @@ agb_arm_func \fn_name
     @ The sound buffer must be SOUND_BUFFER_SIZE * 2 in size = 176 * 2
     push {{r4-r11}}
 
-    ldr r5, =0x00000FFF
-
-    mov r8, r3
-
 .macro add_stereo_sample sample_reg:req
     ldrsh r6, [r0], #2        @ load the current sound sample to r6
 
@@ -157,10 +153,9 @@ agb_arm_func \fn_name
     @
     @ At this point
     @                        r6 = | 1 | 1 | L | R | where the upper bytes are 1s if L is negative. No care about R
-                         @ asr #8 | 1 | 1 | 1 | L | drop R off the right hand side
-    and r7, r5, r6, asr #8 @ r7 = | 0 | 0 | 1 | L | exactly what we want this to be. The mask puts the 1 as 00001111 ready for the shift later
+    mov r7, r6, asr #8     @ r7 = | 1 | 1 | 1 | L | drop R off the right hand side
     lsl r6, r6, #24        @ r6 = | R | 0 | 0 | 0 | drop everything except the right sample
-    orr r6, r7, r6, asr #8 @ r6 = | 1 | R | 1 | L | now we have it perfectly set up
+    add r6, r7, r6, asr #8 @ r6 = | 1 | R | 1 | L | now we have it perfectly set up
 
 .ifc \is_first,true
     mul \sample_reg, r6, r2
@@ -183,7 +178,7 @@ agb_arm_func \fn_name
 
     stmia r1!, {{r9-r12}}         @ store the new value, and increment the pointer
 
-    subs r8, r8, #4          @ loop counter
+    subs r3, r3, #4          @ loop counter
     bne 1b                   @ jump back if we're done with the loop
 
     pop {{r4-r11}}

--- a/agb/src/sound/mixer/sw_mixer.rs
+++ b/agb/src/sound/mixer/sw_mixer.rs
@@ -630,7 +630,7 @@ mod playback_buffer {
             //
             // If increasing this size, make sure to also increase the size of the temp_storage
             // allocation since this guards overrunning that.
-            if channel.playback_speed > num!(1.5) && channel.data.len() > temp_storage.len() {
+            if channel.playback_speed >= num!(1.5) && channel.data.len() > temp_storage.len() {
                 return PlaybackBuffer::Rom(channel.data);
             }
 


### PR DESCRIPTION
Also make the stereo sound example play at different volumes to test this.

- [x] Changelog updated
