### PR TITLE
Fix 256 colour backgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Num<_, _>'s signum implementation to return `num!(1)` rather than `Num::from_raw(1)`.
 - Fixed crash when playing a mono sample at exactly 1.5x speed.
 - Fixed clipping when changing the volume of a stereo sound.
+- Fixed incorrect colours in the palette when importing both 256 and 16 colour backgrounds.
 
 ## [0.25.0] - 2026/07/22
 

--- a/agb-image-converter/src/lib.rs
+++ b/agb-image-converter/src/lib.rs
@@ -7,6 +7,7 @@ use syn::{Expr, ExprLit, Lit, Token};
 use syn::{parse_macro_input, punctuated::Punctuated};
 
 use std::collections::HashMap;
+use std::iter;
 use std::{path::Path, str};
 
 use quote::{ToTokens, quote};
@@ -422,7 +423,11 @@ fn add_image_256_to_tile_data(
     let all_colours: Vec<_> = optimiser
         .optimised_palettes
         .iter()
-        .flat_map(|p| p.colours())
+        .flat_map(|p| {
+            p.colours()
+                .chain(iter::repeat(Colour::from_rgb(0, 0, 0, 0)))
+                .take(16)
+        })
         .collect();
 
     for y in 0..tiles_y {
@@ -432,7 +437,8 @@ fn add_image_256_to_tile_data(
                     for j in inner_y * 8..inner_y * 8 + 8 {
                         for i in inner_x * 8..inner_x * 8 + 8 {
                             let colour = image.colour(x * tile_size + i, y * tile_size + j);
-                            tile_data.push(all_colours.iter().position(|c| **c == colour).unwrap() as u8);
+                            tile_data
+                                .push(all_colours.iter().position(|c| *c == colour).unwrap() as u8);
                         }
                     }
                 }

--- a/agb-image-converter/src/palette16.rs
+++ b/agb-image-converter/src/palette16.rs
@@ -60,8 +60,8 @@ impl Palette16 {
             }) as u8
     }
 
-    pub fn colours(&self) -> impl Iterator<Item = &Colour> {
-        self.colours.iter()
+    pub fn colours(&self) -> impl Iterator<Item = Colour> {
+        self.colours.iter().copied()
     }
 
     fn with_transparent(&self, transparent_colour: Colour) -> Self {

--- a/agb-image-converter/src/palette256.rs
+++ b/agb-image-converter/src/palette256.rs
@@ -38,7 +38,6 @@ impl Palette256 {
             .optimised_palettes
             .iter()
             .flat_map(|p| p.colours())
-            .cloned()
             .collect();
 
         let current_colours_set = BTreeSet::from_iter(optimised_palette_colours.iter().cloned());

--- a/agb-image-converter/src/sprite/regular.rs
+++ b/agb-image-converter/src/sprite/regular.rs
@@ -150,7 +150,7 @@ impl ToTokens for Output {
         });
 
         let palettes = self.palettes.iter().map(|palette| {
-            let mut colours: Vec<_> = palette.colours().copied().map(Colour::to_rgb15).collect();
+            let mut colours: Vec<_> = palette.colours().map(Colour::to_rgb15).collect();
             colours.resize(16, 0);
 
             let colours = colours.iter().map(|c| quote!(Rgb15(#c)));


### PR DESCRIPTION
We were having troubles with 256 colour background importing at the same time as a 16 colour background.

The problem was that when picking indexes for 256 colour tiles, we were using the merged palettes for 16 colours without filling in the gaps.

- [x] Changelog updated