### PR TITLE
Fix fill_with with non 32x32 backgrounds

### DIFF
--- a/agb/src/display/tiled/regular_background.rs
+++ b/agb/src/display/tiled/regular_background.rs
@@ -340,8 +340,11 @@ impl RegularBackground {
         for y in 0..tile_data.height.min(size.height()) {
             for x in 0..tile_data.width.min(size.width()) {
                 let tile_id = y * tile_data.width + x;
-                let tile_pos = y * size.width() + x;
-                self.set_tile_at_pos(tile_pos, &tile_data.tiles, tile_data.tile_settings[tile_id]);
+                self.set_tile(
+                    (x as i32, y as i32),
+                    &tile_data.tiles,
+                    tile_data.tile_settings[tile_id],
+                );
             }
         }
 


### PR DESCRIPTION
I forgot that gba background tiles ids are all over the place, and not sequential.

No changelog update needed because the feature isn't released yet.

- [x] no changelog update needed
