### PR TITLE
test runner compile function fix

### DIFF
--- a/emulator/mgba-sys/build.rs
+++ b/emulator/mgba-sys/build.rs
@@ -101,6 +101,7 @@ fn compile() -> MyError {
         .build();
 
     println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    println!("cargo:rustc-link-search=native={}/lib64", dst.display());
     println!("cargo:rustc-link-search=native={}", dst.display());
     println!("cargo:rustc-link-lib=static=mgba");
 


### PR DESCRIPTION

added println to help the compiler find libmgba.a when it's put into */lib64 instead of */lib

Cheers!

fixes https://github.com/agbrs/agb/issues/1233